### PR TITLE
Refactored where the app reads values for unlist quantity 

### DIFF
--- a/src/components/UI/Modals/UnlistModal.jsx
+++ b/src/components/UI/Modals/UnlistModal.jsx
@@ -177,7 +177,7 @@ const UnlistPage = ({ token, unlistToken, onClose, profile_id }) => {
 							<hr className="mx-8 border-0 border-r-px dark:border-gray-800" />
 						</div>
 						<div className={`p-4 border-b border-gray-100 dark:border-gray-900 flex items-center ${hasMultipleEditions ? 'justify-between' : 'justify-end'}`}>
-							{hasMultipleEditions && <p className="text-gray-600 text-xs font-semibold dark:text-white">{currentListing.quantity} available</p>}
+							{hasMultipleEditions && <p className="text-gray-600 text-xs font-semibold dark:text-white">{currentListing.quantity} listed</p>}
 							<p className="text-gray-600 text-xs font-semibold dark:text-white">{parseInt(token.listing.royalty_percentage)}% Royalties</p>
 						</div>
 					</>


### PR DESCRIPTION
Figma: https://www.figma.com/file/720aUothRCUZMtMEVHfJV0/%F0%9F%96%A5%F0%9F%93%B1-Showtime?node-id=1284%3A34632

- Updates dark styles to mirror Figma
- Display current listing quantity and not total
- Hide but maintain layout if the edition is 1/1

## Screenshots

### 1/1
<img width="601" alt="Screen Shot 2021-10-21 at 2 08 55 PM" src="https://user-images.githubusercontent.com/11730651/138341350-49cd666a-feac-4c42-8b5f-cf2fe07fb7ba.png">

### multiple 
<img width="619" alt="Screen Shot 2021-10-21 at 2 09 24 PM" src="https://user-images.githubusercontent.com/11730651/138341423-053db6e7-be13-413f-9008-071dd17045fd.png">

### Previous for reference
<img width="617" alt="Screen Shot 2021-10-21 at 2 10 31 PM" src="https://user-images.githubusercontent.com/11730651/138341595-38676058-4436-4891-9bd3-ea71e3a8616e.png">

<img width="586" alt="Screen Shot 2021-10-21 at 2 10 56 PM" src="https://user-images.githubusercontent.com/11730651/138341657-d0147df5-056c-411d-a9ce-c5343c43ebf9.png">

