### PR TITLE
fix: header post sign in ui glitch

### DIFF
--- a/packages/app/components/header.tsx
+++ b/packages/app/components/header.tsx
@@ -38,43 +38,42 @@ const HeaderRight = () => {
               <NotificationsTabBarIcon color="white" focused={false} />
             </View>
           )}
-          {isAuthenticated ? (
-            <View tw="bg-white dark:bg-black">
-              {width > 768 && (
-                <View tw="mx-3">
-                  <Button
-                    onPress={() => {}}
-                    variant="primary"
-                    tw="p-2.5 md:px-3.5 md:py-1.5 rounded-full h-10 w-10 md:w-auto"
-                  >
-                    <ButtonLabel tw="hidden md:flex">Create</ButtonLabel>
-                    <Plus
-                      style={tw.style("md:hidden")}
-                      width={20}
-                      height={20}
-                      color={
-                        tw.style("bg-white dark:bg-black")
-                          ?.backgroundColor as string
-                      }
-                    />
-                  </Button>
-                </View>
-              )}
-
+          <View tw="bg-white dark:bg-black w-20 items-end">
+            {isAuthenticated && width > 768 && (
+              <View tw="mx-3">
+                <Button
+                  onPress={() => {}}
+                  variant="primary"
+                  tw="p-2.5 md:px-3.5 md:py-1.5 rounded-full h-10 w-10 md:w-auto"
+                >
+                  <ButtonLabel tw="hidden md:flex">Create</ButtonLabel>
+                  <Plus
+                    style={tw.style("md:hidden")}
+                    width={20}
+                    height={20}
+                    color={
+                      tw.style("bg-white dark:bg-black")
+                        ?.backgroundColor as string
+                    }
+                  />
+                </Button>
+              </View>
+            )}
+            {isAuthenticated ? (
               <HeaderDropdown />
-            </View>
-          ) : (
-            <Button
-              onPress={() => {
-                router.push("/login");
-              }}
-              variant="primary"
-              size="small"
-              labelTW="font-semibold"
-            >
-              Sign&nbsp;In
-            </Button>
-          )}
+            ) : (
+              <Button
+                onPress={() => {
+                  router.push("/login");
+                }}
+                variant="primary"
+                size="small"
+                labelTW="font-semibold"
+              >
+                Sign&nbsp;In
+              </Button>
+            )}
+          </View>
         </View>
       )}
     </View>


### PR DESCRIPTION
# Why
Aims to fix the below UI glitch
![File (1)](https://user-images.githubusercontent.com/23293248/152805158-39dbb5f8-70e9-4f65-97b6-94794fdefd6b.jpg)

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- Wraps avatar menu and sign in buttons in a single fixed width container

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Login with wallet, logout and login again
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
