### PR TITLE
fix(spotlight): allow nft owner to spotlight a purchased nft

### DIFF
--- a/src/components/SpotlightItem.js
+++ b/src/components/SpotlightItem.js
@@ -23,7 +23,7 @@ import backend from '@/lib/backend'
 
 const SpotlightItem = ({ isMyProfile, pageProfile, item, removeSpotlightItem }) => {
 	const { data: thisItem, mutate: mutateItem } = useSWR(
-		() => item && `/v1/spotlight/${item.creator_id}`,
+		() => pageProfile && `/v1/spotlight/${pageProfile.profile_id}`,
 		url => backend.get(url).then(res => res.data.data),
 		{ initialData: item, revalidateOnMount: true, revalidateOnFocus: true }
 	)


### PR DESCRIPTION
### Cause of bug
1. Creator sells an NFT
2. User (that bought previous NFT) makes that item the spotlight
3. We fetch the users spotlight but pass in the creator ID causing two outcomes
	- Creator does not have a spotlight returning null
	- Creator has a different spotlight so possibly showing the wrong spotlight (did not check this scenario but it follows)

### Solution
Update the spotlight call to use `pageProfile.profile_id` vs `item.creator_id`

### Issue Addressed
<img width="936" alt="Screen Shot 2021-11-08 at 2 26 50 PM" src="https://user-images.githubusercontent.com/11730651/140812987-2609e005-6a8b-4666-ad64-0689da5d0c45.png">

<img width="1548" alt="Screen Shot 2021-11-08 at 2 31 05 PM" src="https://user-images.githubusercontent.com/11730651/140813630-a4bf15ab-c0a2-4f5b-b3d0-857dd4508586.png">


