### PR TITLE
add .git-blame-ignore-revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,12 @@
+# List of commits to ignore by default in `git-blame`. Add to this list
+# ONLY commits that are certain to have been functional no-ops, like
+# automated reformattings.
+#
+# To make use of this, you must set the `blame.ignoreRevsFile` Git config
+# option to point to this file. See `git help blame` and `git help config` for
+# more details.
+#
+# tldr; with git >2.23 do:
+# $ git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+17684ae7233c4abe8467074b7876533a8b334111


### PR DESCRIPTION
# Why

I am currently git blame on the whole codebase because of https://github.com/tryshowtime/showtime-frontend/pull/619
# How

add a `.git-blame-ignore-revs` to specify a list of commits to ignore for git blame

# Impact

To make use of this, you must set the `blame.ignoreRevsFile` Git config option to point to this file. See `git help blame` and `git help config` for  more details.

tldr; with git >2.23 do: `git config blame.ignoreRevsFile .git-blame-ignore-revs`

# Test Plan

no