### PR TITLE
Fix logic for displaying "no wallet" modal

### DIFF
--- a/apps/next-react/src/components/UI/Modals/MintModal.jsx
+++ b/apps/next-react/src/components/UI/Modals/MintModal.jsx
@@ -46,7 +46,11 @@ const MintModal = ({ open, onClose }) => {
   const { resolvedTheme } = useTheme();
   const isWeb3ModalActive = useRef(false);
   const confettiCanvas = useRef(null);
-  const [modalPage, setModalPage] = useState(myProfile?.wallet_addresses_excluding_email_v2?.length === 0 ? MODAL_PAGES.NO_WALLET : MODAL_PAGES.GENERAL);
+  const [modalPage, setModalPage] = useState(
+    myProfile?.wallet_addresses_excluding_email_v2?.length === 0
+      ? MODAL_PAGES.NO_WALLET
+      : MODAL_PAGES.GENERAL
+  );
 
   useEffect(() => {
     if (myProfile?.wallet_addresses_excluding_email_v2?.length === 0) {
@@ -124,7 +128,11 @@ const MintModal = ({ open, onClose }) => {
     setHasAcceptedTerms(false);
     setTransactionHash("");
     setTokenID("");
-    setModalPage(myProfile?.wallet_addresses_excluding_email_v2?.length === 0 ? MODAL_PAGES.NO_WALLET : MODAL_PAGES.GENERAL);
+    setModalPage(
+      myProfile?.wallet_addresses_excluding_email_v2?.length === 0
+        ? MODAL_PAGES.NO_WALLET
+        : MODAL_PAGES.GENERAL
+    );
   };
 
   const saveDraft = () =>


### PR DESCRIPTION
# Why

Sometimes when I click the Create button just after loading the page it looks like it doesn’t have the auth state so the modal says to connect a wallet and if I click, it shows the wallet page (but with my wallet because I am authenticated). More context here: https://showtime-rq88331.slack.com/archives/C02Q0E4PBD0/p1640942582251000

# How

- Changed the logic to display the "no wallet" modal when `myProfile?.wallet_addresses_excluding_email_v2?.length === 0`

# Test Plan

- Connect with a wallet (like Rainbow) through WalletConnect then click on the Create button in the header: it should display the create NFT modal
- Connect with an email address through Magic then click on the Create button in the header: it should display the "no wallet" modal asking to add a wallet
- Try this multiple times (closing the modal and re-opening) + try to reproduce the previous bug. It should work as expected