### PR TITLE
Remove other apps when building on EAS

### DIFF
--- a/.github/workflows/expo-production.yml
+++ b/.github/workflows/expo-production.yml
@@ -33,6 +33,9 @@ jobs:
         with:
           node-version: 14.x
 
+      - name: Remove other apps
+        run: rm -rf ../apps/next-react ../apps/next-react-native ../storybook-react ../storybook-react-native
+
       - name: Find yarn cache
         id: yarn-cache-path
         run: echo "::set-output name=dir::$(yarn cache dir)"

--- a/.github/workflows/expo-staging.yml
+++ b/.github/workflows/expo-staging.yml
@@ -26,6 +26,9 @@ jobs:
         with:
           node-version: 14.x
 
+      - name: Remove other apps
+        run: rm -rf ../apps/next-react ../apps/next-react-native ../storybook-react ../storybook-react-native
+
       - name: Find yarn cache
         id: yarn-cache-path
         run: echo "::set-output name=dir::$(yarn cache dir)"


### PR DESCRIPTION
# Why

This PR fixes the very annoying issue where patch-package fails on EAS because it's run in another app than Expo

# How

`rm -rf` everything
