### PR TITLE
Write docs for the current release cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,30 @@ Using `dotenv` for the Expo app. Next.js is automatically picking up the `.env.l
 - `.env.local` in `apps/next-react`
 - `.env.local` in `apps/next-react-native`
 
+## Release Cycle
+
+### Native
+
+#### Over The Air Update (EAS Update)
+
+1. Increment the patch version in the root `package.json`
+
+2. Run `yarn update:production` in `apps/expo`
+
+3. Close and reopen the production app twice to check the new update
+
+#### Native Build (EAS Build + EAS Submit)
+
+1. Increment the major version in the root `package.json`
+
+2. Run `yarn deploy:production` in `apps/expo`
+
+3. Submit the new build for review on TestFlight and Google Play
+
+### Web
+
+TODO: CI/CD with Vercel + GitHub Actions via `/promote` Slack command
+
 ## Notes
 
 Pro tip: you can add `tw` to `Tailwind CSS: Class Attributes` VS Code extension setting to get IntelliSense working.


### PR DESCRIPTION
# Why

I'm going to take some time off so I wanted to write some docs around the current process for our mobile release cycle. It's pretty straightforward and we could even automate this with GitHub Actions and only rely on the future `/promote` Slack command.

