### PR TITLE
connect if wallet not connected during mint

### DIFF
--- a/packages/app/hooks/use-mint-nft.ts
+++ b/packages/app/hooks/use-mint-nft.ts
@@ -284,9 +284,9 @@ export const useMintNFT = () => {
         userAddress = addr;
       } else {
         if (connector.connected) {
-          userAddress = connector.accounts.filter((addr) =>
+          [userAddress] = connector.accounts.filter((addr) =>
             addr.startsWith("0x")
-          )[0];
+          );
         } else {
           await connector.connect();
           console.log("Not connected to wallet, sending connect request");


### PR DESCRIPTION
# Why
- If a user is not connected to a wallet while minting, we show the wallet connect modal. 
- This is useful for [this case](https://linear.app/showtime/issue/SHOW2-459/mint-improvement-connect-wallet-if-its-not-connected)
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
-  Calls connect method on wallet connect and continues minting on successful connection.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Login with wallet -> call connector.killSession() -> try to mint. 
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
