### PR TITLE
fix(listingModal): enforce 0 or above min listing price

### DIFF
--- a/apps/next-react/src/components/UI/Modals/ListModal.jsx
+++ b/apps/next-react/src/components/UI/Modals/ListModal.jsx
@@ -142,11 +142,19 @@ const ListModal = ({ open, onClose, onSuccess = () => null, token }) => {
 
   const isValidPrice = (price) => {
     const aboveMaxPrice = price > MAX_LIST_PRICE;
+    const belowMinPrice = price < 0;
+
     let updatedPriceErrorMessage = "";
     let updatedHasPriceError = false;
 
     if (aboveMaxPrice) {
       updatedPriceErrorMessage = `The listing price has to be below ${MAX_LIST_PRICE}`;
+      updatedHasPriceError = true;
+    }
+
+    if (belowMinPrice) {
+      updatedPriceErrorMessage =
+        "The listing price cannot be a negative number";
       updatedHasPriceError = true;
     }
 
@@ -492,7 +500,7 @@ const ListPage = ({
                 className="text-sm w-full placeholder-shown:text-left text-right px-4 rounded-3xl dark:text-gray-300 bg-white dark:bg-black border  dark:border-gray-700 focus:outline-none focus-visible:ring font-semibold no-spinners h-[40px]"
                 placeholder="Price"
                 value={price}
-                min=".0001"
+                min="0"
                 max="1000"
                 step=".0001"
                 inputMode="decimal"


### PR DESCRIPTION
# Why

Resolve issue discovered by @karmacoma-eth over [slack](https://showtime-rq88331.slack.com/archives/C02Q0E4PBD0/p1640733589207600) that a user can list with a negative number. The min supported number is 0 (freeeeee).

# How

1. The listing modal has a `isValidPrice` function that is ran onChange 
2. Check if input is below the min price, if so then prevent submission + show error message 
3. Update the input min attribute to 0 f


# Test Plan

Tested listing locally on light and dark mode

<img width="722" alt="Screen Shot 2021-12-28 at 11 05 39 PM" src="https://user-images.githubusercontent.com/11730651/147629646-931355f1-9658-4ca2-9638-127009401c2a.png">


## Screenshot
<img width="686" alt="Screen Shot 2021-12-28 at 11 05 53 PM" src="https://user-images.githubusercontent.com/11730651/147629644-8db100a5-1316-4d54-818c-351fcbd15d88.png">

