### PR TITLE
Use React Navigation `getId`

### DIFF
--- a/packages/app/navigation/root-stack-navigator.tsx
+++ b/packages/app/navigation/root-stack-navigator.tsx
@@ -37,7 +37,11 @@ export function RootStackNavigator() {
         // @ts-ignore
         screenOptions={screenOptions({ safeAreaTop, isDark })}
       >
-        <Stack.Screen name="profile" component={ProfileScreen} />
+        <Stack.Screen
+          name="profile"
+          component={ProfileScreen}
+          getId={({ params }) => params?.walletAddress}
+        />
         <Stack.Screen name="settings" component={SettingsScreen} />
         <Stack.Screen
           name="search"
@@ -58,7 +62,11 @@ export function RootStackNavigator() {
         }}
       >
         <Stack.Screen name="login" component={LoginScreen} />
-        <Stack.Screen name="nft" component={NftScreen} />
+        <Stack.Screen
+          name="nft"
+          component={NftScreen}
+          getId={({ params }) => params?.id}
+        />
         <Stack.Screen name="transferNft" component={TransferNftScreen} />
         <Stack.Screen name="create" component={CreateScreen} />
         <Stack.Screen name="burn" component={DeleteScreen} />


### PR DESCRIPTION
# Why

This PR uses React Navigation `getId`: https://twitter.com/reactnavigation/status/1349736208528601089/photo/1. It lets you navigate to a profile from another profile and go back to the previous profile. It's "pushing" to a new screen.

# How

Add `getId` in profile and NFT screens.

# Test Plan

Run the app, navigate to a profile, click on a NFT then click on a profile. Go back. You should be on the initial profile.