### PR TITLE
fix: remove duplicates from feed

### DIFF
--- a/packages/app/hooks/api-hooks.ts
+++ b/packages/app/hooks/api-hooks.ts
@@ -34,9 +34,23 @@ export const useActivity = ({
   const newData = useMemo(() => {
     let newData: any = [];
     if (queryState.data) {
-      queryState.data.forEach((p) => {
-        if (p) {
-          newData = newData.concat(p.data);
+      // filter if duplicate data shows up in pagingation. Flatlist starts acting weird on receiving duplicates
+      // It can happen if database is updating and we are fetching new data.
+      // As new post shows on top, fetching next page can have same post as previous page.
+      // TODO: Cursor based pagination in API?
+      queryState.data.forEach((page) => {
+        if (page) {
+          page.data = page.data.filter((d: any) => {
+            const v = newData.find((x: any) => x.id === d.id);
+            if (v === undefined) {
+              if (__DEV__) {
+                console.log("duplicate record in feed ", d.id);
+              }
+              return true;
+            }
+            return false;
+          });
+          newData = newData.concat(page.data);
         }
       });
     }


### PR DESCRIPTION
# Why?

-  Fixes Feed sometimes turning black https://showtime-rq88331.slack.com/archives/C02PXGK3V8D/p1644537260524899
- Noted that this happen when duplicate keys start appearing in flatlist
- Short term solution is to just filter duplicates from feed


# Test

-  Change to production API URL in env and  do `monkey testing` on feed, it's easy to reproduce if we're following large number of accounts as database will be updated with their posts frequently and we may get a duplicate entry in next page.