### PR TITLE
Fix EAS Update config

### DIFF
--- a/apps/expo/eas.json
+++ b/apps/expo/eas.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "production": {
-      "releaseChannel": "production",
+      "channel": "production",
       "distribution": "store",
       "android": {
         "buildType": "app-bundle",
@@ -16,7 +16,7 @@
       }
     },
     "preview": {
-      "releaseChannel": "staging",
+      "channel": "staging",
       "distribution": "internal",
       "android": {
         "buildType": "apk",


### PR DESCRIPTION
# Why

EAS Update uses `channel` instead of the Expo Updates "classic" `releaseChannel`

# How

Change `releaseChannel` with `channel`

# Test Plan

Create a new production build and deploy an EAS Update