### PR TITLE
small fix - use sortId from tabs response in profile screen

### DIFF
--- a/packages/app/components/profile.tsx
+++ b/packages/app/components/profile.tsx
@@ -98,14 +98,17 @@ const TabList = ({ profileId, list }: { profileId?: number; list: List }) => {
     return item.nft_id;
   }, []);
 
-  const [filter, dispatch] = useReducer((state: any, action: any) => {
-    switch (action.type) {
-      case "collection_change":
-        return { ...state, collectionId: action.payload };
-      case "sort_change":
-        return { ...state, sortId: action.payload };
-    }
-  }, defaultFilters);
+  const [filter, dispatch] = useReducer(
+    (state: any, action: any) => {
+      switch (action.type) {
+        case "collection_change":
+          return { ...state, collectionId: action.payload };
+        case "sort_change":
+          return { ...state, sortId: action.payload };
+      }
+    },
+    { ...defaultFilters, sortId: list.sort_id }
+  );
 
   const { isLoading, data, fetchMore, isRefreshing, refresh, isLoadingMore } =
     useProfileNFTs({


### PR DESCRIPTION
# Why

Small issue - adds a sort id from API instead of defaulting to 0 always
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- Use initial sort_id from tabs response
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Test profile tabs
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
