### PR TITLE
remove 'oldest' sort option from explore page

### DIFF
--- a/apps/next-react/src/pages/c/[collection].js
+++ b/apps/next-react/src/pages/c/[collection].js
@@ -182,16 +182,6 @@ export default function Collection({
           mixpanel.track("Recently sold button clicked");
         }}
       />
-      {!isMobile && (
-        <GridTab
-          label="Oldest"
-          isActive={sortBy === "oldest"}
-          onClickTab={() => {
-            setSortby("oldest");
-            mixpanel.track("Oldest button clicked");
-          }}
-        />
-      )}
     </GridTabs>
   );
 


### PR DESCRIPTION
# Why

it's not a very useful sort option.
removing useless features is something I enjoy

backend PR: https://github.com/tryshowtime/stbackend/pull/164

# How

remove it

# Test Plan

no