### PR TITLE
Adjust gas price by a percentage

### DIFF
--- a/apps/next-react/src/lib/adjust-gas-price.js
+++ b/apps/next-react/src/lib/adjust-gas-price.js
@@ -1,0 +1,19 @@
+import { ethers } from "ethers";
+import { GAS_PRICE_PERCENTAGE } from "@/lib/constants";
+
+/**
+ * Calculate and return the estimated gas price for a transaction
+ * adjusted by the GAS_PRICE_PERCENTAGE constant.
+ *
+ * @param {Function} signer - Interface that supports estimateGas such as signer or provider
+ * @returns {Promise<String>} - The value of estimatedGasPrice + percentage adjustment
+ */
+export const adjustGasPrice = async (signer) => {
+  const multiplyBy = ethers.BigNumber.from(GAS_PRICE_PERCENTAGE);
+  const divideBy = ethers.BigNumber.from("100");
+  const estimatedGasPrice = await signer.estimateGas();
+  const adjustment = estimatedGasPrice.mul(multiplyBy).div(divideBy);
+  const gasPrice = estimatedGasPrice.add(adjustment).toString();
+
+  return gasPrice;
+};

--- a/apps/next-react/src/lib/constants.js
+++ b/apps/next-react/src/lib/constants.js
@@ -257,3 +257,5 @@ export const CURRENCY_NAMES = {
     [LIST_CURRENCIES?.DAI]: "(PoS) Dai Stablecoin",
   },
 }[process.env.NEXT_PUBLIC_CHAIN_ID];
+
+export const GAS_PRICE_PERCENTAGE = "30";


### PR DESCRIPTION
# Why

When the gas price is set by infura we suspect it's conservatively low so it has lead to congestion. This seems to not be the case with our biconomy provider so after feedback from @karmacoma-eth the decision was made to only override the gas price for permits. 

# How

1. Created a constant that represents a percentage
2. Created a utility function to adjust the estimated gas price by the percentage 
3. overrides both permit tx's ([reference method def](https://docs.ethers.io/v5/api/contract/contract/#Contract-functionsCall) 

# Test Plan

Tested locally by creating a new account and going through the buy flow. I disabled the balance check
🚨 **Please more 👀 and testing on the preview branch** (will be doing the same)
