### PR TITLE
fix: wonky creator list

### DIFF
--- a/packages/app/components/trending.tsx
+++ b/packages/app/components/trending.tsx
@@ -187,7 +187,7 @@ const CreatorsList = ({
         removeClippedSubviews={Platform.OS !== "web"}
         ListHeaderComponent={ListHeaderComponent}
         numColumns={1}
-        windowSize={2}
+        windowSize={4}
         initialNumToRender={4}
         alwaysBounceVertical={false}
         ListFooterComponent={ListFooterComponent}


### PR DESCRIPTION
# Why

Fixes wonky creator list 

https://user-images.githubusercontent.com/23293248/151471452-fed0afe9-1736-446b-89d8-7c853b953379.MP4


<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

- the calculation in getItemLayout was incorrect 🤦 missed adding a paranthesis
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- change NEXT_PUBLIC_BACKEND_URL to production url
- Go to 24 hours tab and scroll creator list in trending tab
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
