### PR TITLE
Phone number picker autofocus search

### DIFF
--- a/packages/app/components/login/phone-number-picker.tsx
+++ b/packages/app/components/login/phone-number-picker.tsx
@@ -124,7 +124,7 @@ type Props = {
 };
 
 export function Header({ title, close, onSearchSubmit }: Props) {
-  const [showSearch, setShowSearch] = useState(false);
+  const [showSearch, setShowSearch] = useState(true);
   const searchDebounceTimeout = useRef<any>(null);
 
   const handleSearch = (text: string) => {


### PR DESCRIPTION
# Why

This PR improves the phone number picker

# How

Open search by default

# Test Plan

Open the login modal, click on the flag to open the phone number picker and check if the search is auto focused
