### PR TITLE
Ensure we don't pick a Tezos address when minting

### DIFF
--- a/packages/app/hooks/use-mint-nft.ts
+++ b/packages/app/hooks/use-mint-nft.ts
@@ -129,10 +129,14 @@ export const useMintNFT = () => {
   useEffect(() => {
     if (
       user?.data &&
-      user?.data.profile.wallet_addresses_excluding_email_v2[0]
+      user?.data.profile.wallet_addresses_excluding_email_v2.filter((addr) =>
+        addr.address.startsWith("0x")
+      )[0]
     ) {
       setUserAddress(
-        user.data.profile.wallet_addresses_excluding_email_v2[0].address
+        user.data.profile.wallet_addresses_excluding_email_v2.filter((addr) =>
+          addr.address.startsWith("0x")
+        )[0].address
       );
     }
     // Web3 is initialised for magic users


### PR DESCRIPTION
# Why

If your account includes Tezos wallets, there's a chance one of those will be selected as your address when minting, causing an error related to Ethers not being able to resolve the name.

# How

When picking the first item from the wallets array, we limit ourselves to only Ethereum wallets.

# Test Plan

- Tested locally with expo
