### PR TITLE
upgrade expo dev client on storybook RN

### DIFF
--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -65,7 +65,7 @@
     "expo-av": "~10.1.3",
     "expo-blur": "^10.0.3",
     "expo-constants": "^12.1.3",
-    "expo-dev-client": "0.6.3",
+    "expo-dev-client": "^0.7.1",
     "expo-device": "~4.0.3",
     "expo-font": "~10.0.3",
     "expo-haptics": "~11.0.3",

--- a/apps/storybook-react-native/react-native.config.js
+++ b/apps/storybook-react-native/react-native.config.js
@@ -1,0 +1,7 @@
+// File created by expo-dev-client/app.plugin.js
+
+module.exports = {
+  dependencies: {
+    ...require('expo-dev-client/dependencies'),
+  },
+};

--- a/packages/design-system/checkbox/index.tsx
+++ b/packages/design-system/checkbox/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback,useMemo } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import { Pressable } from 'dripsy'
 import { Path, Svg } from 'react-native-svg'
 import { Platform } from 'react-native'
@@ -6,9 +6,8 @@ import { MotiView } from 'moti'
 import { tw } from '../tailwind'
 import { useOnFocus, useOnHover } from '../hooks'
 import { useIsDarkMode } from '../hooks'
-import Animated, {useAnimatedStyle} from "react-native-reanimated"
-import {colors} from "../tailwind/colors"
-
+import Animated, { useAnimatedStyle } from 'react-native-reanimated'
+import { colors } from '../tailwind/colors'
 
 type CheckboxProps = {
 	onChange: (checked: boolean) => void
@@ -16,7 +15,7 @@ type CheckboxProps = {
 	hitSlop?: number
 	accesibilityLabel: string
 	id?: string
-	disabled?:boolean
+	disabled?: boolean
 }
 
 export const Checkbox = ({ checked, onChange, id, hitSlop = 14, accesibilityLabel, disabled }: CheckboxProps) => {
@@ -26,17 +25,16 @@ export const Checkbox = ({ checked, onChange, id, hitSlop = 14, accesibilityLabe
 
 	const isDark = useIsDarkMode()
 
-	const {onHoverIn, onHoverOut, hovered} = useOnHover()
-	const {onFocus, onBlur, focused} = useOnFocus()
+	const { onHoverIn, onHoverOut, hovered } = useOnHover()
+	const { onFocus, onBlur, focused } = useOnFocus()
 
 	const animatedStyle = useAnimatedStyle(() => {
 		return {
 			borderColor: hovered.value ? colors.gray[400] : colors.gray[300],
-			boxShadow: Platform.OS === 'web' && focused.value ? "0px 0px 0px 4px #E4E4E7" : undefined,
-			disabled: disabled ? 0.4 : 1
+			boxShadow: Platform.OS === 'web' && focused.value ? '0px 0px 0px 4px #E4E4E7' : undefined,
+			disabled: disabled ? 0.4 : 1,
 		}
-	},[focused, hovered,disabled])
-
+	}, [focused, hovered, disabled])
 
 	return (
 		<Pressable
@@ -60,18 +58,25 @@ export const Checkbox = ({ checked, onChange, id, hitSlop = 14, accesibilityLabe
 			})}
 		>
 			<Animated.View
-				style={useMemo(() => ([{
-					height: 24,
-					width: 24,
-					borderRadius: 4,
-					borderWidth: 1,
-					alignItems: 'center',
-					justifyContent: 'center',
-				}, animatedStyle, tw`bg-white dark:bg-black`]), [animatedStyle])}
+				style={useMemo(
+					() => [
+						{
+							height: 24,
+							width: 24,
+							borderRadius: 4,
+							borderWidth: 1,
+							alignItems: 'center',
+							justifyContent: 'center',
+						},
+						animatedStyle,
+						tw`bg-white dark:bg-black`,
+					],
+					[animatedStyle]
+				)}
 			>
 				<MotiView
 					from={{ opacity: 0 }}
-					animate={{ scale: checked ? [1.08, 1] : 1, opacity: checked ? 1 : 0 }}
+					animate={{ opacity: checked ? 1 : 0 }}
 					transition={{ duration: 100, type: 'timing' }}
 				>
 					<Svg width="13" height="12" viewBox="0 0 13 12" fill="none">

--- a/yarn.lock
+++ b/yarn.lock
@@ -11760,18 +11760,6 @@ expo-constants@^12.1.3, expo-constants@~12.1.1, expo-constants@~12.1.2, expo-con
     expo-modules-core "~0.4.4"
     uuid "^3.3.2"
 
-expo-dev-client@0.6.3:
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/expo-dev-client/-/expo-dev-client-0.6.3.tgz#ab3f6cf31c55c96b70f029bb0733236976eafe98"
-  integrity sha512-lYhOoEBSPqsZDi2UNDZhbHbGJ5nYeudviJdnWxMdemf5RDrF0oYumceCsvNem47j+V9t3fHqWmGyvUJ6QxLcmQ==
-  dependencies:
-    "@expo/config-plugins" "^4.0.2"
-    expo-dev-launcher "0.8.4"
-    expo-dev-menu "0.8.4"
-    expo-dev-menu-interface "0.4.1"
-    expo-manifests "~0.2.2"
-    expo-updates-interface "~0.4.0"
-
 expo-dev-client@^0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/expo-dev-client/-/expo-dev-client-0.7.1.tgz#5ff089032ac952f49389086a95cfc7a9be751898"
@@ -11784,15 +11772,6 @@ expo-dev-client@^0.7.1:
     expo-manifests "~0.2.2"
     expo-updates-interface "~0.4.0"
 
-expo-dev-launcher@0.8.4:
-  version "0.8.4"
-  resolved "https://registry.yarnpkg.com/expo-dev-launcher/-/expo-dev-launcher-0.8.4.tgz#505a8ad5f4b31903b161d57c379247a6eef9da4c"
-  integrity sha512-bG2tpCQoxmGsTR7DecyIIOdWbJGfIuxn3YWpkiGLJ4nYokdbO5+A4WW5rl9senb9+oy4vKabKxMbn0ZVy49T5Q==
-  dependencies:
-    "@expo/config-plugins" "^4.0.2"
-    resolve-from "^5.0.0"
-    semver "^7.3.5"
-
 expo-dev-launcher@0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/expo-dev-launcher/-/expo-dev-launcher-0.9.0.tgz#55b7701b4cf67588ff4c35f1e5f3328ffbd6725a"
@@ -11802,23 +11781,10 @@ expo-dev-launcher@0.9.0:
     resolve-from "^5.0.0"
     semver "^7.3.5"
 
-expo-dev-menu-interface@0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/expo-dev-menu-interface/-/expo-dev-menu-interface-0.4.1.tgz#1499992cf96f3d4ccd02eefcfc1c182f44e876c7"
-  integrity sha512-gc1w47D71Y2fRlF0k6JSVYct/aMWeZp5/QAdisqRprtZTeTXxMG9AwtT5NihrlfyaAbHE2udeB7yxBx5vH4pUQ==
-
 expo-dev-menu-interface@0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/expo-dev-menu-interface/-/expo-dev-menu-interface-0.4.2.tgz#061cf77dc4ccf1ea6a937983a073456895098eeb"
   integrity sha512-OaXJTMh1RHnsunpK9iZfWeZhY4uf5GfDsd+rS4RWbdUG7u23EOf465EkcORokoPIyPV3vy3Mp2ehY2wsUJ2NDw==
-
-expo-dev-menu@0.8.4:
-  version "0.8.4"
-  resolved "https://registry.yarnpkg.com/expo-dev-menu/-/expo-dev-menu-0.8.4.tgz#2a329805abe43ab651483bea601c13b69bfc052c"
-  integrity sha512-E3cU0nnmncPg5aVs94QC09tpUAT5EDHz00qLGvB1gC0QxLlVXU6WKR8EW2of6Vd9IP+nukiGMqv9WkIiqqM/Zw==
-  dependencies:
-    "@expo/config-plugins" "^4.0.2"
-    expo-dev-menu-interface "0.4.1"
 
 expo-dev-menu@0.8.6:
   version "0.8.6"


### PR DESCRIPTION
## Why

- Was running into trouble while running storybook for react native dev client locally. It was happening due to different versions of expo dev client and hoisting issues (also probably something the way pod install works (not sure about this))

<img width="1440" alt="Screenshot 2021-12-14 at 6 37 35 PM" src="https://user-images.githubusercontent.com/23293248/146052627-0703e0a7-bb50-4a2b-9675-75b56a445381.png">

## How
- Upgraded storybook's dev client and made it same as the expo app's.
<!--
How was the change made? Is there some gory details to be aware of?
-->

## Impact
- Tested locally, I don't this this should break anything. 
<!--
What this PR will affect?
* API Backward compatibility (mobile)
* Breaking changes
* Security
* Performance
* Privacy
* Documentation & communication
* Model / database migration
* Added dependencies

-->

## Test

Yes. Tested building locally.

<!--
How this PR was tested?
-->

P.S. Checkbox has a small change to fix a crash. Having issues with sequence animation on moti and reanimated 2.3. [looking into this](https://github.com/nandorojo/moti/issues/131). Pushing this change in PR as it's a very small change. Sorry for the prettier changes 🙏 
