### PR TITLE
clarify formatting setup in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,18 @@ Turbo pipelines are configured within the root directory [package.json](./packag
 - `yarn lint:next-storybook` runs the lint script for [@showtime/next-storybook](/apps/next-storybook)
 - `yarn lint:next-react-native` runs the lint script for [@showtime/next-react-native](/apps/next-react-native)
 
+#### Formatting
+
+The formatting rules are the ones from `prettier/recommended`. The actual formatting is done via `eslint`.
+
+To get formatting on save in VS Code, install the `eslint` extension and add the following setting:
+
+```json
+"editor.codeActionsOnSave": {
+  "source.fixAll.eslint": true
+}
+```
+
 #### Graph
 
 - `yarn turbo:graph` generates the current [task graph](https://turborepo.org/docs/reference/command-line-reference#--graph) for all [application](/apps)


### PR DESCRIPTION
# Why

The formatting is done via ESLint using prettier rules instead of the standalone prettier tool.
This might not work in VS Code if it's not setup to automatically fix auto-fixable errors from ES Lint.

opened by request from @axeldelafosse (formatting PR broke his setup)

# How

Add a section in the README to clarify

# Test Plan

no