### PR TITLE
Redirect contract to charity page

### DIFF
--- a/apps/next-react/next.config.js
+++ b/apps/next-react/next.config.js
@@ -69,6 +69,11 @@ const nextConfig = {
         destination: "https://showtime.nolt.io",
         permanent: true,
       },
+      {
+        source: "/0x3a99ea152Dd2eAcc8E95aDdFb943e714Db9ECC22",
+        destination: "/ukraine",
+        permanent: true,
+      },
     ];
   },
 };


### PR DESCRIPTION
# Why

The contract profile is actually the charity route. Since the charity page is not a user they can't login and claim their username. To support this one off we are going to redirect the contract to the proper route.

# How

configure the redirect in next.js

# Test Plan
tested visiting /0x3a99ea152Dd2eAcc8E95aDdFb943e714Db9ECC22


<img width="600" alt="Screen Shot 2022-03-07 at 7 10 17 PM" src="https://user-images.githubusercontent.com/11730651/157145782-41969ab7-665a-4df1-9043-a8adc1c76df8.png">



