### PR TITLE
Use the Modal component for the Create screen

### DIFF
--- a/packages/app/components/create.tsx
+++ b/packages/app/components/create.tsx
@@ -1,12 +1,4 @@
-import {
-  View,
-  Text,
-  Fieldset,
-  ScrollView,
-  Select,
-  Checkbox,
-} from "design-system";
-import { useIsDarkMode } from "design-system/hooks";
+import { View, Text, Fieldset, Select, Checkbox } from "design-system";
 import { Close } from "design-system/icon";
 import { Image } from "design-system/image";
 import { tw } from "design-system/tailwind";
@@ -48,20 +40,10 @@ function CloseButton({
 }
 
 function Create() {
-  const isDark = useIsDarkMode();
-
   const [checked, setChecked] = useState(false);
 
   return (
-    <ScrollView tw="p-4">
-      <View tw="flex-row items-center">
-        <CloseButton variant={isDark ? "dark" : "light"} onPress={() => {}} />
-        <View tw="absolute w-full items-center">
-          <Text tw="text-xl text-gray-900 dark:text-white font-bold">
-            Create NFT
-          </Text>
-        </View>
-      </View>
+    <View tw="p-4">
       <View tw="mt-11 flex-row">
         <Image
           source={{
@@ -121,7 +103,7 @@ function Create() {
           </Text>
         </Pressable>
       </View>
-    </ScrollView>
+    </View>
   );
 }
 

--- a/packages/app/navigation/use-navigation-elements.tsx
+++ b/packages/app/navigation/use-navigation-elements.tsx
@@ -34,3 +34,17 @@ export function useHideNavigationElements() {
     }
   }, []);
 }
+
+export function useHideHeader() {
+  const { setIsHeaderHidden } = useNavigationElements();
+
+  useEffect(() => {
+    if (Platform.OS !== "ios") {
+      setIsHeaderHidden(true);
+
+      return () => {
+        setIsHeaderHidden(false);
+      };
+    }
+  }, []);
+}

--- a/packages/app/screens/create.tsx
+++ b/packages/app/screens/create.tsx
@@ -2,13 +2,23 @@ import { useEffect } from "react";
 
 import { mixpanel } from "app/lib/mixpanel";
 import { Create } from "app/components/create";
+import { useRouter } from "app/navigation/use-router";
+import { useHideHeader } from "app/navigation/use-navigation-elements";
+import { Modal } from "design-system";
 
 const CreateScreen = () => {
+  useHideHeader();
+  const router = useRouter();
+
   useEffect(() => {
     mixpanel.track("Create page view");
   }, []);
 
-  return <Create />;
+  return (
+    <Modal title="Create" close={router.pop} height="h-[90vh]">
+      <Create />
+    </Modal>
+  );
 };
 
 export { CreateScreen };


### PR DESCRIPTION
# Why

We want to use a Modal for the Create screen

# How

Used our Modal component 

# Known bugs

- The bottom sheet component renders behind the modal (on iOS and Android): https://linear.app/showtime/issue/SHOW2-355/bottomsheet-renders-behind-the-modal
- Maybe we could use the numeric keyboard for the inputs?

# Test Plan

Run the native app, take a picture (click on the right button with check) and check the modal