### PR TITLE
Improve marketplace CTA on token card

### DIFF
--- a/apps/next-react/src/components/TokenCard.js
+++ b/apps/next-react/src/components/TokenCard.js
@@ -709,7 +709,7 @@ const TokenCard = ({
 											</div>
 											<div>
 												<span className="text-xs font-medium text-gray-600 dark:text-gray-500">
-													Price
+													Buy
 												</span>
 												<p className="text-sm font-bold text-gray-900 dark:text-gray-200 whitespace-nowrap">
 													{parseFloat(item.listing.min_price)} ${item.listing.currency}


### PR DESCRIPTION
# Why

Our corporate overlords (@AlexMasmej) want the call to action on the token cards to be slightly clearer.

# How

Change the label above the price from "Price" to "Buy"

# Test Plan

With your 👀, look at the new copy on the test deployment, and make sure that the text has indeed changed. [Beware saccades](https://twitter.com/Foone/status/1014267515696922624).
