### PR TITLE
feature(settings): redirect on unauthentication to previous screen

### DIFF
--- a/packages/app/components/settings/index.tsx
+++ b/packages/app/components/settings/index.tsx
@@ -1,5 +1,6 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { Dimensions, Platform } from "react-native";
+import { useRouter } from "app/navigation/use-router";
 import { tw } from "design-system/tailwind";
 import { useUser } from "app/hooks/use-user";
 import { Tabs, TabItem, SelectedTabIndicator } from "design-system/tabs";
@@ -42,7 +43,8 @@ const renderWallet = ({ item }: { item: WalletAddressesExcludingEmailV2 }) => {
 
 const SettingsTabs = () => {
   const [selected, setSelected] = useState(0);
-  const { user } = useUser();
+  const { user, isAuthenticated } = useUser();
+  const router = useRouter();
   const emailWallets = useMemo(
     () =>
       user?.data.profile.wallet_addresses_v2.filter(
@@ -52,6 +54,13 @@ const SettingsTabs = () => {
   );
   const wallets = user?.data.profile.wallet_addresses_excluding_email_v2;
   const keyExtractor = (wallet: WalletAddressesV2) => wallet.address;
+
+  useEffect(() => {
+    const isUnauthenticated = !isAuthenticated;
+    if (isUnauthenticated) {
+      router.pop();
+    }
+  }, [isAuthenticated]);
 
   return (
     <View tw="bg-white dark:bg-black flex-1">


### PR DESCRIPTION
# Why

When a user is not authenticated they should not be able to land or stay on an authenticated screen.

# How

1. if `isAuthenticated` from `useUser()` changes to false we pop the route

# Test Plan

On local testing the log out code by forcing a log out

https://user-images.githubusercontent.com/11730651/152247803-b72a449d-0ed6-478b-84d8-19c7a634ec0a.MP4


