### PR TITLE
Include formatting commit to git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,6 +1,6 @@
 # List of commits to ignore by default in `git-blame`. Add to this list
 # ONLY commits that are certain to have been functional no-ops, like
-# automated reformattings.
+# automated reformatting.
 #
 # To make use of this, you must set the `blame.ignoreRevsFile` Git config
 # option to point to this file. See `git help blame` and `git help config` for
@@ -10,3 +10,5 @@
 # $ git config blame.ignoreRevsFile .git-blame-ignore-revs
 
 17684ae7233c4abe8467074b7876533a8b334111
+ 
+7494c2506bdfe41935b7885446aca633a167e857

--- a/README.md
+++ b/README.md
@@ -273,6 +273,11 @@ Using `dotenv` for the Expo app. Next.js is automatically picking up the `.env.l
 
 Pro tip: you can add `tw` to `Tailwind CSS: Class Attributes` VS Code extension setting to get IntelliSense working.
 
+Pro tip: Ignore a list of commits within `git-blame` by default on version `>2.23`
+```
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+```
+
 ### Root
 
 - Don't add any package here


### PR DESCRIPTION
Small PR, a chore I noticed while working on a ticket

# Why

Noticed while active dev'in that the `git-blame-ignore-rev` intellisense was not active because I did not run the command 🤦🏻‍♂️ so I added it to the `readme` then I noticed a formatting commit was missing so I added it to the config.

# How

Updated files!

# Test Plan

Made sure vs code git blame intellisense was showing the correct previous commit 