### PR TITLE
Buy Flow Stale State Fix

### DIFF
--- a/apps/next-react/src/components/UI/Modals/BuyModal.jsx
+++ b/apps/next-react/src/components/UI/Modals/BuyModal.jsx
@@ -52,6 +52,7 @@ const BuyModal = ({ open, onClose, token }) => {
       ? MODAL_PAGES.GENERAL
       : MODAL_PAGES.NO_WALLET
   );
+
   const [quantity, setQuantity] = useState(1);
   const [transactionHash, setTransactionHash] = useState("");
 
@@ -61,6 +62,8 @@ const BuyModal = ({ open, onClose, token }) => {
   useEffect(() => {
     if (!Boolean(myProfile?.wallet_addresses_excluding_email_v2?.length)) {
       setModalPage(MODAL_PAGES.NO_WALLET);
+    } else {
+      setModalPage(MODAL_PAGES.GENERAL);
     }
   }, [myProfile]);
 


### PR DESCRIPTION
# Why

On initial render of the page the value of `myProfile?.wallet_addresses_excluding_email_v2` sets the modal view to `NO_WALLET` and even after the value changes that state is not updated.

# How

1. In an already coded `useEffect` we set `setModalPage(MODAL_PAGES.NO_WALLET)` inside of an if condition. Added an else to set the `GENERAL` modal view. 

# Test Plan

Tested locally and will test in staging
