### PR TITLE
Enable source maps for all env expect production

### DIFF
--- a/apps/next-react/next.config.js
+++ b/apps/next-react/next.config.js
@@ -37,6 +37,7 @@ const nextConfig = {
     ignoreDevErrors: true,
     ignoreBuildErrors: true,
   },
+  productionBrowserSourceMaps: process.env.ENABLE_SOURCE_MAPS,
   outputFileTracing: false, // https://github.com/vercel/next.js/issues/30601#issuecomment-961323914
   images: {
     disableStaticImages: true,


### PR DESCRIPTION
# Why

Source maps will provide readable error logs and decrease the amount of tracing and debugging. 

# How

Updated the next.config to set `productionBrowserSourceMaps` as an env variable

# Test Plan

Ran `yarn build:next` locally with the env variable set and unset then confirmed in the `.next/static/chunks` has the source maps
