### PR TITLE
Resolve NFT dropdown bug

### DIFF
--- a/packages/app/components/nft-dropdown.tsx
+++ b/packages/app/components/nft-dropdown.tsx
@@ -63,8 +63,8 @@ function NFTDropdown({ nft }: Props) {
   );
 
   const isFollowingUser = useMemo(
-    () => nft?.owner_id && isFollowing(nft?.owner_id),
-    [nft?.owner_id, isFollowing]
+    () => nft?.owner_id && isFollowing(nft?.creator_id),
+    [nft?.creator_id, isFollowing]
   );
 
   return (
@@ -119,7 +119,7 @@ function NFTDropdown({ nft }: Props) {
           <DropdownMenuItem
             onSelect={async () => {
               if (isAuthenticated) {
-                await unfollow(nft?.owner_id);
+                await unfollow(nft?.creator_id);
                 refresh();
               } else {
                 router.push("/login");
@@ -140,7 +140,7 @@ function NFTDropdown({ nft }: Props) {
           <DropdownMenuItem
             onSelect={async () => {
               if (isAuthenticated) {
-                await block(nft?.owner_id);
+                await block(nft?.creator_id);
                 refresh();
               } else {
                 router.push("/login");


### PR DESCRIPTION
Small bug that I came across while working on the unlist flow and felt it was worth fixing in a smaller quicker PR.

# Why

An NFT has two types of user attributions. The first is the creator of the NFT and the second is the owner. _**Their can also be multiple owners**_.

Currently throughout the experience we give preference to the creator (ex: [swipe list](https://github.com/tryshowtime/showtime-frontend/blob/495480d32cb710a7120e36727d34dff089df1e0f/packages/app/components/swipe-list.tsx#L209)) but in the NFT dropdown the logic uses **owner**. 

In some cases they are the same user but not always. **Meaning a user might block/unfollow a profile but actually be  block/unfollowing someone else entirely.** 

# How

1. Update all references to use `creator_id` such as `isFollowing, unfollow and block`

# Test Plan

1. Tested the flows (and console logged the values for sanity) on NFTs that the creator was not the owner
