### PR TITLE
refactor(nftDropdown): check if the active user follows the nft owner…

### DIFF
--- a/packages/app/components/nft-dropdown.tsx
+++ b/packages/app/components/nft-dropdown.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 
 import { useSWRConfig } from "swr";
 
@@ -40,7 +40,7 @@ function NFTDropdown({ nft }: Props) {
   const { userAddress } = useCurrentUserAddress();
   const [isOwner, setIsOwner] = useState(false);
   const { report } = useReport();
-  const { unfollow } = useMyInfo();
+  const { unfollow, isFollowing } = useMyInfo();
   const { block } = useBlock();
   const router = useRouter();
   const { refresh } = useFeed();
@@ -60,6 +60,11 @@ function NFTDropdown({ nft }: Props) {
   // Prevent web3 actions on incorrect contracts caused by environment syncs
   const usableContractAddress = SHOWTIME_CONTRACTS.includes(
     nft?.contract_address
+  );
+
+  const isFollowingUser = useMemo(
+    () => nft?.owner_id && isFollowing(nft?.owner_id),
+    [nft?.owner_id, isFollowing]
   );
 
   return (
@@ -110,7 +115,7 @@ function NFTDropdown({ nft }: Props) {
           </DropdownMenuItemTitle>
         </DropdownMenuItem> */}
 
-        {!isOwner && (
+        {!isOwner && isFollowingUser && (
           <DropdownMenuItem
             onSelect={async () => {
               if (isAuthenticated) {


### PR DESCRIPTION

# Why

Small refactor to improve the unfollow item in the NFT dropdown. I noticed it would display to unfollow even _if_ I was _not_ following that user. Clicking the button did not do anything.

This just ensures that we always display it if the NFT is owned by someone you follow. 

# How

1. Reuse the `isFollowing` method from the useMyInfo hook passing in the nft.owner_id

# Test Plan

Tested Locally

## Issue

https://user-images.githubusercontent.com/11730651/158886315-bcab8e73-7d53-4c52-93c8-9c26c9f5c644.MP4

## Fix


https://user-images.githubusercontent.com/11730651/158886246-92ff4e7d-1653-459c-92b9-320b8af905b5.MP4


