### PR TITLE
Resolve an issue with next.js caching user profiles to a 404

### DIFF
--- a/apps/next-react/src/pages/[profile].js
+++ b/apps/next-react/src/pages/[profile].js
@@ -69,7 +69,9 @@ export async function getStaticProps({ params: { profile: slug_address } }) {
   } catch (err) {
     if (err.response.status == 400) {
       return { redirect: { destination: "/", permanent: false } };
-    } else return { notFound: true, revalidate: 1 };
+    } else {
+      return { notFound: true, revalidate: 1 };
+    }
   }
 }
 


### PR DESCRIPTION
# Why

On every deployment a random subset of users is negatively effected with 404s on their profile. The "randomness" stems from a call `v4/profile_server/${encodeURIComponent(slug_address)}` made in the `[profile].js` during the first time a user hits the route (see [getStaticPaths](https://nextjs.org/docs/api-reference/data-fetching/get-static-paths)). If the call fails and the response is not a 400 then we return `{ notFound: true }` causing the page to be cached and preventing future fetches to occur (see [fallback-blocking](https://nextjs.org/docs/api-reference/data-fetching/get-static-paths#fallback-blocking)).

Removing `{ notFound: true }` completely felt incorrect without first refactoring the entire page. After doing some research I realized that we can revalidate the route and is an approach recommended to other users facing a similar issue (see [this git issue](https://github.com/vercel/next.js/issues/21453))

# How

- Add `revalidate: 1` to the returned notFound block
- 
# Test Plan
Added video, look at the bottom left as the page loads/is hit a second time

### The bug


https://user-images.githubusercontent.com/11730651/149218430-957a9c68-0c98-433d-ae5a-1889a62a56e2.mp4


### With solution


https://user-images.githubusercontent.com/11730651/149218533-748f318d-1397-4c5d-a02f-a0cbc136017f.mp4
