### PR TITLE
fix issue with serverless functions with next 12 and sentry

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,7 @@ const { withSentryConfig } = require('@sentry/nextjs')
 const isDev = process.env.NODE_ENV === 'development'
 
 const nextConfig = {
+	outputFileTracing: false, // https://github.com/vercel/next.js/issues/30601#issuecomment-961323914
 	async redirects() {
 		return [
 			{


### PR DESCRIPTION
As you can see all the serverless functions are failing here: https://vercel.com/showtime/showtime/Em6SMSCqVVC9vJGcn1FDBdPow9hi/functions

This is due to an issue with Next.js 12 and Sentry: https://github.com/vercel/next.js/issues/30601. Seems to be due to https://nextjs.org/docs/advanced-features/output-file-tracing