### PR TITLE
fix: svg crash

### DIFF
--- a/packages/design-system/media/index.tsx
+++ b/packages/design-system/media/index.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from "react";
 import { Pressable, useWindowDimensions } from "react-native";
 import Router from "next/router";
-import { SvgUri } from "react-native-svg";
+// import { SvgUri } from "react-native-svg";
 import { useSWRConfig } from "swr";
 
 import { useRouter } from "app/navigation/use-router";
@@ -93,7 +93,7 @@ function Media({ item, numColumns, tw }: Props) {
         }}
         disabled={isNftModal}
       >
-        {item?.mime_type === "image/svg+xml" && (
+        {/* {item?.mime_type === "image/svg+xml" && (
           <SvgUri
             width={
               numColumns === 3
@@ -111,7 +111,7 @@ function Media({ item, numColumns, tw }: Props) {
             }
             uri={item?.token_img_url}
           />
-        )}
+        )} */}
 
         {item?.mime_type?.startsWith("image") &&
           item?.mime_type !== "image/svg+xml" && (


### PR DESCRIPTION
# Why
SVG crash. It crashes when svg has a custom font family, we'll have to convert svgs to png. [Linear issue](https://linear.app/showtime/issue/SHOW2-458/svguri-crash-on-scrolling-profile-username-showdeer)
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
Removed SvgUri, we might have to do svg to png conversion

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
Scroll profile and make sure it doesn't crash for user named showdeer (test with production backend API URL)

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
