### PR TITLE
remove activity icons

### DIFF
--- a/packages/app/components/activity/activity.tsx
+++ b/packages/app/components/activity/activity.tsx
@@ -38,7 +38,7 @@ function Activity({ activity }: Props) {
         <Link href={`/profile/${actor.wallet_address}`}>
           <Avatar
             url={getProfileImageUrl(actor.img_url ?? DEFAULT_PROFILE_PIC)}
-            icon={type}
+            // icon={type}
           />
         </Link>
 


### PR DESCRIPTION
# Why

Task - https://linear.app/showtime/issue/SHOW2-499/remove-activity-icon-from-card-header

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->


<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Test feed, icons should be gone
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
