### PR TITLE
Simplify eth signing messages

### DIFF
--- a/src/components/ModalAddWallet.js
+++ b/src/components/ModalAddWallet.js
@@ -134,7 +134,7 @@ export default function Modal({ isOpen, setWalletModalOpen, walletAddresses }) {
 		try {
 			setSignaturePending(true)
 			const signature = await web3.eth.personal.sign(
-				process.env.NEXT_PUBLIC_SIGNING_MESSAGE_ADD_WALLET + response_nonce.data.data,
+				process.env.NEXT_PUBLIC_SIGNING_MESSAGE_ADD_WALLET + ' ' + response_nonce.data.data,
 				addressDetected,
 				'' // MetaMask will ignore the password argument here
 			)

--- a/src/components/ModalLogin.js
+++ b/src/components/ModalLogin.js
@@ -112,7 +112,7 @@ export default function Modal({ isOpen }) {
 		try {
 			setSignaturePending(true)
 			const signature = await web3.eth.personal.sign(
-				process.env.NEXT_PUBLIC_SIGNING_MESSAGE + response_nonce.data.data,
+				process.env.NEXT_PUBLIC_SIGNING_MESSAGE + ' ' + response_nonce.data.data,
 				address,
 				'' // MetaMask will ignore the password argument here
 			)

--- a/src/components/NotificationsBtn.js
+++ b/src/components/NotificationsBtn.js
@@ -185,7 +185,7 @@ export default function NotificationsBtn() {
 													<span className="text-gray-500">, </span>
 													<Link href="/[profile]" as={`/${notif.actors[1]?.username || notif.actors[1].wallet_address}`}>
 														<a className="text-black dark:text-gray-200 cursor-pointer hover:text-stpink dark:hover:text-stpink" onClick={() => setIsActive(!isActive)}>
-															{notif.actors[1].name}{' '}
+															{notif.actors[1].name}
 														</a>
 													</Link>
 													<span className="text-gray-500">, and </span>

--- a/src/pages/api/auth/login/signature.js
+++ b/src/pages/api/auth/login/signature.js
@@ -14,7 +14,7 @@ export default handler().post(async ({ body: { address, signature } }, res) => {
 	} = await backend.get(`/v1/getnonce?address=${address}`)
 
 	// If it checks out, save to a cookie
-	const msg = process.env.NEXT_PUBLIC_SIGNING_MESSAGE + nonce
+	const msg = process.env.NEXT_PUBLIC_SIGNING_MESSAGE + ' ' + nonce
 
 	// We now are in possession of msg, publicAddress and signature. We
 	// will use a helper from eth-sig-util to extract the address from the signature

--- a/src/pages/api/auth/wallet/eth.js
+++ b/src/pages/api/auth/wallet/eth.js
@@ -15,7 +15,7 @@ export default handler().put(async ({ cookies, body: { addressDetected: address,
 
 	// We now are in possession of msg, publicAddress and signature. We
 	// will use a helper from eth-sig-util to extract the address from the signature
-	const msgBufferHex = bufferToHex(Buffer.from(process.env.NEXT_PUBLIC_SIGNING_MESSAGE_ADD_WALLET + nonce, 'utf8'))
+	const msgBufferHex = bufferToHex(Buffer.from(process.env.NEXT_PUBLIC_SIGNING_MESSAGE_ADD_WALLET + ' ' + nonce, 'utf8'))
 	const verifiedAddress = recoverPersonalSignature({ data: msgBufferHex, sig: signature })
 
 	// The signature verification is successful if the address found with


### PR DESCRIPTION
Converted the signing message to a single line, since the backend was treating the line breaks in the environment variable differently than the frontend and was making things unnecessarily complicated