### PR TITLE
Implement share NFT button (mobile)

### DIFF
--- a/packages/app/components/nft-dropdown.tsx
+++ b/packages/app/components/nft-dropdown.tsx
@@ -14,7 +14,7 @@ import type { NFT } from "app/types";
 import { useCurrentUserId } from "app/hooks/use-current-user-id";
 import { useReport } from "app/hooks/use-report";
 import { useRouter } from "app/navigation/use-router";
-import { CHAIN_IDENTIFIERS } from "../lib/constants";
+import { CHAIN_IDENTIFIERS } from "app/lib/constants";
 
 type Props = {
   nft: NFT;
@@ -29,7 +29,7 @@ function NFTDropdown({ nft }: Props) {
   const { report } = useReport();
   const router = useRouter();
 
-  const token_chain_name = Object.keys(CHAIN_IDENTIFIERS).find(
+  const tokenChainName = Object.keys(CHAIN_IDENTIFIERS).find(
     (key) => CHAIN_IDENTIFIERS[key] == nft.chain_identifier
   );
 
@@ -52,7 +52,7 @@ function NFTDropdown({ nft }: Props) {
         <DropdownMenuItem
           onSelect={() =>
             Share.share({
-              url: `https://showtime.io/t/${token_chain_name}/${nft.contract_address}/${nft.token_id}`,
+              url: `https://showtime.io/t/${tokenChainName}/${nft.contract_address}/${nft.token_id}`,
             })
           }
           key="copy-link"


### PR DESCRIPTION
# Why

Instead of just copying the link as we do on web, we can use the native share sheet.

# How

Used the react native builtin module for this, not sure if there's a more performant package.

# Test Plan

- Tried it on my iPhone used the expo development build
- Installing the android simulator now to test on Android as well

Couldn't find an issue for it, so assuming I'm not taking over anyone's work, feel free to close if someone's already working on this.
