### PR TITLE
Create a function that uses magic.link to sign messages

### DIFF
--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -2,7 +2,7 @@ import axios from '@/lib/axios'
 import useSWR from 'swr'
 
 export default function useAuth() {
-	const { data: user, error } = useSWR('/api/auth/user', url => axios.get(url).then(res => res.data || null))
+	const { data: user, error, revalidate } = useSWR('/api/auth/user', url => axios.get(url).then(res => res.data), { revalidateOnFocus: false, shouldRetryOnError: false })
 
-	return { user, error, loading: user === undefined }
+	return { user, error, loading: !user && !error, isAuthenticated: user && !error, revalidate }
 }

--- a/src/lib/web3Modal.js
+++ b/src/lib/web3Modal.js
@@ -1,0 +1,60 @@
+import WalletConnectProvider from '@walletconnect/web3-provider'
+import Fortmatic from 'fortmatic'
+import { WalletLink } from 'walletlink'
+import { useTheme } from 'next-themes'
+import Web3Modal from 'web3modal'
+
+class DummyModal {}
+
+const useWeb3Modal = () => {
+	const { resolvedTheme } = useTheme()
+
+	if (typeof window === 'undefined') return DummyModal
+
+	const web3Modal = new Web3Modal({
+		network: 'mainnet',
+		cacheProvider: false,
+		providerOptions: {
+			walletconnect: {
+				display: {
+					description: 'Use Rainbow & other popular wallets',
+				},
+				package: WalletConnectProvider,
+				options: {
+					infuraId: process.env.NEXT_PUBLIC_INFURA_ID,
+				},
+			},
+			fortmatic: {
+				package: Fortmatic,
+				options: {
+					key: process.env.NEXT_PUBLIC_FORTMATIC_PUB_KEY,
+				},
+			},
+			'custom-walletlink': {
+				display: {
+					logo: '/coinbase.svg',
+					name: 'Coinbase',
+					description: 'Use the Coinbase Wallet app on your mobile device',
+				},
+				options: {
+					appName: 'Showtime',
+					networkUrl: `https://mainnet.infura.io/v3/${process.env.NEXT_PUBLIC_INFURA_ID}`,
+					chainId: process.env.NEXT_PUBLIC_CHAINID,
+				},
+				package: WalletLink,
+				connector: async (_, options) => {
+					const { appName, networkUrl, chainId } = options
+					const walletLink = new WalletLink({ appName })
+					const provider = walletLink.makeWeb3Provider(networkUrl, chainId)
+					await provider.enable()
+					return provider
+				},
+			},
+		},
+		theme: resolvedTheme,
+	})
+
+	return web3Modal
+}
+
+export default useWeb3Modal

--- a/src/pages/_test/sign.js
+++ b/src/pages/_test/sign.js
@@ -1,0 +1,51 @@
+import Layout from '@/components/layout'
+import { Magic } from 'magic-sdk'
+import { useState } from 'react'
+import useAuth from '@/hooks/useAuth'
+import Web3 from 'web3'
+import useWeb3Modal from '@/lib/web3Modal'
+
+const _SignPage = () => {
+	const { isAuthenticated, loading } = useAuth()
+	const [signText, setSignText] = useState('')
+	const web3Modal = useWeb3Modal()
+
+	const submitForm = async e => {
+		e.preventDefault()
+
+		const signature = await signMessage(signText)
+
+		alert(`SIGNATURE: ${signature}`)
+	}
+
+	const signMessage = async message => {
+		const magic = new Magic(process.env.NEXT_PUBLIC_MAGIC_PUB_KEY)
+		let web3
+
+		if (await magic.user.isLoggedIn()) web3 = new Web3(magic.rpcProvider)
+		else web3 = new Web3(await web3Modal.connect())
+
+		const fromAddress = (await web3.eth.getAccounts())[0]
+
+		return web3.eth.personal.sign(message, fromAddress)
+	}
+
+	if (loading || !isAuthenticated) {
+		return (
+			<Layout>
+				<span>Not logged in!</span>
+			</Layout>
+		)
+	}
+
+	return (
+		<Layout>
+			<form onSubmit={submitForm} className="flex items-center justify-center mt-20">
+				<textarea className="rounded-lg border mr-2" value={signText} onChange={event => setSignText(event.target.value)} />
+				<button type="submit">Sign</button>
+			</form>
+		</Layout>
+	)
+}
+
+export default _SignPage


### PR DESCRIPTION
This PR creates a temporary `/_test/sign` to demonstrate the magic.link signing functionality. The page simply provides a textbox where you can type the message to sign, and a button to sign the message. Once the button is clicked, we'll check if the user is currently logged in with magic.link (aka they initiated the current session by logging in with email), and if so use magic.link to sign the message. If that's not the case, it'll use Web3Modal to prompt the user with a traditional wallet to use.

We have to use the magic.link frontend state and Web3Modal since Showtime doesn't currently store how the session started, or a connection to the user's wallet. This could be improved so that, upon logging in with WalletConnect, Showtime remembers this and will automatically pick WalletConnect when there's something that needs signing. I haven't done this here since it'd require adding the connection to the global state, but it's probably something to consider.