### PR TITLE
fixes full window overlay crash

### DIFF
--- a/patches/react-native-screens+3.10.1.patch
+++ b/patches/react-native-screens+3.10.1.patch
@@ -1,0 +1,17 @@
+diff --git a/node_modules/react-native-screens/ios/RNSFullWindowOverlay.m b/node_modules/react-native-screens/ios/RNSFullWindowOverlay.m
+index b8c13e2..ff59642 100644
+--- a/node_modules/react-native-screens/ios/RNSFullWindowOverlay.m
++++ b/node_modules/react-native-screens/ios/RNSFullWindowOverlay.m
+@@ -76,7 +76,11 @@ - (void)didMoveToWindow
+ {
+   if (self.window == nil) {
+     [self hide];
+-    [_touchHandler detachFromView:_container];
++      
++    if (_container != nil){
++        [_touchHandler detachFromView:_container];
++    }
++   
+   } else {
+     if (_touchHandler == nil) {
+       _touchHandler = [[RCTTouchHandler alloc] initWithBridge:_bridge];


### PR DESCRIPTION
# Why

- I have seen a crash when we go back to our app from wallet app. It's not reproducible every time, will make a PR in RN screens once i find the exact cause.

```
2022-01-28 06:14:29.171005+0530 Showtime[19007:1955985] [javascript] 'status ', 'requestingNonce'

2022-01-28 06:14:29.212563+0530 Showtime[19007:1952689] *** Assertion failure in -[RCTTouchHandler detachFromView:](), /Users/nishanbende/Desktop/nishan/work/showtime-frontend/node_modules/react-native/React/Base/RCTTouchHandler.m:80

2022-01-28 06:14:29.216897+0530 Showtime[19007:1952689] DevLauncher tries to handle uncaught exception: 'view' is a required parameter

2022-01-28 06:14:29.245954+0530 Showtime[19007:1952689] Stack Trace: (

    "0   CoreFoundation                      0x0000000180bb5060 B2D21CFD-378C-36D5-BAF7-3F70599CFEFC + 626784",

    "1   libobjc.A.dylib                     0x0000000199229f54 objc_exception_throw + 60",

    "2   Foundation                          0x000000018246e834 D59C6975-5AF2-37BC-93BE-43B80B4293A5 + 1247284",

    "3   Showtime                            0x000000010497f4c8 -[RCTTouchHandler detachFromView:] + 228",

    "4   Showtime                            0x0000000104781a64 -[RNSFullWindowOverlay didMoveToWindow] + 120",

    "5   UIKitCore                           0x000000018327bd04 8388EB03-002B-3B35-A78A-6A022894292E + 2858244",

    "6   UIKitCore                           0x00000001831a1de4 8388EB03-002B-3B35-A78A-6A022894292E + 1965540",

    "7   CoreAutoLayout                      0x000000019951f5f8 34226C3D-B469-32D6-A7B6-82E027859D41 + 34296",

    "8   UIKitCore                           0x0000000183230ff4 8388EB03-002B-3B35-A78A-6A022894292E + 2551796",

    "9   UIKitCore    

2022-01-28 06:14:29.246708+0530 Showtime[19007:1952689] *** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: ''view' is a required parameter'

*** First throw call stack:

(0x180bb504c 0x199229f54 0x18246e834 0x10497f4c8 0x104781a64 0x18327bd04 0x1831a1de4 0x19951f5f8 0x183230ff4 0x183161ddc 0x183173cf8 0x1049bc3ac 0x1046f2688 0x1046d36d0 0x1046d3a10 0x1046d3200 0x1080206d4 0x1080223b4 0x108032898 0x180b6dcd4 0x180b27eac 0x180b3b3b8 0x19c4cb38c 0x1834db6a8 0x18325a7f4 0x104407f70 0x107f95a24)

libc++abi: terminating with uncaught exception of type NSException

dyld4 config: DYLD_LIBRARY_PATH=/usr/lib/system/introspection DYLD_INSERT_LIBRARIES=/Developer/usr/lib/libBacktraceRecording.dylib:/Developer/usr/lib/libMainThreadChecker.dylib:/Developer/Library/PrivateFrameworks/DTDDISupport.framework/libViewDebuggerSupport.dylib:/Developer/Library/PrivateFrameworks/GPUTools.framework/libglInterpose.dylib

*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: ''view' is a required parameter'

terminating with uncaught exception of type NSException

(lldb) 
```
<img width="1478" alt="Screenshot 2022-01-28 at 6 42 21 AM" src="https://user-images.githubusercontent.com/23293248/151469572-993c1d98-4811-4393-8f86-f67a5f95be3a.png">

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

- Adds a null check by going through the logs. 
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Needs a new dev client. Test login with wallets
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
