### PR TITLE
Refactor TokenCard Component

### DIFF
--- a/apps/next-react/src/components/TokenCard.js
+++ b/apps/next-react/src/components/TokenCard.js
@@ -50,9 +50,9 @@ const TokenCard = ({
   const [muted, setMuted] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [showModel, setShowModel] = useState(false);
-  const hasMatchingListing = item?.listing?.all_sellers?.find(
-    (seller) => seller.profile_id === pageProfile.profile_id
-  );
+  const hasMatchingListing = item?.listing?.all_sellers?.find((seller) => {
+    return seller.profile_id === pageProfile?.profile_id;
+  });
   const ifListedIsOwner =
     myProfile?.profile_id === item?.listing?.profile_id &&
     typeof myProfile?.profile_id === "number";


### PR DESCRIPTION
# Why

The `https://showtime.io/c/showtime` route is crashing in production because a component used in multiple routes was being passed in an optional prop (prop only used on the profile route). 

On the `c/showtime` route if an NFT item was listed when rendering it would trigger code to run that had an undefined `pageProfile` prop that caused the error.  On `c/showtime` we don't ever need `pageProfile` to be defined so an optional chaining check suffices for now. 

# How

- Added an optional check on `pageProfile` as it's the optional prop that is only passed into the profile route. 

# Test Plan

## On Local
To recreate the issue and test that it worked

- I minted and listed new NFTs
- Went to the `c/showtime` route
- selected to browse `user spotlight ` by new
- Your or any listed component will cause the route to crash
- With this fix the page will load as normal

## Screenshot
### Page loading with a listed item

<img width="881" alt="Screen Shot 2022-01-04 at 10 15 48 PM" src="https://user-images.githubusercontent.com/11730651/148161638-c3117e5c-d122-4460-b81e-64b694c6e43d.png">
 