### PR TITLE
Access refresh only triggered for 401's

### DIFF
--- a/src/lib/authenticated-client-side-axios.js
+++ b/src/lib/authenticated-client-side-axios.js
@@ -8,7 +8,7 @@ const axios = Axios.create()
 
 /**
  * An expired or missing access token sent to our backend services will trigger a
- * 401 or 500 response status code that we intercept to trigger a silent access token refresh.
+ * 401 response status code that we intercept to trigger a silent access token refresh.
  * On refresh success the request will be resent and on failure we force the logout flow.
  */
 createAuthRefreshInterceptor(
@@ -45,7 +45,7 @@ createAuthRefreshInterceptor(
 			return Promise.reject()
 		}
 	},
-	{ statusCodes: [401, 500] }
+	{ statusCodes: [401] }
 )
 
 /**


### PR DESCRIPTION
1. removed the 500 from the interceptor 
1. validated as much of the flow as possible 

Did not validate the 401/refresh logic, The access token expiration is to long to trigger it but if we wanted to double check I can work with @kilkka on temporarily changing that for testing. Can't wait for end to end 