### PR TITLE
fix: pin next adapter version to 3.1.7

### DIFF
--- a/apps/next-react-native/package.json
+++ b/apps/next-react-native/package.json
@@ -76,7 +76,7 @@
 	},
 	"devDependencies": {
 		"@babel/eslint-parser": "^7.16.3",
-		"@expo/next-adapter": "^3.1.7",
+		"@expo/next-adapter": "3.1.7",
 		"critters": "^0.0.14",
 		"eslint": "7.32.0",
 		"eslint-config-next": "^12.0.7",

--- a/apps/next-react/package.json
+++ b/apps/next-react/package.json
@@ -82,7 +82,7 @@
 	},
 	"devDependencies": {
 		"@babel/eslint-parser": "^7.16.3",
-		"@expo/next-adapter": "^3.1.7",
+		"@expo/next-adapter": "3.1.7",
 		"critters": "^0.0.14",
 		"eslint": "7.32.0",
 		"eslint-config-next": "^12.0.7",


### PR DESCRIPTION
# Why
Newer version of adapter is giving [webpack issues](https://github.com/expo/expo-cli/issues/4066)
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# Test Plan
- Run `yarn` and `yarn build`. Also try deleting node_modules and yarn.lock
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
