### PR TITLE
Resolve sticky position when a modal is open

### DIFF
--- a/apps/next-react/src/pages/_document.js
+++ b/apps/next-react/src/pages/_document.js
@@ -23,7 +23,8 @@ class Document extends NextDocument {
             crossOrigin="anonymous"
           />
         </Head>
-        <body className="!max-w-screen">
+        {/* overflow-y-visible resolves applied css reset issue caused by `@expo/next-adapter/document`*/}
+        <body className="!max-w-screen overflow-y-visible">
           {/* Here we will mount our modal portal */}
           <div id="modal" />
           <Main />


### PR DESCRIPTION
# Why

Latest _pending_ release is blocked by a bug caused by having a modal open on the home page. The header and left/right col's should have position sticky applied. But are not being _stuck_. After debugging it turns out that the integration for next.js and expo applies various css resets.

We want (I assume) to keep most of them to maintain compatibility with react native web so this PR _only_ changes the value of the offending property. 

 
# How

Apply the tailwind class [overflow-y-visible](https://tailwindcss.com/docs/overflow#scrolling-in-all-directions) to `body` set the default value of [overflow-y](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-y)

# Test Plan

Test on local before push and will test on vercel route

## Bug
https://user-images.githubusercontent.com/11730651/147893696-661bac5f-8fcb-43d9-bc5b-daa899d8e655.mp4

## Solution

https://user-images.githubusercontent.com/11730651/147893701-817ab31a-ec1b-4af7-b695-45dc1030c7d0.mp4


