### PR TITLE
Add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+apps/next-react @TatisLois
+apps/next-react-native @TatisLois
+apps/expo @intergalacticspacehighway
+apps/storybook-react @axeldelafosse
+apps/storybook-react-native @axeldelafosse
+packages/app @axeldelafosse @intergalacticspacehighway @TatisLois
+packages/design-system @axeldelafosse
+.github/workflows @axeldelafosse


### PR DESCRIPTION
# Why

This PR adds code owners on GitHub to make sure we each own a part of the code. The idea is to improve the code quality and make sure our part of the codebase is always clean, always running and tested properly. More context here https://showtime-rq88331.slack.com/archives/C02PTNZMEPQ/p1644490402125659
