### PR TITLE
feature(ukraine): add the nft modal on charity page

### DIFF
--- a/apps/next-react/src/components/SpotlightItem-ukraine.js
+++ b/apps/next-react/src/components/SpotlightItem-ukraine.js
@@ -19,6 +19,7 @@ import CappedWidth from "./CappedWidth";
 import BadgeIcon from "./Icons/BadgeIcon";
 import EllipsisIcon from "./Icons/EllipsisIcon";
 import OrbitIcon from "./Icons/OrbitIcon";
+import ModalTokenDetail from "./ModalTokenDetail";
 import Button from "./UI/Buttons/Button";
 import BuyModal from "./UI/Modals/BuyModal";
 
@@ -126,6 +127,11 @@ const SpotlightItem = ({
     <>
       {typeof document !== "undefined" ? (
         <>
+          <ModalTokenDetail
+            isOpen={currentlyOpenModal}
+            setEditModalOpen={setCurrentlyOpenModal}
+            item={thisItem}
+          />
           <BuyModal
             open={buyModalOpen}
             onClose={() => setBuyModalOpen(false)}


### PR DESCRIPTION
For sake of time and because it was manually tested by the team going to merge this PR. Feel free for anyone to post review.

# Why

Toggle the NFT view on the charity page

# How

1. Add modal to the route

# Test Plan

Local env