### PR TITLE
fix(transfer): amount logic and copy fix

### DIFF
--- a/packages/app/components/transfer.tsx
+++ b/packages/app/components/transfer.tsx
@@ -48,6 +48,7 @@ function Transfer({ nftId }: { nftId?: string }) {
   );
 
   const maxQuantity = ownerListItem?.quantity || 1;
+  const hideCopiesInput = maxQuantity === 1;
   const copiesHelperText = `1 by default, you own ${maxQuantity}`;
 
   const defaultValues = {
@@ -185,31 +186,33 @@ function Transfer({ nftId }: { nftId?: string }) {
 
           <Owner nft={nft} price={true} tw="px-0" />
 
-          <View tw="mt-4 flex-row">
-            <Controller
-              control={control}
-              name="quantity"
-              render={({ field: { onChange, onBlur, value } }) => {
-                const errorText = errors.quantity?.message
-                  ? `Copies amount must be between 1 and ${maxQuantity}`
-                  : undefined;
-                return (
-                  <Fieldset
-                    tw="flex-1"
-                    label="Copies"
-                    placeholder="1"
-                    helperText={copiesHelperText}
-                    onBlur={onBlur}
-                    keyboardType="numeric"
-                    errorText={errorText}
-                    value={value?.toString()}
-                    onChangeText={onChange}
-                    returnKeyType="done"
-                  />
-                );
-              }}
-            />
-          </View>
+          {!hideCopiesInput && (
+            <View tw="mt-4 flex-row">
+              <Controller
+                control={control}
+                name="quantity"
+                render={({ field: { onChange, onBlur, value } }) => {
+                  const errorText = errors.quantity?.message
+                    ? `Copies amount must be between 1 and ${maxQuantity}`
+                    : undefined;
+                  return (
+                    <Fieldset
+                      tw="flex-1"
+                      label="Copies"
+                      placeholder="1"
+                      helperText={copiesHelperText}
+                      onBlur={onBlur}
+                      keyboardType="numeric"
+                      errorText={errorText}
+                      value={value?.toString()}
+                      onChangeText={onChange}
+                      returnKeyType="done"
+                    />
+                  );
+                }}
+              />
+            </View>
+          )}
 
           <View tw="mt-4 flex-row">
             <Controller


### PR DESCRIPTION
# Why

Logic to determine transfer NFT amount was incorrect and caused a bug where on mismatch of address the user could not bypass the form error validation and transfer an NFT.

+ When a user only owns a single edition we should omit showing the copies form input and default it for them.

# How

1. Refactor the logic to determine transfer amount and used a util that simplifies the check
2. Update copy to be slightly more human readable and match figma for Error + Helper text
3. Use updated owned amount to determine if we should show copies input

# Test Plan

Tested locally on a few different NFTs

<img width="300" src="https://user-images.githubusercontent.com/11730651/158416635-864265e2-d7e0-4094-8a39-60623d5038d6.PNG" />
<img width="300" src="https://user-images.githubusercontent.com/11730651/158416646-0cf41a6b-3b80-4667-81a1-3ba4bf3ae7c6.PNG" />

<img width="300" src="https://user-images.githubusercontent.com/11730651/158416620-7ad21941-24cc-4124-a860-a9b58a913be5.PNG" />

