### PR TITLE
Fix MMKV config plugin

### DIFF
--- a/apps/expo/plugins/react-native-mmkv-plugin.js
+++ b/apps/expo/plugins/react-native-mmkv-plugin.js
@@ -107,6 +107,10 @@ const withMainApplication = (config) => {
     "android",
     async (config) => {
       await editMainApplication(config, (mainApplication) => {
+        if (mainApplication.includes('return new MMKVJSIModulePackage();')) {
+          return mainApplication;
+        }
+
         mainApplication = mainApplication.replace(
           `    @Override
     protected String getJSMainModuleName() {


### PR DESCRIPTION
# Why

The config plugin is not idempotent anymore: you can't run `expo prebuild` multiple times, it will add the `getJSIModulePackage()` function every time.

# How

Added a check to return the current `MainApplication.java` file without changes if we already made them.

# Test Plan

Run `yarn android` multiple times locally