### PR TITLE
add All Time option on trending page

### DIFF
--- a/apps/next-react/src/pages/trending.js
+++ b/apps/next-react/src/pages/trending.js
@@ -111,6 +111,13 @@ const Leaderboard = () => {
 								setLeaderboardDays(30)
 							}}
 						/>
+						<GridTab
+							label="All Time"
+							isActive={leaderboardDays === 10000}
+							onClickTab={() => {
+								setLeaderboardDays(10000)
+							}}
+						/>
 					</GridTabs>
 				</div>
 				<div className="md:grid md:grid-cols-3 xl:grid-cols-4 ">


### PR DESCRIPTION
# Why
Frontend for SHOW2-87 Add "All Time" option to Trending page

Backend counterpart: https://github.com/tryshowtime/stbackend/pull/147 +  https://github.com/tryshowtime/stbackend/pull/148

# How
Simply add a `GridTab` component allowing to set `leaderboardDays` to 10k

![Screenshot 2021-12-10 at 19 13 18](https://user-images.githubusercontent.com/14199823/145622092-efc7dec7-6a46-4245-999d-896caca3820e.png)

# Test
Only tested manually