### PR TITLE
fix(settings): resolve header and pills not showing

### DIFF
--- a/packages/app/components/settings/index.tsx
+++ b/packages/app/components/settings/index.tsx
@@ -1,6 +1,8 @@
 import { useState, useMemo, useEffect } from "react";
 import { Dimensions, Platform } from "react-native";
 
+import { useHeaderHeight } from "@react-navigation/elements";
+
 import { useUser } from "app/hooks/use-user";
 import { TAB_LIST_HEIGHT } from "app/lib/constants";
 import { useRouter } from "app/navigation/use-router";
@@ -47,6 +49,7 @@ const renderWallet = ({ item }: { item: WalletAddressesExcludingEmailV2 }) => {
 const SettingsTabs = () => {
   const [selected, setSelected] = useState(0);
   const { user, isAuthenticated } = useUser();
+  const headerHeight = useHeaderHeight();
   const router = useRouter();
   const emailWallets = useMemo(
     () =>
@@ -74,6 +77,7 @@ const SettingsTabs = () => {
         lazy
       >
         <Tabs.Header>
+          {Platform.OS !== "android" && <View tw={`h-[${headerHeight}px]`} />}
           <View tw="bg-white dark:bg-black pt-4 pl-4 pb-[3px]">
             <Text
               variant="text-2xl"


### PR DESCRIPTION
# Why

Not sure when but I noticed a regression in the settings page where the page title and pills were not displaying anymore. 

# How

1. Found how the issue was resolved on profile
2. Use the same solution on settings :) 

# Test Plan

Ran it locally

## Screenshot of the issue
<img width="300" src="https://user-images.githubusercontent.com/11730651/158931001-21736039-bab3-45af-9dfc-a96c83578ea1.PNG" />


## Screenshot of the fix

<img width="300" src="https://user-images.githubusercontent.com/11730651/158931009-de4a39e7-d4c4-4c63-83b9-f42aba236704.PNG" />

