### PR TITLE
increase the max listing price from 1000 to 9_999_999_999

### DIFF
--- a/apps/next-react/src/components/UI/Modals/ListModal.jsx
+++ b/apps/next-react/src/components/UI/Modals/ListModal.jsx
@@ -43,7 +43,7 @@ const MODAL_PAGES = {
  * Listing price range is fixed across currencies.
  * As currency list grows this can be a candidate to be refactored into LIST_CURRENCIES
  */
-const MAX_LIST_PRICE = 1000;
+const MAX_LIST_PRICE = 9_999_999_999;
 
 const ListModal = ({ open, onClose, onSuccess = () => null, token }) => {
   const { myProfile } = useProfile();


### PR DESCRIPTION
This is a nonsense number because it is the same across multiple currencies.

9_999_999_999 has been completely arbitrarily, the point is that users shouldn't realistically run into it.

At the moment, listings are limited to $1000 which is too limiting.
