### PR TITLE
refactor(list-unlist): updates to use accurate listings.all_sellers t…

### DIFF
--- a/src/components/TokenCard.js
+++ b/src/components/TokenCard.js
@@ -27,6 +27,7 @@ const TokenCard = ({ originalItem, isMyProfile, listId, changeSpotlightItem, cur
 	const [muted, setMuted] = useState(true)
 	const [refreshing, setRefreshing] = useState(false)
 	const [showModel, setShowModel] = useState(false)
+	const hasMatchingListing = item?.listing?.all_sellers?.find(seller => seller.profile_id === pageProfile.profile_id)
 
 	// Automatically load models that have no preview image. We don't account for video here because currently token_animation_url is a glb file.
 	useEffect(() => {
@@ -131,25 +132,23 @@ const TokenCard = ({ originalItem, isMyProfile, listId, changeSpotlightItem, cur
 									<Menu.Items className="z-1 absolute right-0 mt-2 origin-top-right border border-transparent dark:border-gray-800 bg-white dark:bg-gray-900 shadow-lg rounded-xl p-2 text-base ring-1 ring-black ring-opacity-5 overflow-auto focus:outline-none sm:text-sm">
 										{SHOWTIME_CONTRACTS.includes(item.contract_address) && item?.show_transfer_options == 1 && (
 											<>
-												{!item.listing && (
+												{!hasMatchingListing ? (
 													<Menu.Item>
 														{({ active }) => (
-															<button onClick={() => setListModal(item)} className={classNames(active ? 'text-gray-900 dark:text-gray-300 bg-gray-100 dark:bg-gray-800' : 'text-gray-900 dark:text-gray-400', 'cursor-pointer select-none rounded-xl py-3 px-3 w-full text-left')}>
+															<button onClick={() => setListModal(item)} className={classNames(active ? 'text-gray-900 dark:text-white bg-gray-100 dark:bg-gray-800' : 'text-gray-900 dark:text-white', 'cursor-pointer select-none rounded-xl py-3 px-3 w-full text-left')}>
 																<span className="block truncate font-medium">List</span>
 															</button>
 														)}
 													</Menu.Item>
-												)}
-												{item.listing?.profile_id === pageProfile?.profile_id && (
+												) : (
 													<Menu.Item>
 														{({ active }) => (
-															<button onClick={() => setUnlistModal(item)} className={classNames(active ? 'text-gray-900 dark:text-gray-300 bg-gray-100 dark:bg-gray-800' : 'text-gray-900 dark:text-gray-400', 'cursor-pointer select-none rounded-xl py-3 px-3 w-full text-left')}>
+															<button onClick={() => setUnlistModal(item)} className={classNames(active ? 'text-gray-900 dark:text-white bg-gray-100 dark:bg-gray-800' : 'text-gray-900 dark:text-white', 'cursor-pointer select-none rounded-xl py-3 px-3 w-full text-left')}>
 																<span className="block truncate font-medium">Unlist</span>
 															</button>
 														)}
 													</Menu.Item>
 												)}
-												<hr className="border-gray-100 dark:border-gray-700 my-1" />
 											</>
 										)}
 										<Menu.Item>
@@ -188,7 +187,6 @@ const TokenCard = ({ originalItem, isMyProfile, listId, changeSpotlightItem, cur
 														</button>
 													)}
 												</Menu.Item>
-												<hr className="border-gray-100 dark:border-gray-700 my-1" />
 
 												<Menu.Item>
 													{({ active }) => (


### PR DESCRIPTION
Figma: https://www.figma.com/file/720aUothRCUZMtMEVHfJV0/%F0%9F%96%A5%F0%9F%93%B1-Showtime?node-id=0%3A1

1. Update list/unlist dark theme font color to match Figma
2. Removed `<hr>` breaks to match Figma 
3. Refactored list/unlist menu visibility condition to check for a match in `listings.all_sellers<seller>.profile_id` against the `pageProfile.profile_id` 
	- Solves an issue where `listing` would not show if the item was listed by **_another_** user already.
	- Also where the user would not be able to `unlist` if they were not the original lister. 


## Screenshots
<img width="384" alt="Screen Shot 2021-10-21 at 12 21 35 PM" src="https://user-images.githubusercontent.com/11730651/138326712-1f508d9d-d657-46b7-a623-c3716b974ed9.png">


<img width="402" alt="Screen Shot 2021-10-21 at 12 16 35 PM" src="https://user-images.githubusercontent.com/11730651/138326079-6b2933c4-5235-48c7-a9ac-f69302b1618e.png">
 
### Before (reference) 
<img width="311" alt="Screen Shot 2021-10-21 at 12 29 21 PM" src="https://user-images.githubusercontent.com/11730651/138327767-1be243a6-5756-40f2-93ab-1a98d1dc7b52.png">
<img width="302" alt="Screen Shot 2021-10-21 at 12 29 17 PM" src="https://user-images.githubusercontent.com/11730651/138327768-7e4f039a-d387-45a8-a87e-9cc775ea787d.png">

