### PR TITLE
fix: added access token for web

### DIFF
--- a/packages/app/lib/access-token.web.ts
+++ b/packages/app/lib/access-token.web.ts
@@ -1,11 +1,19 @@
+const ACCESS_TOKEN_STRING = "access-token";
+
 export function setAccessToken(token: string) {
-  // localStorage.setItem('access-token', token)
+  localStorage.setItem(ACCESS_TOKEN_STRING, token);
 }
 
 export function getAccessToken() {
-  // return localStorage.getItem('access-token')
+  return localStorage.getItem(ACCESS_TOKEN_STRING);
 }
 
 export function deleteAccessToken() {
-  // localStorage.removeItem('access-token')
+  localStorage.removeItem(ACCESS_TOKEN_STRING);
+}
+
+export function useAccessToken() {
+  // TODO: implement a storage listener
+
+  return getAccessToken();
 }


### PR DESCRIPTION
# Why

the last commit https://github.com/tryshowtime/showtime-frontend/commit/f45c472232e00e65eb5606d0901e06ab9b325868 broke the `next-react-native` package, and that is because `useAccessToken` was introduce in `access-token` file but not the `access-token.web`.

# How

- uncomment previous implementation for `access-token.web`.
- added `useAccessToken` for web

# Test Plan

tested by running `next-react-native`  
