### PR TITLE
fix: center profile image

### DIFF
--- a/packages/app/components/profile.tsx
+++ b/packages/app/components/profile.tsx
@@ -231,7 +231,7 @@ const ProfileTop = ({ address }: { address?: string }) => {
       <View tw="bg-white dark:bg-black px-2">
         <View tw="flex-row justify-between pr-2">
           <View tw="flex-row items-end">
-            <View tw="bg-gray-100 dark:bg-gray-900 h-[144px] w-[144px] rounded-full mt-[-72px]">
+            <View tw="bg-white dark:bg-gray-900 rounded-full mt-[-72px] p-2">
               <Skeleton
                 height={144}
                 width={144}
@@ -245,7 +245,7 @@ const ProfileTop = ({ address }: { address?: string }) => {
                       uri: getProfileImage(profileData?.data.profile),
                     }}
                     alt="Profile avatar"
-                    tw="border-white h-[144px] w-[144px] dark:border-gray-900 rounded-full border-8"
+                    tw="border-white h-[144px] w-[144px] rounded-full"
                   />
                 </Animated.View>
               </Skeleton>


### PR DESCRIPTION
# Why
- Centers profile image in profile screen

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- Weird bug in RN's image. If we add a border width, it adds some top/left offset to image. Will debug in isolation. For the time being, we can use container's padding as borders!

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Test if user profile pictures are centered in profile screen
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
