### PR TITLE
Scroll to top when switching to a new profile

### DIFF
--- a/packages/design-system/tabs/tablib/index.tsx
+++ b/packages/design-system/tabs/tablib/index.tsx
@@ -7,7 +7,6 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { tw } from "../../tailwind";
 import {
   Pressable,
   View,
@@ -23,7 +22,7 @@ import {
   LayoutRectangle,
 } from "react-native";
 import PagerView from "react-native-pager-view";
-import { useIsFocused } from "@react-navigation/native";
+import { useIsFocused, useScrollToTop } from "@react-navigation/native";
 import Reanimated, {
   useSharedValue,
   useDerivedValue,
@@ -37,8 +36,9 @@ import Reanimated, {
   useAnimatedStyle,
   useAnimatedReaction,
 } from "react-native-reanimated";
+
+import { tw } from "design-system/tailwind";
 import { TabListProps, TabRootProps, TabsContextType } from "./types";
-import { useScrollToTop } from "@react-navigation/native";
 import { usePageScrollHandler } from "./usePagerScrollHandler";
 import { ViewabilityTrackerFlatlist } from "app/components/viewability-tracker-flatlist";
 
@@ -215,6 +215,14 @@ const ListImpl = ({
     }
     prevIndex.value = index.value;
   }, [windowWidth]);
+
+  useScrollToTop(
+    React.useRef({
+      scrollToTop: () => {
+        runOnUI(scrollTo)(0);
+      },
+    })
+  );
 
   const styles = React.useMemo(() => {
     return [tw.style(`bg-white dark:bg-gray-900`), style];


### PR DESCRIPTION
# Why

This PR fixes a little issue when loading a new profile. We weren't scrolling to the top.

# How

Call React Navigation's `useScrollToTop`

# Test Plan

Run the app, go to a profile, scroll down and click on a NFT then click on a username. This should load the new profile and the list should be scrolled to the top.