### PR TITLE
Sentry Configuration Update

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "@magic-sdk/admin": "^1.3.0",
         "@sentry/integrations": "^6.13.2",
         "@sentry/nextjs": "^6.13.2",
+        "@sentry/tracing": "^6.13.3",
         "@tailwindcss/forms": "^0.3.2",
         "@tippyjs/react": "^4.2.5",
         "@walletconnect/web3-provider": "^1.6.5",

--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -3,9 +3,22 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from '@sentry/nextjs'
+import { Integrations as TracingIntegrations } from '@sentry/tracing'
 import { ExtraErrorData, CaptureConsole, Offline } from '@sentry/integrations'
 
 Sentry.init({
 	dsn: process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN,
-	integrations: [new ExtraErrorData(), new CaptureConsole(), new Offline()],
+	release: `showtime-frontend-client@${process.env.NEXT_PUBLIC_SENTRY_RELEASE_ENVIRONMENT}`,
+	environment: process.env.NEXT_PUBLIC_SENTRY_CLIENT_ENVIRONMENT,
+	tracesSampleRate: 0.2,
+	integrations: [
+		new TracingIntegrations.BrowserTracing({
+			tracingOrigins: [process.env.NEXT_PUBLIC_BACKEND_URL, process.env.NEXT_PUBLIC_NOTIFICATIONS_URL],
+		}),
+		new ExtraErrorData(),
+		new CaptureConsole({
+			levels: ['warn', 'error'],
+		}),
+		new Offline(),
+	],
 })

--- a/sentry.server.config.js
+++ b/sentry.server.config.js
@@ -7,5 +7,13 @@ import { ExtraErrorData, CaptureConsole } from '@sentry/integrations'
 
 Sentry.init({
 	dsn: process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN,
-	integrations: [new ExtraErrorData(), new CaptureConsole()],
+	release: `showtime-frontend-server@${process.env.SENTRY_SERVER_RELEASE_ENVIRONMENT}`,
+	environment: process.env.SENTRY_SERVER_ENVIRONMENT,
+	tracesSampleRate: 0.2,
+	integrations: [
+		new ExtraErrorData(),
+		new CaptureConsole({
+			levels: ['warn', 'error'],
+		}),
+	],
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1281,6 +1281,15 @@
     "@sentry/utils" "6.13.2"
     tslib "^1.9.3"
 
+"@sentry/hub@6.13.3":
+  version "6.13.3"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.13.3.tgz#cc09623a69b5343315fdb61c7fdd0be74b72299f"
+  integrity sha512-eYppBVqvhs5cvm33snW2sxfcw6G20/74RbBn+E4WDo15hozis89kU7ZCJDOPkXuag3v1h9igns/kM6PNBb41dw==
+  dependencies:
+    "@sentry/types" "6.13.3"
+    "@sentry/utils" "6.13.3"
+    tslib "^1.9.3"
+
 "@sentry/integrations@6.13.2", "@sentry/integrations@^6.13.2":
   version "6.13.2"
   resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-6.13.2.tgz#906f2dd920439e5886f479a6da57f9c5d928f656"
@@ -1298,6 +1307,15 @@
   dependencies:
     "@sentry/hub" "6.13.2"
     "@sentry/types" "6.13.2"
+    tslib "^1.9.3"
+
+"@sentry/minimal@6.13.3":
+  version "6.13.3"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.13.3.tgz#a675a79bcc830142e4f95e6198a2efde2cd3901e"
+  integrity sha512-63MlYYRni3fs5Bh8XBAfVZ+ctDdWg0fapSTP1ydIC37fKvbE+5zhyUqwrEKBIiclEApg1VKX7bkKxVdu/vsFdw==
+  dependencies:
+    "@sentry/hub" "6.13.3"
+    "@sentry/types" "6.13.3"
     tslib "^1.9.3"
 
 "@sentry/nextjs@^6.13.2":
@@ -1352,10 +1370,26 @@
     "@sentry/utils" "6.13.2"
     tslib "^1.9.3"
 
+"@sentry/tracing@^6.13.3":
+  version "6.13.3"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-6.13.3.tgz#ca657d4afa99c50f15e638fe38405bac33e780ee"
+  integrity sha512-yyOFIhqlprPM0g4f35Icear3eZk2mwyYcGEzljJfY2iU6pJwj1lzia5PfSwiCW7jFGMmlBJNhOAIpfhlliZi8Q==
+  dependencies:
+    "@sentry/hub" "6.13.3"
+    "@sentry/minimal" "6.13.3"
+    "@sentry/types" "6.13.3"
+    "@sentry/utils" "6.13.3"
+    tslib "^1.9.3"
+
 "@sentry/types@6.13.2":
   version "6.13.2"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.13.2.tgz#8388d5b92ea8608936e7aae842801dc90e0184e6"
   integrity sha512-6WjGj/VjjN8LZDtqJH5ikeB1o39rO1gYS6anBxiS3d0sXNBb3Ux0pNNDFoBxQpOhmdDHXYS57MEptX9EV82gmg==
+
+"@sentry/types@6.13.3":
+  version "6.13.3"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.13.3.tgz#63ad5b6735b0dfd90b3a256a9f8e77b93f0f66b2"
+  integrity sha512-Vrz5CdhaTRSvCQjSyIFIaV9PodjAVFkzJkTRxyY7P77RcegMsRSsG1yzlvCtA99zG9+e6MfoJOgbOCwuZids5A==
 
 "@sentry/utils@6.13.2":
   version "6.13.2"
@@ -1363,6 +1397,14 @@
   integrity sha512-foF4PbxqPMWNbuqdXkdoOmKm3quu3PP7Q7j/0pXkri4DtCuvF/lKY92mbY0V9rHS/phCoj+3/Se5JvM2ymh2/w==
   dependencies:
     "@sentry/types" "6.13.2"
+    tslib "^1.9.3"
+
+"@sentry/utils@6.13.3":
+  version "6.13.3"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.13.3.tgz#188754d40afe693c3fcae410f9322531588a9926"
+  integrity sha512-zYFuFH3MaYtBZTeJ4Yajg7pDf0pM3MWs3+9k5my9Fd+eqNcl7dYQYJbT9gyC0HXK1QI4CAMNNlHNl4YXhF91ag==
+  dependencies:
+    "@sentry/types" "6.13.3"
     tslib "^1.9.3"
 
 "@sentry/webpack-plugin@1.17.1":


### PR DESCRIPTION
Updated the sentry configuration

- integrates with the tracing/perf BrowserTracing feature for apis
- named release updated for the client + server (nextjs api routes)
- named environment updated for client + server per env
- log levels only capturing errors and warning (reduce noise + hitting limits)
- set sample rate to `0.2` recommendation per docs
- BrowserTracing configured to trace backend calls (beyond nextjs api routes)

## Screenshot examples
<img width="583" alt="Screen Shot 2021-10-26 at 1 32 36 PM" src="https://user-images.githubusercontent.com/11730651/138940052-1f54a73a-2f74-409c-afab-aaa1a3a0556b.png">
<img width="1567" alt="Screen Shot 2021-10-26 at 1 32 29 PM" src="https://user-images.githubusercontent.com/11730651/138940055-0269d198-d6e7-4ddd-8d82-e73a5bfd15d6.png">

