### PR TITLE
Update to handle long collection names 

### DIFF
--- a/apps/next-react/src/components/TokenCard.js
+++ b/apps/next-react/src/components/TokenCard.js
@@ -20,7 +20,10 @@ import { Menu, Transition } from "@headlessui/react";
 import MiniFollowButton from "./MiniFollowButton";
 import useProfile from "@/hooks/useProfile";
 import OrbitIcon from "./Icons/OrbitIcon";
-import { CHAIN_IDENTIFIERS } from "../lib/constants";
+import {
+  CHAIN_IDENTIFIERS,
+  COLLECTION_NAME_TRUNCATE_LENGTH,
+} from "../lib/constants";
 import ShowtimeIcon from "./Icons/ShowtimeIcon";
 import Tippy from "@tippyjs/react";
 
@@ -862,7 +865,10 @@ const TokenCard = ({
                   />
                 )}
                 <p className="text-xs font-semibold text-gray-600 dark:text-gray-400">
-                  {item.collection_name}
+                  {truncateWithEllipses(
+                    item.collection_name,
+                    COLLECTION_NAME_TRUNCATE_LENGTH
+                  )}
                 </p>
               </div>
               <p className="text-xs font-semibold text-gray-600 dark:text-gray-400">

--- a/apps/next-react/src/lib/constants.js
+++ b/apps/next-react/src/lib/constants.js
@@ -259,3 +259,5 @@ export const CURRENCY_NAMES = {
 }[process.env.NEXT_PUBLIC_CHAIN_ID];
 
 export const GAS_PRICE_PERCENTAGE = "30";
+
+export const COLLECTION_NAME_TRUNCATE_LENGTH = 22;


### PR DESCRIPTION
# Why

Resolve [linear issue 298](https://linear.app/showtime/issue/SHOW2-298/overflow-on-long-collection-names). If an NFT belongs to a collection with a long name it caused a text overflow. 


# How

Follow the truncate pattern used on other long text (ex: addresses, usernames etc...) and use the `truncateWithEllipses` utility to trim it.

# Test Plan

Tested on local on this route `http://localhost:3000/0xe761107af0b22293866c618d5662356eb3bc41f8?list=owned` user was the original reported use case.

## Screenshots
### Issue
<img width="827" alt="Screen Shot 2022-01-06 at 12 26 38 AM" src="https://user-images.githubusercontent.com/11730651/148339217-45dffb9c-c2aa-4dcc-9d9c-54cf4085bf52.png">

### Solution 
<img width="964" alt="Screen Shot 2022-01-06 at 12 25 57 AM" src="https://user-images.githubusercontent.com/11730651/148339220-0d196c6d-909e-48e3-83eb-06bcb91a4a75.png">

