### PR TITLE
fix: min height profile fix

### DIFF
--- a/packages/app/components/profile.tsx
+++ b/packages/app/components/profile.tsx
@@ -324,7 +324,6 @@ const TabList = ({
       alwaysBounceVertical={false}
       ListFooterComponent={ListFooterComponent}
       style={listStyle}
-      minHeight={0}
     />
   );
 };


### PR DESCRIPTION
# Why

Reverts https://github.com/tryshowtime/showtime-frontend/pull/918 due to below reason
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

https://user-images.githubusercontent.com/23293248/160132493-52a8babd-9147-4a46-be6e-b86daecb9152.mov

Actually, we need minimum height in tabs especially profile. Most of the apps with collapsible headers use this approach because I guess there's no simple way. If we see below Twitter app, it allows over-scrolling. In short, we need min scrolling to allow collapsible headers in each tab. Can discuss this in detail.

This only affects profile that has very less content as we only set the `min-height.` Profile with content > min-height won't face overscrolling

https://user-images.githubusercontent.com/23293248/160132871-12c0c4c3-35fd-4cbc-b64f-06ddb95e1e9a.MP4



# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
