### PR TITLE
Prevent editable field when listing a single token

### DIFF
--- a/apps/next-react/src/components/UI/Modals/ListModal.jsx
+++ b/apps/next-react/src/components/UI/Modals/ListModal.jsx
@@ -394,6 +394,7 @@ const ListPage = ({
   priceErrorMessage,
   preventExponent,
 }) => {
+  const ownsSingleToken = 1 === maxTokens;
   return (
     <>
       <div className="flex-1">
@@ -534,6 +535,7 @@ const ListPage = ({
               </p>
             </div>
             <input
+              disabled={ownsSingleToken}
               id="copies"
               type="number"
               min="1"


### PR DESCRIPTION
# Why

Per testing feedback it doesn't make sense to have the editable field for the number of copies to list if it's one. 
Source: https://showtime-rq88331.slack.com/archives/C02PTNZMEPQ/p1640020369124800
Linear:  https://linear.app/showtime/issue/SHOW2-279/catch-all-marketplace-feedback-aggregate-issue

# How

The `ListingModal` component renders a component named `ListPage` with a `maxTokens` prop that represents the amount owned by the lister. I use this value to check if the amount owned is one. If so we disable the field inputs and leave it at its default value of one.

# Test Plan

Listed and unlisted NFT's in dark and light mode

## Screenshots
<img width="644" alt="Screen Shot 2021-12-27 at 8 31 47 AM" src="https://user-images.githubusercontent.com/11730651/147481814-82a8ee57-98e8-4b4a-9ada-9e897b781406.png">

<img width="647" alt="Screen Shot 2021-12-27 at 8 32 01 AM" src="https://user-images.githubusercontent.com/11730651/147481812-3826e815-cc1a-4f4f-b903-b0e75b194c12.png">

