### PR TITLE
fix: bottomsheet select is not showing list of items

### DIFF
--- a/packages/design-system/bottom-sheet/index.tsx
+++ b/packages/design-system/bottom-sheet/index.tsx
@@ -76,7 +76,7 @@ export const BottomSheet = (props: BottomSheetProps) => {
       )}
       snapPoints={snapPoints ?? defaultSnapPoints}
     >
-      <View tw={["flex-1 pt-6 px-4", bodyContentTW]} />
+      <View tw={["flex-1 pt-6 px-4", bodyContentTW]}>{children}</View>
     </BottomSheetModal>
   );
 };


### PR DESCRIPTION
# Why

- The children prop was not being passed to view. [here](https://github.com/tryshowtime/showtime-frontend/commit/5cfcab6d4bf8db896fd17bd9a24c5b39279c083f#diff-ab619e802f5ce0cbfa0cd6f1f53324d6da1b7d762d6c6e543d91ec58b4f3e736L68) 🤦. Let me know if this has any usecases!
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- Pass children prop in view
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Try opening `Select` in Profile screen
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
