### PR TITLE
fix: profile swipelist loading items

### DIFF
--- a/packages/app/components/profile.tsx
+++ b/packages/app/components/profile.tsx
@@ -231,19 +231,22 @@ const TabList = ({
     [dispatch]
   );
 
+  const onItemPress = useCallback(
+    (index: number) => {
+      router.push(
+        `/swipeList?initialScrollIndex=${index}&listId=${list.id}&profileId=${profileId}&collectionId=${filter.collectionId}&sortId=${filter.sortId}&type=profile`
+      );
+    },
+    [list.id, profileId, filter.collectionId, filter.sortId]
+  );
+
   const renderItem = useCallback(
     ({ item, index }) => (
-      <Pressable
-        onPress={() => {
-          router.push(
-            `/swipeList?initialScrollIndex=${index}&listId=${list.id}&profileId=${profileId}&collectionId=${filter.collectionId}&sortId=${filter.sortId}&type=profile`
-          );
-        }}
-      >
+      <Pressable onPress={() => onItemPress(index)}>
         <Media item={item} numColumns={3} />
       </Pressable>
     ),
-    []
+    [onItemPress]
   );
 
   const ListFooterComponent = useCallback(


### PR DESCRIPTION
# Why
Fixes profile swipelist not loading items based on the currently selected filters.
https://showtime-rq88331.slack.com/archives/C02PXGK3V8D/p1647298116680879
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
Adds missing dependency in hooks. Could be prevented with the hook eslint rule.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
Go to profile, change filters, tap on item.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
