### PR TITLE
fix(): Activity Feed Character Breaking The App

### DIFF
--- a/packages/app/components/activity/activity.tsx
+++ b/packages/app/components/activity/activity.tsx
@@ -81,7 +81,7 @@ function Activity({ activity }: Props) {
           <View tw="h-2" />
 
           <Text variant="text-xs" tw="text-gray-600 dark:text-gray-400">
-            {formatDistanceToNowStrict(new Date(`${activity.timestamp}Z`), {
+            {formatDistanceToNowStrict(new Date(`${activity.timestamp}`), {
               addSuffix: true,
             })}
           </Text>


### PR DESCRIPTION
# Why

Not sure why it's failing now but git says it's been included for sometime now. But the extra `Z` char passed into `new Date` is breaking the app on my end. Feed works without it. I also don't see it as a supported argument in the docs https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date

# How

1. Remove extra Z char. 

# Test Plan

1. Tested feed locally