### PR TITLE
Rename "burn" action to "delete" throughout the app

### DIFF
--- a/apps/next-react/src/components/Modals/BurnModal.js
+++ b/apps/next-react/src/components/Modals/BurnModal.js
@@ -111,7 +111,7 @@ const BurnModal = ({ open, onClose, token }) => {
             error?.body || error?.error?.body || "{}"
           )?.error?.message?.includes("burn amount exceeds balance")
         ) {
-          alert("Burn failed: You're trying to burn more tokens than you own.");
+          alert("Delete failed: You're trying to delete more tokens than you own.");
           throw setModalState(MODAL_STATES.GENERAL);
         }
 
@@ -195,7 +195,7 @@ const BurnModal = ({ open, onClose, token }) => {
             <div className="inline-block align-bottom rounded-t-3xl sm:rounded-b-3xl text-left overflow-hidden transform transition-all sm:align-middle bg-white dark:bg-black shadow-xl sm:max-w-lg w-full">
               <div className="p-4 border-b border-gray-100 dark:border-gray-900 flex items-center justify-between">
                 <h2 className="text-gray-900 dark:text-white text-xl font-bold">
-                  Burn NFT
+                  Delete NFT
                 </h2>
                 {modalState !== MODAL_STATES.PROCESSING && (
                   <button
@@ -224,9 +224,9 @@ const GeneralState = ({
 }) => (
   <>
     <div className="p-4 space-y-4 border-b border-gray-100 dark:border-gray-900 text-gray-900 dark:text-white">
-      <p className="font-medium">Are you sure you want to burn this NFT?</p>
+      <p className="font-medium">Are you sure you want to delete this NFT?</p>
       <p className="font-medium">
-        This can’t be undone and it will be sent to a burn address.
+        The NFT will be transferred to a burn address. This can’t be undone.
       </p>
     </div>
     <div className="p-4 border-b border-gray-100 dark:border-gray-900">
@@ -262,7 +262,7 @@ const GeneralState = ({
           Cancel
         </Button>
         <Button style="danger" onClick={burnToken}>
-          Burn
+          Delete
         </Button>
       </div>
     </div>
@@ -278,7 +278,7 @@ const LoadingState = () => {
       <div className="inline-block border-2 w-6 h-6 rounded-full border-gray-100 dark:border-gray-700 border-t-indigo-500 dark:border-t-cyan-400 animate-spin" />
       <div className="space-y-1">
         <p className="font-medium text-gray-900 dark:text-white text-center">
-          Preparing to burn this NFT...
+          Preparing to delete this NFT...
         </p>
         <p className="font-medium text-gray-900 dark:text-white text-center max-w-xs">
           We'll ask you to confirm with the wallet holding it shortly.
@@ -294,7 +294,7 @@ const BurningState = ({ transactionHash }) => {
       <div className="inline-block border-2 w-6 h-6 rounded-full border-gray-100 dark:border-gray-700 border-t-indigo-500 dark:border-t-cyan-400 animate-spin" />
       <div className="space-y-1">
         <p className="font-medium text-gray-900 dark:text-white text-center">
-          Your NFT is being burned on the Polygon network.
+          Your NFT is being deleted on the Polygon network.
         </p>
         <p className="font-medium text-gray-900 dark:text-white text-center max-w-xs mx-auto">
           Feel free to navigate away from this screen
@@ -321,7 +321,7 @@ const BurnedState = ({ transactionHash, quantity }) => {
     <div className="p-12 space-y-8 flex-1 flex flex-col items-center justify-center">
       <p className="font-medium text-5xl">🔥</p>
       <p className="font-medium text-gray-900 dark:text-white text-center">
-        Your NFT has been forever burned on the Polygon network.{" "}
+        Your NFT has been forever deleted on the Polygon network.{" "}
         {quantity == 1
           ? "It might still show up on your profile for a few minutes"
           : "The editions might still appear on your profile for a few minutes"}

--- a/apps/next-react/src/components/Modals/TransferModal.js
+++ b/apps/next-react/src/components/Modals/TransferModal.js
@@ -119,7 +119,7 @@ const TransferModal = ({ open, onClose, token }) => {
           )?.error?.message?.includes("transfer amount exceeds balance")
         ) {
           alert(
-            "Burn failed: You're trying to transfer more tokens than you own."
+            "Transfer failed: You're trying to transfer more tokens than you own."
           );
           throw setModalState(MODAL_STATES.GENERAL);
         }

--- a/apps/next-react/src/components/TokenCard.js
+++ b/apps/next-react/src/components/TokenCard.js
@@ -370,7 +370,7 @@ const TokenCard = ({
                                 )}
                               >
                                 <span className="block truncate font-medium text-red-500 dark:text-red-700">
-                                  Burn
+                                  Delete
                                 </span>
                               </button>
                             )}

--- a/apps/next-react/src/components/TokenHistoryCard.js
+++ b/apps/next-react/src/components/TokenHistoryCard.js
@@ -141,7 +141,7 @@ export default function TokenHistoryCard({ nftId, closeModal }) {
                         </a>
                       </Link>
                     ) : (
-                      <div className="text-gray-400">Burned</div>
+                      <div className="text-gray-400">Deleted</div>
                     )}
                   </td>
                   {nftHistory.multiple && (


### PR DESCRIPTION
# Why

As [discussed on Slack](https://showtime-rq88331.slack.com/archives/C02Q0EY6RMH/p1642011228153600?thread_ts=1641540126.035400&cid=C02Q0EY6RMH), if we're going with more normie-friendly language (create instead of mint), it makes sense to also carry this logic throughout the rest of the app. 

# How

Updated all the copy to mention deleting tokens instead of burning them. "Burning" is still used internally on function names and other invisible details.

# Test Plan

- Make sure the copy shows up as expected.
