### PR TITLE
Show an error when username is too short

### DIFF
--- a/apps/next-react/src/components/ModalEditProfile.js
+++ b/apps/next-react/src/components/ModalEditProfile.js
@@ -25,6 +25,11 @@ const handleUsernameLookup = async (value, myProfile, setCustomURLError) => {
   const username = value ? value.trim() : null;
   let validUsername = false;
 
+  if (username.length < 3) {
+    setCustomURLError({ isError: true, message: "Username must be longer than 2 characters" })
+    return false;
+  }
+
   try {
     if (
       username === null ||


### PR DESCRIPTION
# Why

We don't allow usernames shorter than 2 characters, so we should show an error instead of silently failing.

# How

Added an error when the lenght is > 2 chars

# Test Plan

- Tested the error shows up