### PR TITLE
Fix current pill matching

### DIFF
--- a/packages/app/components/settings/settings-wallet-slot.tsx
+++ b/packages/app/components/settings/settings-wallet-slot.tsx
@@ -109,7 +109,8 @@ export const SettingsWalletSlot = (props: Props) => {
   const display = ensDomain ? ensDomain : formatAddressShort(address);
   const isEthereumAddress = address.startsWith("0x");
   const [connectedAddress] = connector?.session?.accounts;
-  const isConnectedAddress = notMagic && connectedAddress;
+  const isConnectedAddress =
+    notMagic && connectedAddress.toLowerCase() === address.toLowerCase();
   const multiplePills = isConnectedAddress && mintingEnabled;
 
   return (


### PR DESCRIPTION
# Why

Quick fix to the `Current` pill to only display on the active address

# How

1. Update `isConnectedAddress` to check current address with the address being passed into the slot

# Test Plan

1. Log into multiple addresses connected addresses and make sure the current pill matches correctly

## Screenshot

### Before
<img width="300" src="https://user-images.githubusercontent.com/11730651/153328415-14c24c4b-6da1-42f7-bf50-ba49e4f97828.PNG" />

### After
<img width="300" src="https://user-images.githubusercontent.com/11730651/153328429-39d482a8-5108-4761-b360-6e270e9cdc02.PNG" />

