### PR TITLE
refactor: updated tabs item header width to be dynamic

### DIFF
--- a/packages/design-system/tabs/tablib/components.tsx
+++ b/packages/design-system/tabs/tablib/components.tsx
@@ -1,15 +1,15 @@
-import { View } from "../../view";
-import { Text } from "../../text";
-import React from "react";
+import { Platform, useColorScheme } from "react-native";
 import Animated, {
   useAnimatedStyle,
   Extrapolate,
   interpolate,
   useDerivedValue,
 } from "react-native-reanimated";
-import { useTabIndexContext, useTabsContext } from "../tablib";
-import { Platform, useColorScheme } from "react-native";
+import React from "react";
 import { tw } from "design-system/tailwind";
+import { View } from "../../view";
+import { Text } from "../../text";
+import { useTabIndexContext, useTabsContext } from "../tablib";
 
 type TabItemProps = {
   name: string;
@@ -75,7 +75,6 @@ export const SelectedTabIndicator = () => {
   const isDark = useColorScheme() === "dark";
 
   const { offset, position, tabItemLayouts } = useTabsContext();
-  // const [itemOffsets, setItemOffsets] = React.useState([0, 0]);
 
   const itemOffsets = useDerivedValue(() => {
     let result = [];


### PR DESCRIPTION
# Why

The current implementation is static , and it won't fit "Sign in with SMS" for login screen.

# How

- converted `itemOffsets` from being a state value to a reanimated derived value
- added `width` to container animated style.

https://user-images.githubusercontent.com/4061838/149219525-b28c767e-86fb-46b0-815d-02916251dcb2.mov


# Test Plan

- Tested locally 
