### PR TITLE
fix magic mint on login

### DIFF
--- a/apps/expo/App.tsx
+++ b/apps/expo/App.tsx
@@ -27,7 +27,6 @@ import { useNavigation } from "@react-navigation/native";
 import * as NavigationBar from "expo-navigation-bar";
 import * as SystemUI from "expo-system-ui";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
-import { ethers } from "ethers";
 import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
 import LogRocket from "@logrocket/react-native";
 
@@ -38,14 +37,12 @@ import { AuthProvider } from "app/providers/auth-provider";
 import { UserProvider } from "app/providers/user-provider";
 import { Web3Provider } from "app/providers/web3-provider";
 import { WalletConnectProvider } from "app/providers/wallet-connect-provider";
-import { NextTabNavigator } from "app/navigation/next-tab-navigator";
 import { AppContext } from "app/context/app-context";
 import { ToastProvider } from "design-system/toast";
 import {
   setColorScheme as setUserColorScheme,
   useColorScheme as useUserColorScheme,
 } from "app/lib/color-scheme";
-import { Relayer } from "app/lib/magic";
 import { RootStackNavigator } from "app/navigation/root-stack-navigator";
 
 enableScreens(true);
@@ -181,8 +178,6 @@ function AppContextProvider({
 }: {
   children: React.ReactNode;
 }): JSX.Element {
-  const [mountRelayerOnApp, setMountRelayerOnApp] = useState(true);
-
   useDeviceContext(tw, { withDeviceColorScheme: false });
   // Default to device color scheme
   const deviceColorScheme = useDeviceColorScheme();
@@ -220,17 +215,7 @@ function AppContextProvider({
     }
   }, [isDark]);
 
-  // useEffect(() => {
-  //   magic.user.isLoggedIn().then((isLoggedIn) => {
-  //     if (magic.rpcProvider && isLoggedIn) {
-  //       const provider = new ethers.providers.Web3Provider(magic.rpcProvider);
-  //       setWeb3(provider);
-  //     }
-  //   });
-  // }, []);
-
   const injectedGlobalContext = {
-    setMountRelayerOnApp,
     colorScheme,
     setColorScheme: (newColorScheme: "light" | "dark") => {
       setColorScheme(newColorScheme);
@@ -241,8 +226,6 @@ function AppContextProvider({
   return (
     <AppContext.Provider value={injectedGlobalContext}>
       {children}
-      {/* TODO: Open Relayer on FullWindow, need change in relayer source */}
-      {mountRelayerOnApp ? <Relayer /> : null}
     </AppContext.Provider>
   );
 }

--- a/packages/app/components/login/login-container.tsx
+++ b/packages/app/components/login/login-container.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect, useState } from "react";
 import { View, Spinner } from "design-system";
-import { AppContext } from "../../context/app-context";
 import { Relayer } from "../../lib/magic";
+import { Web3Context } from "app/context/web3-context";
 
 interface LoginContainerProps {
   loading?: boolean;
@@ -12,16 +12,16 @@ export function LoginContainer({
   loading = false,
   children,
 }: LoginContainerProps) {
-  const context = useContext(AppContext);
+  const context = useContext(Web3Context);
   const [mountRelayer, setMountRelayer] = useState(false);
 
   useEffect(() => {
-    context.setMountRelayerOnApp(false);
+    context?.setMountRelayerOnApp(false);
     setMountRelayer(true);
     return () => {
-      context.setMountRelayerOnApp(true);
+      context?.setMountRelayerOnApp(true);
     };
-  }, []);
+  }, [context?.setMountRelayerOnApp]);
 
   return (
     <View

--- a/packages/app/context/app-context.ts
+++ b/packages/app/context/app-context.ts
@@ -3,7 +3,6 @@ import { createContext } from "react";
 type AppContextType = {
   colorScheme: "light" | "dark";
   setColorScheme: (colorScheme: "light" | "dark") => void;
-  setMountRelayerOnApp: (hide: boolean) => void;
 };
 
 const AppContext = createContext({} as AppContextType);

--- a/packages/app/context/web3-context.ts
+++ b/packages/app/context/web3-context.ts
@@ -4,6 +4,7 @@ import type { Web3Provider } from "@ethersproject/providers";
 type Web3ContextType = {
   web3?: Web3Provider;
   setWeb3: (web3?: Web3Provider) => void;
+  setMountRelayerOnApp: (hide: boolean) => void;
 };
 
 export const Web3Context = createContext<Web3ContextType | null>(null);

--- a/packages/app/providers/web3-provider.tsx
+++ b/packages/app/providers/web3-provider.tsx
@@ -1,6 +1,7 @@
-import { useMemo, useState } from "react";
-import type { Web3Provider as Web3ProviderType } from "@ethersproject/providers";
+import { useEffect, useMemo, useState } from "react";
+import { Web3Provider as EthersWeb3Provider } from "@ethersproject/providers";
 import { Web3Context } from "app/context/web3-context";
+import { magic, Relayer } from "app/lib/magic";
 
 interface Web3ProviderProps {
   children: React.ReactNode;
@@ -8,7 +9,8 @@ interface Web3ProviderProps {
 
 export function Web3Provider({ children }: Web3ProviderProps) {
   //#region state
-  const [web3, setWeb3] = useState<Web3ProviderType | undefined>(undefined);
+  const [web3, setWeb3] = useState<EthersWeb3Provider | undefined>(undefined);
+  const [mountRelayerOnApp, setMountRelayerOnApp] = useState(true);
   //#endregion
 
   //#region variables
@@ -16,13 +18,26 @@ export function Web3Provider({ children }: Web3ProviderProps) {
     () => ({
       web3,
       setWeb3,
+      setMountRelayerOnApp,
     }),
     [web3]
   );
+
+  useEffect(() => {
+    magic.user.isLoggedIn().then((isLoggedIn) => {
+      if (magic.rpcProvider && isLoggedIn) {
+        const provider = new EthersWeb3Provider(magic.rpcProvider);
+        setWeb3(provider);
+      }
+    });
+  }, []);
+
   //#endregion
   return (
     <Web3Context.Provider value={Web3ContextValue}>
       {children}
+      {/* TODO: Open Relayer on FullWindow, need change in relayer source */}
+      {mountRelayerOnApp ? <Relayer /> : null}
     </Web3Context.Provider>
   );
 }


### PR DESCRIPTION
# Why
Fixes magic mint if user is logged in with magic and reopens the app (after killing).
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

This hack stems from the issue that we can only mount one Relayer instance from magic (which is a webview) or else it throws weird errors. The magic modal is needed in login container as it's using that for the otp/email UI. I've asked magic folks if they're planning to port to non webview RN sdk. We also can't use FullWindowOverlay as the webview always stays mounted and made visible with [zIndex](https://github.com/magiclabs/magic-js/blob/master/packages/%40magic-sdk/react-native/src/react-native-webview-controller.tsx#L30) 😭. So it's more like forcing us for a hack

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- login with magic, kill the app, reopen the app, try minting flow
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
