### PR TITLE
fix: safari date parsing

### DIFF
--- a/apps/next-react/src/components/ActivityCard.js
+++ b/apps/next-react/src/components/ActivityCard.js
@@ -11,7 +11,7 @@ import {
 import { truncateWithEllipses } from "@/lib/utilities";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { DotsHorizontalIcon } from "@heroicons/react/solid";
-import { formatDistanceToNowStrict } from "date-fns";
+import { formatDistanceToNowStrict, parseISO } from "date-fns";
 import mixpanel from "mixpanel-browser";
 import Link from "next/link";
 
@@ -168,9 +168,11 @@ export default function ActivityCard({
                 </Link>
               )}
               <div className="text-gray-400 text-xs">
-                {formatDistanceToNowStrict(new Date(`${act.timestamp}Z`), {
-                  addSuffix: true,
-                })}
+                {act.timestamp && typeof act.timestamp === "string"
+                  ? formatDistanceToNowStrict(parseISO(act.timestamp), {
+                      addSuffix: true,
+                    })
+                  : null}
               </div>
             </div>
           </div>


### PR DESCRIPTION
# Why
Backup PR. @fontanierh is working on a backend fix. We can merge this only if needed.

The below timestamp format doesn't work on safari. 

`2022-01-16 21:27:51.044151+00:00`. Try printing this in chrome vs safari `new Date('2022-01-16 21:27:51.044151+00:00')`

<img width="975" alt="Screenshot 2022-03-07 at 10 15 50 PM" src="https://user-images.githubusercontent.com/23293248/157078871-99b39ddb-ce9e-4393-ae33-c10845173e48.png">


# How
- use parseIso function which seems to handle it
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- run next-react app and open localhost:3000 in safari. Let the feed load.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
