### PR TITLE
Tabs Spacing Fix

### DIFF
--- a/packages/app/components/settings/index.tsx
+++ b/packages/app/components/settings/index.tsx
@@ -81,12 +81,8 @@ const SettingsTabs = () => {
           </View>
         </Tabs.Header>
         <Tabs.List
-          contentContainerStyle={{
-            justifyContent: "space-between",
-            width: Dimensions.get("window").width,
-          }}
           style={tw.style(
-            `h-[${TAB_LIST_HEIGHT}px] dark:bg-black bg-white border-b border-b-gray-100 dark:border-b-gray-900`
+            `h-[${TAB_LIST_HEIGHT}px] dark:bg-black bg-white border-b border-b-gray-100 dark:border-b-gray-900 w-screen`
           )}
         >
           <Tabs.Trigger>


### PR DESCRIPTION
# Why

Resolve feedback from design on updating tab spacing. [Figma](https://www.figma.com/file/720aUothRCUZMtMEVHfJV0/%F0%9F%96%A5%F0%9F%93%B1-Showtime?node-id=1240%3A54403) for reference.

# How

1. Remove flex properties that made `space between`
2. Refactored  `Dimensions.get("window").width` to `w-screen`

# Test Plan

Tested on local device
1. Login and visit the settings screen
2. Review tabs 

## Screenshot
<img width="300" src="https://user-images.githubusercontent.com/11730651/152443701-a0738b5c-0455-41ad-916e-ac5c7f4791d2.PNG"/>

