### PR TITLE
feature(mint): set royalties for magic users to zero

### DIFF
--- a/packages/app/components/create.tsx
+++ b/packages/app/components/create.tsx
@@ -11,6 +11,7 @@ import {
   UseMintNFT,
 } from "app/hooks/use-mint-nft";
 import { useUser } from "app/hooks/use-user";
+import { useWeb3 } from "app/hooks/use-web3";
 import { yup } from "app/lib/yup";
 import { useRouter } from "app/navigation/use-router";
 
@@ -66,6 +67,9 @@ interface CreateProps {
 function Create({ uri, state, startMinting }: CreateProps) {
   const router = useRouter();
   const { user } = useUser();
+  const { web3 } = useWeb3();
+
+  const isNotMagic = !web3;
 
   const handleSubmitForm = (values: Omit<UseMintNFT, "filePath">) => {
     console.log("** Submiting minting form **", values);
@@ -233,24 +237,26 @@ function Create({ uri, state, startMinting }: CreateProps) {
                         />
                       )}
                     /> */}
-                    <Controller
-                      control={control}
-                      name="royaltiesPercentage"
-                      render={({ field: { onChange, onBlur, value } }) => (
-                        <Fieldset
-                          label="Creator Royalties"
-                          placeholder="10%"
-                          // tw="ml-4 w-[48%]"
-                          value={value}
-                          onBlur={onBlur}
-                          onChangeText={onChange}
-                          helperText="How much you'll earn each time this NFT is sold."
-                          keyboardType="numeric"
-                          returnKeyType="done"
-                          errorText={errors.royaltiesPercentage?.message}
-                        />
-                      )}
-                    />
+                    {isNotMagic ? (
+                      <Controller
+                        control={control}
+                        name="royaltiesPercentage"
+                        render={({ field: { onChange, onBlur, value } }) => (
+                          <Fieldset
+                            label="Creator Royalties"
+                            placeholder="10%"
+                            // tw="ml-4 w-[48%]"
+                            value={value}
+                            onBlur={onBlur}
+                            onChangeText={onChange}
+                            helperText="How much you'll earn each time this NFT is sold."
+                            keyboardType="numeric"
+                            returnKeyType="done"
+                            errorText={errors.royaltiesPercentage?.message}
+                          />
+                        )}
+                      />
+                    ) : null}
                   </View>
                 </Accordion.Content>
               </Accordion.Item>

--- a/packages/app/hooks/use-mint-nft.ts
+++ b/packages/app/hooks/use-mint-nft.ts
@@ -287,6 +287,7 @@ export const useMintNFT = () => {
         const signer = web3.getSigner();
         const addr = await signer.getAddress();
         userAddress = addr;
+        params.royaltiesPercentage = 0;
       } else {
         if (connector.connected) {
           [userAddress] = connector.accounts.filter((addr) =>


### PR DESCRIPTION
# Why

[Linear Task](https://linear.app/showtime/issue/SHOW2-554/enforce-0percent-royalties-on-magic-wallets)

Magic users do not have full ownership of their address. So while on mobile we allow web3 actions the team decided to minimize the security risk we are programmatically setting minting royalties to 0 for magic users. 

# How

1. hide the input from the mint options
2. set the value to zero on mint

# Test Plan

Ran it locally on my phone

<img width="380" alt="Screen Shot 2022-03-02 at 10 45 54 PM" src="https://user-images.githubusercontent.com/11730651/156498203-ededb08f-7ad7-4362-958c-a190ccf544f8.png">