### PR TITLE
Rename PR preview comment in GitHub action

### DIFF
--- a/.github/workflows/expo-preview.yml
+++ b/.github/workflows/expo-preview.yml
@@ -88,7 +88,7 @@ jobs:
               id: existing-comment
               with:
                   issue-number: ${{ steps.PR.outputs.number }}
-                  body-includes: PR Preview
+                  body-includes: PR Preview - App
 
             - name: Create or update comment
               uses: peter-evans/create-or-update-comment@v1
@@ -98,7 +98,7 @@ jobs:
                   issue-number: ${{ steps.PR.outputs.number }}
                   edit-mode: replace
                   body: |
-                      ## PR Preview
+                      ## PR Preview - App
 
                       This pull request preview deployment is now available.
 


### PR DESCRIPTION
# Why

Prevents conflicts between PR preview comment

# How

Specify `PR Preview - App`

# Test Plan

Check if both comments are posted in this PR