### PR TITLE
disable save changes button when username is not available

### DIFF
--- a/apps/next-react/src/components/ModalEditProfile.js
+++ b/apps/next-react/src/components/ModalEditProfile.js
@@ -542,7 +542,11 @@ export default function Modal({ isOpen, setEditModalOpen }) {
             {/* Submit section */}
             <div>
               <div className="border-t-2 dark:border-gray-800 pt-4">
-                <GreenButton type="submit" loading={submitting}>
+                <GreenButton
+                  type="submit"
+                  loading={submitting}
+                  disabled={customURLError?.isError}
+                >
                   Save changes
                 </GreenButton>
                 <GhostButton


### PR DESCRIPTION
# Why

Context here: https://showtime-rq88331.slack.com/archives/C02Q0EKN2TC/p1641802226006400

We're not disabling the "Save Changes" button of the edit profile feature when the username is known to be unavailable. 
The button is clickable, and makes the UI "load" forever.

# How

Disable button if username isn't available.

# Test Plan

Manually via vercel temporary deployment