### PR TITLE
fix: feed not fetching next page post login

### DIFF
--- a/packages/app/hooks/use-infinite-list-query.ts
+++ b/packages/app/hooks/use-infinite-list-query.ts
@@ -62,7 +62,7 @@ export const useInfiniteListQuerySWR = <T>(
       if (!isLoadingMore) {
         setSize((size) => size + 1);
       }
-    }, [isLoadingMore]),
+    }, [isLoadingMore, setSize]),
     retry: mutate,
     isLoading: isLoadingInitialData,
     isLoadingMore,


### PR DESCRIPTION
# Why
- Fixes an issue reported by Alex [here](https://showtime-rq88331.slack.com/files/U02Q0EWRN67/F031ZGSAA8K/image_from_ios.mp4) and noticed the feed is not fetching next page on scroll post login.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- A dependency was missing in fetchMore callback and it was probably calling the previous unauthenticated api's fetcher.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Open app without authentication -> scroll feed -> Login with wallet -> scroll feed

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
