### PR TITLE
Axios catch and throw

### DIFF
--- a/packages/app/lib/axios.ts
+++ b/packages/app/lib/axios.ts
@@ -101,8 +101,8 @@ const axiosAPI = async ({
     return await axios(request).then((res) => res.data);
   } catch (error) {
     console.log("failed request ", request);
-    // TODO: Evaluate if we should continue to allow axios to swallow errors
     console.error(error);
+    throw error;
   }
 };
 


### PR DESCRIPTION
# Why

Axios currently will swallow any caught errors. This behavior prevents the application from properly reacting to happy/unhappy paths.

# How

1. Continued to catch in axios. Helpful for debugging + sending logs (in the future)
2. Throw after caught with the original error

# Test Plan

1. Forced errors to happen on local. 
2. Combed code and made sure that anywhere that was not catching correctly is also updated. (separate PR)
