### PR TITLE
keep videos muted and remove native controls

### DIFF
--- a/packages/app/components/swipe-list.tsx
+++ b/packages/app/components/swipe-list.tsx
@@ -99,8 +99,8 @@ export const SwipeList = ({
 
   const videoConfig = useMemo(
     () => ({
-      isMuted: false,
-      useNativeControls: true,
+      isMuted: true,
+      useNativeControls: false,
     }),
     []
   );


### PR DESCRIPTION
## Why?

- Native control doesn't look very good with the designs. Also, we can just use mute/unmute button in UI instead of showing controls.
- The video should be muted unless user has unmuted it manually. 
 
Will pick video tasks after finishing current priority items.