### PR TITLE
Improve chromatic pipeline feedback

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -69,7 +69,7 @@ jobs:
               id: existing-comment
               with:
                   issue-number: ${{ steps.PR.outputs.number }}
-                  body-includes: PR Preview
+                  body-includes: PR Preview - Storybook on Chromatic
 
             - name: Create or update comment
               uses: peter-evans/create-or-update-comment@v1


### PR DESCRIPTION
(small PR branched from the #609 PR)

# Why

Equal to the value of being able to scan a QR code to preview storybook changes on mobile from a PR comment a link posted as a comment from chromatic will encourage and make it easier for devs to check our their PR builds on storybook.

# How

1. Update the publish step to store outputs in an ID
2. Format the `storybookUrl` output (as-is would sometimes cause a broken link)
3. Reference the formatted link in a github action comment 

# Test Plan

Click the link 🙂
