### PR TITLE
fix(activity): format issue with timestamps

### DIFF
--- a/apps/next-react/src/components/ActivityCard.js
+++ b/apps/next-react/src/components/ActivityCard.js
@@ -168,7 +168,7 @@ export default function ActivityCard({
                 </Link>
               )}
               <div className="text-gray-400 text-xs">
-                {formatDistanceToNowStrict(new Date(`${act.timestamp}Z`), {
+                {formatDistanceToNowStrict(new Date(act.timestamp), {
                   addSuffix: true,
                 })}
               </div>


### PR DESCRIPTION
# Why

Breaking the home page on safari, see [slack thread](https://showtime-rq88331.slack.com/archives/C02Q0E4PBD0/p1646669351711799) caused by a similar issue experienced on mobile as described on this [slack thread](https://showtime-rq88331.slack.com/archives/C02PTPFCZAA/p1646347601480709)

# How

1. remove additional char

# Test Plan

Ran the application locally on safari, firefox and chrome
