### PR TITLE
fix: android popover menu fix

### DIFF
--- a/packages/app/components/nft-dropdown.tsx
+++ b/packages/app/components/nft-dropdown.tsx
@@ -36,7 +36,7 @@ function NFTDropdown({ nft }: Props) {
   return (
     <DropdownMenuRoot>
       <DropdownMenuTrigger>
-        <Button variant="tertiary" iconOnly={true} size="regular">
+        <Button variant="tertiary" iconOnly={true} size="regular" asChild>
           <MoreHorizontal
             color={
               tw.style("bg-black dark:bg-white")?.backgroundColor as string

--- a/packages/app/components/profile-dropdown.tsx
+++ b/packages/app/components/profile-dropdown.tsx
@@ -28,7 +28,7 @@ function ProfileDropdown({ user }: Props) {
   return (
     <DropdownMenuRoot>
       <DropdownMenuTrigger>
-        <Button variant="tertiary" iconOnly={true} size="regular">
+        <Button variant="tertiary" iconOnly={true} size="regular" asChild>
           <MoreHorizontal
             color={
               tw.style("bg-black dark:bg-white")?.backgroundColor as string

--- a/packages/app/components/settings/address-menu.tsx
+++ b/packages/app/components/settings/address-menu.tsx
@@ -35,7 +35,7 @@ export const AddressMenu = (props: AddressMenuProps) => {
   return (
     <DropdownMenuRoot>
       <DropdownMenuTrigger>
-        <Button iconOnly={true} variant="tertiary">
+        <Button iconOnly={true} variant="tertiary" asChild>
           <MoreHorizontal />
         </Button>
       </DropdownMenuTrigger>

--- a/packages/design-system/activity/activity-dropdown.tsx
+++ b/packages/design-system/activity/activity-dropdown.tsx
@@ -26,7 +26,12 @@ function ActivityDropdown({ activity }: Props) {
     <DropdownMenuRoot>
       <DropdownMenuTrigger>
         <View tw="w-8 h-8">
-          <Button variant="tertiary" tw="h-8 rounded-full p-2" iconOnly={true}>
+          <Button
+            variant="tertiary"
+            tw="h-8 rounded-full p-2"
+            iconOnly={true}
+            asChild
+          >
             <MoreHorizontal
               width={24}
               height={24}

--- a/packages/design-system/button/button-base.tsx
+++ b/packages/design-system/button/button-base.tsx
@@ -3,6 +3,8 @@ import { useSharedValue, useAnimatedStyle } from "react-native-reanimated";
 import { useIsDarkMode } from "../hooks";
 import { Pressable } from "design-system/pressable-scale";
 import { Text } from "design-system/text";
+import Animated from "react-native-reanimated";
+import { tw as tailwind } from "design-system/tailwind";
 
 import {
   CONTAINER_HEIGHT_TW,
@@ -24,6 +26,7 @@ export function BaseButton({
   iconOnly,
   iconColor = ["white", "black"],
   children,
+  asChild,
   ...props
 }: BaseButtonProps) {
   //#region variables
@@ -85,6 +88,20 @@ export function BaseButton({
       });
     });
   }, [size, iconColor, labelStyle, children, isDarkMode]);
+
+  if (asChild) {
+    return (
+      <Animated.View
+        style={useMemo(
+          () => [containerAnimatedStyle, tailwind.style(containerStyle)],
+          [containerAnimatedStyle, containerStyle]
+        )}
+      >
+        {renderChildren}
+      </Animated.View>
+    );
+  }
+
   return (
     <Pressable
       {...props}

--- a/packages/design-system/button/types.ts
+++ b/packages/design-system/button/types.ts
@@ -13,6 +13,7 @@ export type ButtonProps = {
    */
   variant?: ButtonVariant;
   children?: React.ReactNode | string;
+  asChild?: boolean;
 } & PressableScaleProps &
   Partial<Pick<BaseButtonProps, "tw" | "labelTW" | "iconOnly" | "size">>;
 
@@ -54,4 +55,9 @@ export type BaseButtonProps = {
   size: ButtonSize;
 
   children?: React.ReactNode | string;
+
+  /**
+   * Renders the child of button as the Button
+   */
+  asChild?: boolean;
 } & PressableScaleProps;


### PR DESCRIPTION
# Why

- fixes menu not opening in nft view, activity, profile and settings.
- zeego menu adds a Pressable internally and I think this broke when we replaced touchable native feedback with pressable. So we have two Pressables, one from our button and one zeego's. The top pressable is not passing press events to zeego's pressable

This adds a short term fix, on long term we should add a prop asChild in zeego's trigger similar to radix, which will use child passed by us instead of adding a pressable

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->



<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Run on android or iOS and test all the menus
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
