### PR TITLE
fix: sign in button cutting off

### DIFF
--- a/packages/app/components/header.tsx
+++ b/packages/app/components/header.tsx
@@ -40,7 +40,7 @@ const HeaderRight = () => {
               <NotificationsTabBarIcon color="white" focused={false} />
             </View>
           )}
-          <View tw="bg-white dark:bg-black w-20 items-end">
+          <View tw="bg-white dark:bg-black min-w-20 items-end">
             {isAuthenticated && width > 768 && (
               <View tw="mx-3">
                 <Button


### PR DESCRIPTION
# Why
- Fixes sign in button text cuttoff https://linear.app/showtime/issue/SHOW2-548/iphone-12-pro-sign-in-button-is-cutoff
- This is not related to iphone 12 pro. We had set a fixed width for outer view in button to fix the native header re-render UI bug and the user has enabled large text size in accessibility settings which is causing the issue. 

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- Changed width to min width. I think that should solve the header bug and this issue too.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Increase font size in iOS accessibility settings and open the app, sign in text should not cutoff
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
