### PR TITLE
fix: chevron not working on create

### DIFF
--- a/packages/app/components/create.tsx
+++ b/packages/app/components/create.tsx
@@ -196,9 +196,9 @@ function Create({ uri, state, startMinting }: CreateProps) {
                 <Accordion.Trigger>
                   <Accordion.Label>Options</Accordion.Label>
                   <Accordion.Chevron>
-                    <Button variant="tertiary" tw="rounded-full h-8 w-8">
+                    <View tw="rounded-full h-8 w-8 bg-gray-100 dark:bg-gray-900 items-center justify-center">
                       <ChevronUp color={isDark ? "#fff" : "#000"} />
-                    </Button>
+                    </View>
                   </Accordion.Chevron>
                 </Accordion.Trigger>
                 <Accordion.Content>


### PR DESCRIPTION
# Why
Fixes chevron not working in create screen 
https://linear.app/showtime/issue/SHOW2-599/pressing-the-accordionchevron-is-not-doing-anything
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
Replace button with a View
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
Open create screen, press chevron in options
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
