### PR TITLE
Remove remaining stale "news" copy

### DIFF
--- a/apps/next-react/src/pages/index.js
+++ b/apps/next-react/src/pages/index.js
@@ -245,9 +245,14 @@ const Activity = () => {
         </Head>
 
         {context.user === null ? (
-          <div className="py-12 sm:pt-48 sm:py-14 px-8 sm:px-10 text-left bg-cover bg-center" style={{ backgroundImage: 'url(/img/gradient.png)' }}>
+          <div
+            className="py-12 sm:pt-48 sm:py-14 px-8 sm:px-10 text-left bg-cover bg-center"
+            style={{ backgroundImage: "url(/img/gradient.png)" }}
+          >
             <CappedWidth>
-              <p className="font-tomato font-semibold text-5xl text-black">discover, create, collect</p>
+              <p className="font-tomato font-semibold text-5xl text-black">
+                discover, create, collect
+              </p>
             </CappedWidth>
           </div>
         ) : null}
@@ -347,7 +352,7 @@ const Activity = () => {
                 {context.user === undefined ? null : context.user === null ? (
                   <div className="flex flex-1 items-center justify-center mb-6 sm:px-3">
                     <div className="text-gray-400 shadow-md bg-white dark:bg-gray-800 sm:rounded-lg w-full px-4 py-6 text-center">
-                      <span>News Feed preview.</span>{" "}
+                      <span>Feed preview.</span>{" "}
                       <span
                         className="cursor-pointer text-gray-800 dark:text-gray-200 hover:text-stpink dark:hover:text-stpink"
                         onClick={() => context.setLoginModalOpen(true)}


### PR DESCRIPTION
# Why

During taking a pass at [QA](https://www.notion.so/showtimeinc/Web-App-UI-Updates-b6b755f876d34458be669bbd6c206d48) testing I uncovered a reference to `news`. It's a small fix so opening up a PR felt like the fastest path towards a resolution.


# How

Copy updated

# Test Plan

### Before
<img width="930" alt="Screen Shot 2022-01-18 at 3 25 39 PM" src="https://user-images.githubusercontent.com/11730651/150022338-2091179c-53f9-4009-8abd-6a84be04fa2c.png">


### Change
<img width="895" alt="Screen Shot 2022-01-18 at 3 38 34 PM" src="https://user-images.githubusercontent.com/11730651/150022811-d8416dbf-c838-4add-a6cc-ca6a4d2aaead.png">

