### PR TITLE
Update like + unlike to catch thrown errors

### DIFF
--- a/packages/app/hooks/api-hooks.ts
+++ b/packages/app/hooks/api-hooks.ts
@@ -350,25 +350,30 @@ export const useMyInfo = () => {
       }
 
       if (data) {
-        mutate(
-          queryKey,
-          {
-            data: {
-              ...data.data,
-              likes_nft: [...data.data.likes_nft, nftId],
+        try {
+          mutate(
+            queryKey,
+            {
+              data: {
+                ...data.data,
+                likes_nft: [...data.data.likes_nft, nftId],
+              },
             },
-          },
-          false
-        );
+            false
+          );
 
-        await axios({
-          url: `/v3/like/${nftId}`,
-          method: "POST",
-        });
+          await axios({
+            url: `/v3/like/${nftId}`,
+            method: "POST",
+          });
 
-        mutate(queryKey);
+          mutate(queryKey);
 
-        return true;
+          return true;
+        } catch (error) {
+          mutate(queryKey);
+          return false;
+        }
       }
     },
     [data, isAuthenticated]
@@ -377,23 +382,29 @@ export const useMyInfo = () => {
   const unlike = useCallback(
     async (nftId: number) => {
       if (data) {
-        mutate(
-          queryKey,
-          {
-            data: {
-              ...data.data,
-              likes_nft: data.data.likes_nft.filter((id) => id !== nftId),
+        try {
+          mutate(
+            queryKey,
+            {
+              data: {
+                ...data.data,
+                likes_nft: data.data.likes_nft.filter((id) => id !== nftId),
+              },
             },
-          },
-          false
-        );
+            false
+          );
 
-        await axios({
-          url: `/v3/unlike/${nftId}`,
-          method: "POST",
-        });
+          await axios({
+            url: `/v3/unlike/${nftId}`,
+            method: "POST",
+          });
 
-        mutate(queryKey);
+          mutate(queryKey);
+          return true;
+        } catch (error) {
+          mutate(queryKey);
+          return false;
+        }
       }
     },
     [data]

--- a/packages/design-system/card/social/index.tsx
+++ b/packages/design-system/card/social/index.tsx
@@ -22,8 +22,10 @@ function Social({ nft }: { nft?: NFT }) {
           active={isLikedNft}
           onPress={useCallback(async () => {
             if (isLikedNft) {
-              unlike(nft.nft_id);
-              setLikeCount(likeCount - 1);
+              const isSuccessfullyUnlike = await unlike(nft.nft_id);
+              if (isSuccessfullyUnlike) {
+                setLikeCount(likeCount - 1);
+              }
             } else {
               const isSuccessfullyLiked = await like(nft.nft_id);
               if (isSuccessfullyLiked) {


### PR DESCRIPTION
# Why

With [axios](https://github.com/tryshowtime/showtime-frontend/pull/799) throwing errors that it's caught. The `like` and `unlike` functions need to update its error handling as axios won't swallow anymore and there is no guarantee the calls will succeed. 

# How

1. Wrap the calls in a try/catch
2. `like`
  - Happy path stays the same
  - Error path will mutate and return false.
3. `unlike`
  - refactored to have the same return style as `like` (true or false)
  - Only on confirmed happy path will it decrement by 1 
  - Error path will mutate and return false.

# Test Plan

On local
1. Forced fail adding a like for an NFT
2. Forced failed removing a life from an NFT

Small video of the force fail (happens fast because it's a force fail)

https://user-images.githubusercontent.com/11730651/152602547-4dbcccfa-e972-407c-8c86-387e445ff2ae.MP4


