### PR TITLE
Fix the approval refresh bug

### DIFF
--- a/apps/next-react/src/components/UI/Modals/BuyModal.jsx
+++ b/apps/next-react/src/components/UI/Modals/BuyModal.jsx
@@ -782,7 +782,7 @@ const AllowanceRequiredPage = ({
     setTransactionHash(transaction);
     setModalPage(MODAL_PAGES.PROCESSING_ALLOWANCE);
 
-    web3.once(transaction, buyToken);
+    web3.waitForTransaction(transaction).then(buyToken)
   };
 
   return (


### PR DESCRIPTION
# Why

it was broken. now it's fixed.

# How

we were using the wrong method lmao. so I switched it to the right one. it totally didn't take me a few hours to figure this out.

# Test Plan

- Attempt to buy an NFT with a token you haven't issued an approval for yet (alternatively, remove the approval from the contract)
- Marvel yourself as the flow finally works as it's supposed to, instead of getting stuck on the "transaction pending" stage.