### PR TITLE
Small Yarn Workspace Fix

### DIFF
--- a/apps/storybook-react-native/package.json
+++ b/apps/storybook-react-native/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "storybook-react-native",
+	"name": "@showtime/storybook-react-native",
 	"version": "1.0.0",
 	"main": "index.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"dev:storybook:react": "yarn workspace @showtime/storybook-react storybook",
 		"dev:storybook:react-native": "yarn workspace @showtime/storybook-react-native start",
 		"build": "yarn turbo run build --ignore='packages/**/*' --ignore='apps/**/*' --ignore='!/apps/next-react/**/*'",
+		"clean": "find . -name 'node_modules' -type d -prune -exec rm -rf '{}' +",
 		"postinstall": "patch-package"
 	},
 	"resolutions": {


### PR DESCRIPTION
In the root directory the command `yarn dev:storybook:react-native` would throw an error and not run the app. This was not the case for the other apps. I realized after debugging that the workspace name for `apps/storybook-react-native` was mismatching the convention used in the root package.json.

- Update `apps/storybook-react-native` to use `@showtime` scoping convention 
- Add a utility command to rm all monorepo node_modules at once (I found myself doing this often when debugging the workspace) (reference: http://man.he.net/?topic=find&section=all)

**Might have to run `yarn` in the root to pick up change`**