### PR TITLE
fix: scroll to top, svg crash and trending nft view navigation

### DIFF
--- a/packages/app/navigation/tab-bar-icons.tsx
+++ b/packages/app/navigation/tab-bar-icons.tsx
@@ -1,4 +1,4 @@
-import { View, Pressable, Button } from "design-system";
+import { View, Pressable } from "design-system";
 import { tw } from "design-system/tailwind";
 import {
   Home,
@@ -12,33 +12,37 @@ import {
   Plus,
 } from "design-system/icon";
 import { useRouter } from "app/navigation/use-router";
+import { Platform } from "react-native";
 
 function TabBarIcon({ tab, children }) {
   const router = useRouter();
+  if (Platform.OS === "web") {
+    return (
+      <Pressable
+        tw={[
+          "md:bg-white md:dark:bg-gray-800 rounded-[20] w-12 h-12 items-center justify-center",
+        ]}
+        // @ts-expect-error web only
+        onMouseEnter={() => {
+          router.prefetch(tab);
+        }}
+        onPress={() => {
+          router.push(tab);
+        }}
+        // animate={useCallback(({ hovered }) => {
+        // 	'worklet'
 
-  return (
-    <Pressable
-      tw={[
-        "md:bg-white md:dark:bg-gray-800 rounded-[20] w-12 h-12 items-center justify-center",
-      ]}
-      // @ts-expect-error web only
-      onMouseEnter={() => {
-        router.prefetch(tab);
-      }}
-      onPress={() => {
-        router.push(tab);
-      }}
-      // animate={useCallback(({ hovered }) => {
-      // 	'worklet'
+        // 	return hovered
+        // 		? tw.style('bg-gray-100 dark:bg-gray-800 md:dark:bg-gray-700')
+        // 		: tw.style('bg-white dark:bg-gray-900 md:dark:bg-gray-800')
+        // }, [])}
+      >
+        {children}
+      </Pressable>
+    );
+  }
 
-      // 	return hovered
-      // 		? tw.style('bg-gray-100 dark:bg-gray-800 md:dark:bg-gray-700')
-      // 		: tw.style('bg-white dark:bg-gray-900 md:dark:bg-gray-800')
-      // }, [])}
-    >
-      {children}
-    </Pressable>
-  );
+  return children;
 }
 
 export const HomeTabBarIcon = ({ color, focused }) => {

--- a/packages/design-system/media/index.tsx
+++ b/packages/design-system/media/index.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from "react";
 import { Pressable, useWindowDimensions } from "react-native";
 import Router from "next/router";
-import { SvgUri } from "react-native-svg";
+// import { SvgUri } from "react-native-svg";
 import { useSWRConfig } from "swr";
 
 import { useRouter } from "app/navigation/use-router";
@@ -93,7 +93,7 @@ function Media({ item, numColumns, tw }: Props) {
         }}
         disabled={isNftModal}
       >
-        {item?.mime_type === "image/svg+xml" && (
+        {/* {item?.mime_type === "image/svg+xml" && (
           <SvgUri
             width={
               numColumns === 3
@@ -111,7 +111,7 @@ function Media({ item, numColumns, tw }: Props) {
             }
             uri={item?.token_img_url}
           />
-        )}
+        )} */}
 
         {item?.mime_type?.startsWith("image") &&
           item?.mime_type !== "image/svg+xml" && (


### PR DESCRIPTION
# Why

## Fixes 

- SVG crash. It crashes when svg has a custom font family, we'll have to convert svgs to png. (Linear issue)[https://linear.app/showtime/issue/SHOW2-458/svguri-crash-on-scrolling-profile-username-showdeer]
- scrollToTop not working in feed list bottom tab icon press
- Fixes navigation on opening nft modal



<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
1. Removed SVGUri, we might have to do svg to png conversion
2. Removed pressable on native, it was preventing the scrollToTop press in some instances
3. Noticed in navigatonState for top views, path field is not present so added name as fallback.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Test navigation
- Scroll profile and make sure it doesn't crash for user named showdeer (test with prod API url)
- Try opening nft view on trending screen
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
