### PR TITLE
Fix tw prop type

### DIFF
--- a/packages/app/navigation/link/link.tsx
+++ b/packages/app/navigation/link/link.tsx
@@ -3,6 +3,7 @@ import { Platform, TextProps, ViewProps } from "react-native";
 import { Pressable } from "design-system/pressable-scale";
 import { Text } from "design-system/text";
 import { View } from "design-system/view";
+import type { TW } from "design-system/tailwind/types";
 
 import { Props, LinkCore } from "app/navigation/link/link-core";
 
@@ -24,7 +25,7 @@ function Link({ viewProps, ...props }: LinkProps) {
 type TextLinkProps = Props & {
   textProps?: TextProps;
   variant?: string;
-  tw?: string | string[];
+  tw?: TW;
 };
 
 function TextLink({ textProps, variant, tw, ...props }: TextLinkProps) {

--- a/packages/design-system/activity-indicator/index.tsx
+++ b/packages/design-system/activity-indicator/index.tsx
@@ -2,8 +2,9 @@ import { ComponentProps } from "react";
 import { ActivityIndicator as DripsyActivityIndicator } from "dripsy";
 
 import { tw as tailwind } from "design-system/tailwind";
+import type { TW } from "design-system/tailwind/types";
 
-type ActivityIndicatorProps = { tw?: string | string[] } & ComponentProps<
+type ActivityIndicatorProps = { tw?: TW } & ComponentProps<
   typeof DripsyActivityIndicator
 >;
 

--- a/packages/design-system/button/index.tsx
+++ b/packages/design-system/button/index.tsx
@@ -5,9 +5,10 @@ import {
   Pressable,
   Props as PressableScaleProps,
 } from "design-system/pressable-scale";
+import type { TW } from "design-system/tailwind/types";
 
 type Props = {
-  tw?: string | string[];
+  tw?: TW;
   iconOnly?: boolean;
   variant?: "primary" | "danger" | "tertiary";
   size?: "small" | "regular";
@@ -79,7 +80,7 @@ export const ButtonLabel = ({
   tw,
   ...props
 }: {
-  tw?: string | string[];
+  tw?: TW;
   children?: React.ReactNode;
 }) => {
   // TODO: md:text-base

--- a/packages/design-system/dropdown-menu/index.tsx
+++ b/packages/design-system/dropdown-menu/index.tsx
@@ -8,6 +8,7 @@ import Animated, {
 } from "react-native-reanimated";
 
 import { tw as tailwind } from "design-system/tailwind";
+import type { TW } from "design-system/tailwind/types";
 import { Text } from "design-system";
 
 const DropdownMenuRoot = DropdownMenu.Root;
@@ -17,7 +18,7 @@ const DropdownMenuGroup = DropdownMenu.Group;
 const DropdownMenuTrigger = DropdownMenu.Trigger;
 
 const DropdownMenuContent = DropdownMenu.menuify(
-  (props: { tw?: string | string[] } & ComponentProps<typeof DropdownMenu.Content>) => (
+  (props: { tw?: TW } & ComponentProps<typeof DropdownMenu.Content>) => (
     <DropdownMenu.Content {...props} style={tailwind.style(props.tw)} />
   ),
   "Content"
@@ -90,7 +91,7 @@ const DropdownMenuItem = DropdownMenu.menuify(
     onBlur,
     onFocus,
     ...props
-  }: { tw?: string | string[] } & ComponentProps<typeof DropdownMenu.Item>) => {
+  }: { tw?: TW } & ComponentProps<typeof DropdownMenu.Item>) => {
     const { isFocused, handleBlur, handleFocus } = useFocusedItem({
       onFocus,
       onBlur,
@@ -118,7 +119,7 @@ const DropdownMenuCheckboxItem = DropdownMenu.menuify(
     onBlur,
     onFocus,
     ...props
-  }: { tw?: string | string[] } & ComponentProps<typeof DropdownMenu.CheckboxItem>) => {
+  }: { tw?: TW } & ComponentProps<typeof DropdownMenu.CheckboxItem>) => {
     const { isFocused, handleBlur, handleFocus } = useFocusedItem({
       onFocus,
       onBlur,
@@ -172,7 +173,7 @@ const DropdownMenuItemSubtitle = DropdownMenu.menuify(
 
 const DropdownMenuItemIndicator = DropdownMenu.menuify(
   (
-    props: { tw?: string | string[] } & ComponentProps<typeof DropdownMenu.ItemIndicator>
+    props: { tw?: TW } & ComponentProps<typeof DropdownMenu.ItemIndicator>
   ) => (
     <DropdownMenu.ItemIndicator {...props} style={tailwind.style(props.tw)} />
   ),
@@ -180,7 +181,7 @@ const DropdownMenuItemIndicator = DropdownMenu.menuify(
 );
 
 const DropdownMenuSeparator = DropdownMenu.menuify(
-  (props: { tw?: string | string[] } & ComponentProps<typeof DropdownMenu.Separator>) => (
+  (props: { tw?: TW } & ComponentProps<typeof DropdownMenu.Separator>) => (
     <DropdownMenu.Separator {...props} style={tailwind.style(props.tw)} />
   ),
   "Separator"
@@ -193,7 +194,7 @@ const DropdownMenuTriggerItem = DropdownMenu.menuify(
     onBlur,
     onFocus,
     ...props
-  }: { tw?: string | string[] } & ComponentProps<typeof DropdownMenu.TriggerItem>) => {
+  }: { tw?: TW } & ComponentProps<typeof DropdownMenu.TriggerItem>) => {
     const { isFocused, handleBlur, handleFocus } = useFocusedItem({
       onFocus,
       onBlur,
@@ -215,21 +216,21 @@ const DropdownMenuTriggerItem = DropdownMenu.menuify(
 );
 
 const DropdownMenuItemIcon = DropdownMenu.menuify(
-  (props: { tw?: string | string[] } & ComponentProps<typeof DropdownMenu.ItemIcon>) => (
+  (props: { tw?: TW } & ComponentProps<typeof DropdownMenu.ItemIcon>) => (
     <DropdownMenu.ItemIcon {...props} style={tailwind.style(props.tw)} />
   ),
   "ItemIcon"
 );
 
 const DropdownMenuItemImage = DropdownMenu.menuify(
-  (props: { tw?: string | string[] } & ComponentProps<typeof DropdownMenu.ItemImage>) => (
+  (props: { tw?: TW } & ComponentProps<typeof DropdownMenu.ItemImage>) => (
     <DropdownMenu.ItemImage {...props} style={tailwind.style(props.tw)} />
   ),
   "ItemImage"
 );
 
 const DropdownMenuLabel = DropdownMenu.menuify(
-  (props: { tw?: string | string[] } & ComponentProps<typeof DropdownMenu.Label>) => (
+  (props: { tw?: TW } & ComponentProps<typeof DropdownMenu.Label>) => (
     <DropdownMenu.Label {...props} style={tailwind.style(props.tw)} />
   ),
   "Label"

--- a/packages/design-system/gradient/index.tsx
+++ b/packages/design-system/gradient/index.tsx
@@ -2,8 +2,9 @@ import { ComponentProps } from "react";
 import { Gradient as DripsyGradient } from "@dripsy/gradient";
 
 import { tw as tailwind } from "design-system/tailwind";
+import type { TW } from "design-system/tailwind/types";
 
-type GradientProps = { tw?: string | string[]; borderRadius?: number } & ComponentProps<
+type GradientProps = { tw?: TW; borderRadius?: number } & ComponentProps<
   typeof DripsyGradient
 >;
 

--- a/packages/design-system/image/index.tsx
+++ b/packages/design-system/image/index.tsx
@@ -7,7 +7,7 @@ import {
 import { Blurhash } from "react-native-blurhash";
 
 import { tw as tailwind } from "design-system/tailwind";
-import { View } from "design-system";
+import type { TW } from "design-system/tailwind/types";
 
 function Img({ source, width, height, ...props }: ReactNativeImageProps) {
   return (
@@ -27,7 +27,7 @@ function Img({ source, width, height, ...props }: ReactNativeImageProps) {
 }
 
 type ImageProps = {
-  tw?: string | string[];
+  tw?: TW;
   alt?: string;
   blurhash?: string;
 } & ComponentProps<typeof Img>;

--- a/packages/design-system/image/index.web.tsx
+++ b/packages/design-system/image/index.web.tsx
@@ -9,6 +9,7 @@ import { decode } from "blurhash";
 import { getImgFromArr } from "array-to-image";
 
 import { tw as tailwind } from "design-system/tailwind";
+import type { TW } from "design-system/tailwind/types";
 import { View } from "design-system";
 
 const resizeModeToObjectFit = (resizeMode: ImageResizeMode) => {
@@ -92,7 +93,7 @@ function Img({
   );
 }
 
-type ImageProps = { tw?: string | string[] } & ComponentProps<typeof Img>;
+type ImageProps = { tw?: TW } & ComponentProps<typeof Img>;
 
 function StyledImage({ tw, ...props }: ImageProps) {
   const width = Number(tailwind.style(tw).width);

--- a/packages/design-system/pressable-scale/index.tsx
+++ b/packages/design-system/pressable-scale/index.tsx
@@ -2,10 +2,11 @@ import React, { ComponentProps, useMemo } from "react";
 import { MotiPressable, mergeAnimateProp } from "moti/interactions";
 
 import { tw as tailwind } from "design-system/tailwind";
+import type { TW } from "design-system/tailwind/types";
 
 export type Props = ComponentProps<typeof MotiPressable> & {
   scaleTo?: number;
-  tw?: string | string[];
+  tw?: TW;
 };
 
 export function Pressable({

--- a/packages/design-system/scroll-view/index.tsx
+++ b/packages/design-system/scroll-view/index.tsx
@@ -2,8 +2,9 @@ import { ComponentProps } from "react";
 import { ScrollView as DripsyScrollView } from "dripsy";
 
 import { tw as tailwind } from "design-system/tailwind";
+import type { TW } from "design-system/tailwind/types";
 
-type ScrollViewProps = { tw?: string | string[] } & ComponentProps<
+type ScrollViewProps = { tw?: TW } & ComponentProps<
   typeof DripsyScrollView
 >;
 

--- a/packages/design-system/select/types.ts
+++ b/packages/design-system/select/types.ts
@@ -1,10 +1,12 @@
+import type { TW } from "design-system/tailwind/types";
+
 export interface SelectProps {
   value?: string | number,
   placeholder?: string;
   options?: SelectOption[],
   size?: 'small' | 'regular',
   disabled?: boolean,
-  tw?: string,
+  tw?: TW,
   onChange?: (value: string | number) => void;
 }
 

--- a/packages/design-system/skeleton/index.tsx
+++ b/packages/design-system/skeleton/index.tsx
@@ -3,11 +3,12 @@ import { Skeleton as MotiSkeleton } from "moti/skeleton";
 import { styled } from "dripsy";
 
 import { tw as tailwind } from "design-system/tailwind";
+import type { TW } from "design-system/tailwind/types";
 
 const StyledSkeleton = styled(MotiSkeleton)();
 
 type Props = ComponentProps<typeof StyledSkeleton> & {
-  tw?: string | string[];
+  tw?: TW;
 };
 
 function Skeleton({ tw, sx, ...props }: Props) {

--- a/packages/design-system/tailwind/types.ts
+++ b/packages/design-system/tailwind/types.ts
@@ -1,0 +1,3 @@
+type TW = string | string[];
+
+export { TW };

--- a/packages/design-system/text-input/index.tsx
+++ b/packages/design-system/text-input/index.tsx
@@ -2,8 +2,9 @@ import { ComponentProps } from "react";
 import { TextInput as DripsyTextInput } from "dripsy";
 
 import { tw as tailwind } from "design-system/tailwind";
+import type { TW } from "design-system/tailwind/types";
 
-type TextInputProps = { tw?: string | string[] } & ComponentProps<typeof DripsyTextInput>;
+type TextInputProps = { tw?: TW } & ComponentProps<typeof DripsyTextInput>;
 
 function TextInput({ tw, ...props }: TextInputProps) {
   return <DripsyTextInput sx={tailwind.style(tw)} {...props} />;

--- a/packages/design-system/text/index.tsx
+++ b/packages/design-system/text/index.tsx
@@ -4,13 +4,14 @@ import { ComponentProps, createContext, forwardRef, useContext } from "react";
 import type { Text as TextType } from "react-native";
 
 import { tw as tailwind } from "design-system/tailwind";
+import type { TW } from "design-system/tailwind/types";
 
 type Variant = keyof Theme["text"];
 
 type TextProps = ComponentProps<typeof DripsyText>;
 
 export type Props = {
-  tw?: string | string[];
+  tw?: TW;
   variant?: Variant;
   htmlFor?: string;
 } & Pick<

--- a/packages/design-system/view/index.tsx
+++ b/packages/design-system/view/index.tsx
@@ -2,8 +2,9 @@ import { ComponentProps } from "react";
 import { View as DripsyView } from "dripsy";
 
 import { tw as tailwind } from "design-system/tailwind";
+import type { TW } from "design-system/tailwind/types";
 
-export type ViewProps = { tw?: string | string[] } & ComponentProps<typeof DripsyView>;
+export type ViewProps = { tw?: TW } & ComponentProps<typeof DripsyView>;
 
 function View({ tw, sx, ...props }: ViewProps) {
   return <DripsyView sx={{ ...sx, ...tailwind.style(tw) }} {...props} />;


### PR DESCRIPTION
# Why

[Tailwind React Native Classnames](https://github.com/jaredh159/tailwind-react-native-classnames) is based on the same API as [classnames](https://github.com/JedWatson/classnames#readme) which is a utility for conditionally joining classNames together. So instead of using template literals (backticks) to join styles we can use the array API to join multiple styles. This is better. The first design system implementation wasn't taking this into account so we needed to update the TypeScript type for the `tw` prop.

# How

Update the `tw` prop type to `tw?: string | string[];`

# Test Plan

Check if Storybook is deploying and working correctly