### PR TITLE
fix: keep username and bio nullable

### DIFF
--- a/packages/app/components/edit-profile.tsx
+++ b/packages/app/components/edit-profile.tsx
@@ -87,7 +87,6 @@ export const EditProfile = () => {
   }, [defaultValues]);
 
   const handleSubmitForm = async (values: typeof defaultValues) => {
-    console.log("lol ", values);
     const links = Object.keys(values.links)
       .filter((key) => values.links[key]?.trim())
       .map((key) => {


### PR DESCRIPTION
# Why
An error is thrown by yup if bio and username are not submitted by the user. We can allow them to be null
https://showtime-rq88331.slack.com/archives/C02PXGK3V8D/p1647328708008759
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
Make username and bio nullable in yup.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Go to profile 
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
