### PR TITLE
fix web3modal z-index

### DIFF
--- a/apps/next-react/src/styles/styles.css
+++ b/apps/next-react/src/styles/styles.css
@@ -70,5 +70,5 @@
 
 /* Default Z-index for web3modal is 2, which doesn't play nice with our buyModal */
 .web3modal-modal-lightbox {
-	z-index: 10 !important;
+  z-index: 10 !important;
 }


### PR DESCRIPTION
# Why

https://showtime-rq88331.slack.com/archives/C02PTNZMEPQ/p1640019476121400

the web3modal sometimes (most of the time in my experience) gets rendered behind our `buyModal` which makes it unusable

# How

override web3modal style to set a higher z-index (default is 2)

# Test Plan

manual. It 100% fixes the issue on my end. You can try with the vercel preview