### PR TITLE
Add deploy command

### DIFF
--- a/apps/expo/eas.json
+++ b/apps/expo/eas.json
@@ -48,7 +48,8 @@
   "submit": {
     "production": {
       "android": {
-        "serviceAccountKeyPath": "./service-account-key.json"
+        "serviceAccountKeyPath": "./service-account-key.json",
+        "track": "beta"
       },
       "ios": {
         "appName": "Showtime: NFT Social Network",

--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -14,7 +14,6 @@
     "update:development": "STAGE=development eas update --branch default",
     "update:staging": "STAGE=staging eas update --branch staging",
     "update:production": "STAGE=production eas update --branch production",
-    "build": "yarn build:production",
     "build:development": "STAGE=development eas build --profile development --platform all",
     "build:development:ios": "STAGE=development eas build --profile development --platform ios",
     "build:development:android": "STAGE=development eas build --profile development --platform android",
@@ -26,6 +25,7 @@
     "build:production:android": "STAGE=production eas build --profile production --platform android",
     "submit:ios": "STAGE=production eas submit --platform ios",
     "submit:android": "STAGE=production eas submit --platform android",
+    "deploy:production": "echo 'Do not do this unless you know what you are doing!' && yarn update:production --message 'Deploy to production' && yarn build:production --auto-submit",
     "adb:reverse": "adb reverse tcp:3000 tcp:3000",
     "eas-build-post-install": "react-native link"
   },


### PR DESCRIPTION
# Why

We need a simple way to trigger new builds on EAS and automatically submit them to the stores

# How

Added the `deploy:production` command

# Test Plan

Run `yarn deploy:production`