### PR TITLE
Sentry Configuration

### DIFF
--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -8,7 +8,6 @@ import { ExtraErrorData, CaptureConsole, Offline } from '@sentry/integrations'
 
 Sentry.init({
 	dsn: process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN,
-	release: `showtime-frontend-client@${process.env.NEXT_PUBLIC_SENTRY_RELEASE_ENVIRONMENT}`,
 	environment: process.env.NEXT_PUBLIC_SENTRY_CLIENT_ENVIRONMENT,
 	tracesSampleRate: 0.2,
 	integrations: [

--- a/sentry.server.config.js
+++ b/sentry.server.config.js
@@ -7,7 +7,6 @@ import { ExtraErrorData, CaptureConsole } from '@sentry/integrations'
 
 Sentry.init({
 	dsn: process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN,
-	release: `showtime-frontend-server@${process.env.SENTRY_SERVER_RELEASE_ENVIRONMENT}`,
 	environment: process.env.SENTRY_SERVER_ENVIRONMENT,
 	tracesSampleRate: 0.2,
 	integrations: [


### PR DESCRIPTION
- remove release var from sentry init to ensure compatibility with newest versions of the SDK and Nextjs 12+