### PR TITLE
fix(buy-modal): bump z-index so buy modal is above nft detail modal

### DIFF
--- a/src/components/UI/Modals/BuyModal.jsx
+++ b/src/components/UI/Modals/BuyModal.jsx
@@ -178,7 +178,7 @@ const BuyModal = ({ open, onClose, token }) => {
 
 	return (
 		<Transition.Root show={open && modalVisibility} as={Fragment} afterLeave={afterModalCloseAnimation}>
-			<Dialog as="div" static className="fixed inset-0 overflow-y-auto z-1 pt-[96px] md:pt-0" open={open} onClose={updateModalVisibility}>
+			<Dialog as="div" static className="fixed inset-0 overflow-y-auto z-10 pt-[96px] md:pt-0" open={open} onClose={updateModalVisibility}>
 				<canvas ref={confettiCanvas} className="absolute inset-0 w-screen h-screen z-[11] pointer-events-none" />
 				<div className="min-h-screen text-center">
 					<Transition.Child as={Fragment} enter="ease-out duration-300" enterFrom="opacity-0" enterTo="opacity-100" leave="ease-in duration-200" leaveFrom="opacity-100" leaveTo="opacity-0">


### PR DESCRIPTION
z-index bug causing an issue when a user clicks the "buy" CTA on the NFT detail view the buy modal opens below the NFT detail modal view.

- bumps up the buy modal index to the next tailwind value

## Solution screenshot

<img width="1526" alt="Screen Shot 2021-11-09 at 10 54 50 PM" src="https://user-images.githubusercontent.com/11730651/141052543-6cc37e98-7827-4730-b140-2d366a4a01a0.png">

