### PR TITLE
fix: removed refresh token error screen

### DIFF
--- a/packages/app/hooks/auth/use-access-token-manager.ts
+++ b/packages/app/hooks/auth/use-access-token-manager.ts
@@ -47,11 +47,7 @@ export function useAccessTokenManager() {
       setRefreshToken(_refreshToken);
 
       isRefreshing.current = false;
-    } catch (error) {
-      if (__DEV__) {
-        console.error(error);
-      }
-
+    } catch (error: any) {
       isRefreshing.current = false;
 
       accessTokenStorage.deleteAccessToken();
@@ -64,7 +60,9 @@ export function useAccessTokenManager() {
         },
       });
 
-      throw "Failed to refresh tokens";
+      throw `Failed to refresh tokens. ${
+        typeof error === "string" ? error : error.message || ""
+      }`;
     }
   }, []);
   //#endregion

--- a/packages/app/providers/auth-provider.tsx
+++ b/packages/app/providers/auth-provider.tsx
@@ -120,7 +120,11 @@ export function AuthProvider({ children }: AuthProviderProps) {
         try {
           await refreshTokens();
           setAuthenticationStatus("AUTHENTICATED");
-        } catch (error) {
+        } catch (error: any) {
+          console.log(
+            "AuthProvider",
+            typeof error === "string" ? error : error.message || "unknown"
+          );
           await logout();
         }
       }


### PR DESCRIPTION
# Why

Currently when trying to refresh access token for unlogged in customer, the logic will throw an error screen _ONLY FOR DEBUG_, which is not necessary. 

https://showtime-rq88331.slack.com/archives/C02RX6JUKLY/p1644255140713819

# How

- change refresh token error from throwing an error to just print in app console.

# Test Plan

- install and launch the app
- app should print refresh token error in the console 