### PR TITLE
Resolve issue where user can't delete their own listing if they are not the cheapest

### DIFF
--- a/apps/next-react/src/components/TokenCard.js
+++ b/apps/next-react/src/components/TokenCard.js
@@ -24,6 +24,7 @@ import {
   CHAIN_IDENTIFIERS,
   COLLECTION_NAME_TRUNCATE_LENGTH,
 } from "../lib/constants";
+import { findListingItemByOwner } from "@/lib/utilities";
 
 const TokenCard = ({
   originalItem,
@@ -52,10 +53,10 @@ const TokenCard = ({
   const [refreshing, setRefreshing] = useState(false);
   const [showModel, setShowModel] = useState(false);
 
-  const hasMatchingListing = item?.listing?.all_sellers?.find((seller) => {
-    return seller.profile_id === pageProfile?.profile_id;
-  });
-
+  const hasMatchingListing = findListingItemByOwner(
+    item,
+    pageProfile?.profile_id
+  );
   const freeListedItem = item?.listing?.min_price === 0;
   const singleItem = item?.token_count === 1;
 

--- a/apps/next-react/src/components/UI/Modals/UnlistModal.jsx
+++ b/apps/next-react/src/components/UI/Modals/UnlistModal.jsx
@@ -13,7 +13,11 @@ import useProfile from "@/hooks/useProfile";
 import { ExclamationIcon } from "@heroicons/react/outline";
 import XIcon from "@/components/Icons/XIcon";
 import { DEFAULT_PROFILE_PIC } from "@/lib/constants";
-import { formatAddressShort, truncateWithEllipses } from "@/lib/utilities";
+import {
+  formatAddressShort,
+  truncateWithEllipses,
+  findListingItemByOwner,
+} from "@/lib/utilities";
 import BadgeIcon from "@/components/Icons/BadgeIcon";
 import useFlags, { FLAGS } from "@/hooks/useFlags";
 
@@ -76,6 +80,7 @@ const UnlistModal = ({ open, onClose, onSuccess = () => null, token }) => {
 
   const unlistToken = async () => {
     setModalPage(MODAL_PAGES.LOADING);
+    const ownerItem = findListingItemByOwner(token, myProfile.profile_id);
 
     const web3Modal = getWeb3Modal({
       theme: resolvedTheme,
@@ -110,7 +115,7 @@ const UnlistModal = ({ open, onClose, onSuccess = () => null, token }) => {
     const provider = biconomy.getEthersProvider();
 
     const { data } = await contract.populateTransaction.cancelSale(
-      token.listing.sale_identifier
+      ownerItem.sale_identifier
     );
 
     const transaction = await provider
@@ -225,9 +230,7 @@ const UnlistModal = ({ open, onClose, onSuccess = () => null, token }) => {
 };
 
 const UnlistPage = ({ token, unlistToken, onClose, profile_id }) => {
-  const currentListing = token?.listing?.all_sellers?.find(
-    (seller) => seller.profile_id === profile_id
-  );
+  const currentListing = findListingItemByOwner(token, profile_id);
   const hasMultipleEditions = token?.listing?.total_edition_quantity > 1;
 
   return (

--- a/apps/next-react/src/lib/utilities.js
+++ b/apps/next-react/src/lib/utilities.js
@@ -375,3 +375,11 @@ export const parseBalance = (balance, currency) => {
 
   return parseUnits(balance, 6);
 };
+
+export const findListingItemByOwner = (item, profileID) => {
+  const listedItem = item?.listing?.all_sellers?.find((seller) => {
+    return seller.profile_id === profileID;
+  });
+
+  return listedItem;
+};


### PR DESCRIPTION
# Why

Resolves issue [326](https://linear.app/showtime/issue/SHOW2-326/cant-delete-your-own-listing-if-youre-not-the-cheapest) where a user can't delete their own listing if they are not the cheapest

Issue is caused by submitting the wrong `sale_identifier`. This will refactor the code to find the current sellers listing and submit the correct `sale_identifier`  

# How

1. The `find my listing` logic was used in two other places, making it a good candidate to be added as a util. Created one called `findListingItemByOwner`
2. Refactored all the call sites
3. In `apps/next-react/src/components/UI/Modals/UnlistModal.jsx` updated the unlist tx to use the owners item

# Test Plan

1. Created account A
2. Created account B and minted a NFT with 100 editions 
3. Account B list the NFT at price 50 tkn
2. Account B sends some editions to A
3. Account A list the NFT at 100 tkn and then delist the NFT
4. Account A list the NFT at 5 tkn and then delist the NFT
