### PR TITLE
Support magic testmode for a configurable email

### DIFF
--- a/packages/app/lib/constants.js
+++ b/packages/app/lib/constants.js
@@ -221,3 +221,8 @@ export const CHAIN_IDENTIFIERS = {
 
 // static height can improve tabs list initial rendering
 export const TAB_LIST_HEIGHT = 50;
+
+export const BYPASS_EMAIL = "test+success@magic.link";
+
+export const BYPASS_EMAIL_WITH_INSECURE_KEYS =
+  "test+success_with_{0x89A3983da27fF0eFCF901F74C4df84e0450A17B7:0x19de850af732e9e5745915162d707d6d8cf013ce7b2862e93081b0c8883bdfae}@magic.link";

--- a/packages/app/utilities.ts
+++ b/packages/app/utilities.ts
@@ -1,8 +1,12 @@
 import * as React from "react";
 
 import { Biconomy } from "@biconomy/mexa";
+import { Magic } from "@magic-sdk/react-native";
 import { ethers } from "ethers";
 import removeMd from "remove-markdown";
+
+import { BYPASS_EMAIL } from "app/lib/constants";
+import { magic } from "app/lib/magic";
 
 import { Profile } from "./types";
 
@@ -143,3 +147,31 @@ export function flattenChildren(children: React.ReactNode): ReactChildArray {
     return flatChildren;
   }, []);
 }
+/**
+ * Under matching conditions return an instance of magic in test mode
+ */
+export const overrideMagicInstance = (email: string) => {
+  if (email === BYPASS_EMAIL) {
+    const isMumbai = process.env.NEXT_PUBLIC_CHAIN_ID === "mumbai";
+    // Default to polygon chain
+    const customNodeOptions = {
+      rpcUrl: "https://rpc-mainnet.maticvigil.com/",
+      chainId: 137,
+    };
+
+    if (isMumbai) {
+      console.log("Magic network is connecting to Mumbai testnet");
+      customNodeOptions.rpcUrl =
+        "https://polygon-mumbai.g.alchemy.com/v2/kh3WGQQaRugQsUXXLN8LkOBdIQzh86yL";
+      customNodeOptions.chainId = 80001;
+    }
+
+    const testMagic = new Magic(process.env.NEXT_PUBLIC_MAGIC_PUB_KEY, {
+      network: customNodeOptions,
+      testMode: true,
+    });
+    return testMagic;
+  }
+
+  return magic;
+};


### PR DESCRIPTION
# Why

Google store rejection feedback highlighted that we can provide a demo account so that they can preview required UGC features like blocking. Since our flow is passwordless it would reduce approval friction if we just bypassed that part of the login flow _only_ under these conditions. We can always remove/approve it after approval. 

# How

1. Create two constants. The first is the input email to check enablement against. The second is the address we override the inputed one with (has a key/value pair of a burner address). We might not _need_ the key/value burner address but if they want to do a web3 thats how we can offer support.
2. Create a utility function that if the conditions are true will create a new magic instance with `testMode` true
3. In the email login in `packages/app/hooks/auth/use-magic-login.ts` we use the utility and constants

This should be backwards compatible with our current flow.

### Blocker

- [x] waiting on backend updates to support `/v1/login_magic`

# Test Plan

1. Tested current flow with these changes
2. Partial testing of the testMode flow (waiting on remaining changes)

## Test it out yourself
1. Log in with magic as normal, this should not change the flow on magic
2. Log in using `test+success@magic.link` you should not be prompt to check an e-mail and should be dropped right into the app. Some web3 features (mint) might be spotty but imo a non issue for the reviewers. 


https://user-images.githubusercontent.com/11730651/154333452-2bbbfe59-0bf2-49c5-8d43-c5d718d9a80a.MP4


