### PR TITLE
Success flow after minting

### DIFF
--- a/packages/app/components/create.tsx
+++ b/packages/app/components/create.tsx
@@ -105,7 +105,7 @@ function Create({ uri, state, startMinting }: CreateProps) {
         }, 1000);
       }
     },
-    [state.status]
+    [state.status, user]
   );
 
   return (


### PR DESCRIPTION
# Why

Staying on the Create modal after successfully minting is a weird UX. This PR redirects to the user's profile after minting

# How

- Redirect after minting
- TODO: revalidate the profile data to show the latest NFT
- TODO: maybe send some love in the Create modal just before redirecting?

# Test Plan

Run the app and mint a NFT