### PR TITLE
Show "Block" button while logged out

### DIFF
--- a/packages/app/components/profile-dropdown.tsx
+++ b/packages/app/components/profile-dropdown.tsx
@@ -71,24 +71,24 @@ function ProfileDropdown({ user }: Props) {
 
         <DropdownMenuSeparator tw="h-[1px] m-1 bg-gray-200 dark:bg-gray-700" />
 
-        {isAuthenticated && (
-          <DropdownMenuItem
-            onSelect={async () => {
+        <DropdownMenuItem
+          onSelect={async () => {
+            if (isAuthenticated) {
               await block(user.profile_id);
               router.pop();
-            }}
-            tw="h-8 rounded-sm overflow-hidden flex-1 p-2"
-            key="block"
-          >
-            <DropdownMenuItemTitle tw="text-black dark:text-white">
-              Block
-            </DropdownMenuItemTitle>
-          </DropdownMenuItem>
-        )}
+            } else {
+              router.push("/login");
+            }
+          }}
+          tw="h-8 rounded-sm overflow-hidden flex-1 p-2"
+          key="block"
+        >
+          <DropdownMenuItemTitle tw="text-black dark:text-white">
+            Block
+          </DropdownMenuItemTitle>
+        </DropdownMenuItem>
 
-        {isAuthenticated && (
-          <DropdownMenuSeparator tw="h-[1px] m-1 bg-gray-200 dark:bg-gray-700" />
-        )}
+        <DropdownMenuSeparator tw="h-[1px] m-1 bg-gray-200 dark:bg-gray-700" />
 
         <DropdownMenuItem
           onSelect={async () => {


### PR DESCRIPTION
# Why

This PR adds the "Block" button even if the user is logged out. We redirect do the login screen because we don't have the block feature for logged out user. It might trigger the Google Play review team to log in and properly test and review the app.

# How

Check if the user is authenticated and redirect to login if not.

# Test Plan

Try to block a user while logged out.