### PR TITLE
Resolve undefined variable for listed by value

### DIFF
--- a/apps/next-react/src/components/TokenGridV5.js
+++ b/apps/next-react/src/components/TokenGridV5.js
@@ -185,7 +185,7 @@ const TokenGridV5 = ({
           <BuyModal
             open={!!buyModal}
             onClose={() => setBuyModal(null)}
-            token={buyModal}
+            token={buyModal} // BuyModal value is the individual item in items
           />
         </>
       ) : null}

--- a/apps/next-react/src/components/UI/Modals/BuyModal.jsx
+++ b/apps/next-react/src/components/UI/Modals/BuyModal.jsx
@@ -435,11 +435,11 @@ const BuyPage = ({ token, quantity, setQuantity, buyToken, onClose }) => {
                   </p>
                   <div className="flex items-center space-x-1 -mt-0.5">
                     <p className="text-gray-900 dark:text-white font-semibold text-sm">
-                      {item.listing.name
-                        ? item.listing.name === item.listing.address
-                          ? formatAddressShort(item.listing.name)
-                          : truncateWithEllipses(item.listing.name, 22)
-                        : formatAddressShort(item.listing.name)}
+                      {token.listing.name
+                        ? token.listing.name === token.listing.address
+                          ? formatAddressShort(token.listing.name)
+                          : truncateWithEllipses(token.listing.name, 22)
+                        : formatAddressShort(token.listing.name)}
                     </p>
                     {token.listing.verified == 1 && (
                       <BadgeIcon


### PR DESCRIPTION
# Why

`item` is not defined in the `BuyModal` component and causes the buying flow to break. The value representing `item` is passed in as a prop named token. Naming/Data flow will be an area of improvement when the modals are refactored + types will help.  

I also left a small comment in `apps/next-react/src/components/TokenGridV5.js` mentioning that the value of `token={buyModal}` is the same as an item in the items list. 

# How

Update references to item to token

# Test Plan

Tested locally by going through a few buy flows

## CALL OUT

Eslint should have caught this and when I tested it out, I had inconsistent results 😱 needs to be looked into...