### PR TITLE
fix: sentry error cannot read play async

### DIFF
--- a/packages/app/hooks/use-viewability-mount.ts
+++ b/packages/app/hooks/use-viewability-mount.ts
@@ -37,9 +37,9 @@ export const useViewabilityMount = ({
       }
 
       if (shouldPlay) {
-        videoRef.current.playAsync();
+        videoRef.current?.playAsync();
       } else {
-        videoRef.current.pauseAsync();
+        videoRef.current?.pauseAsync();
       }
 
       loaded.current = true;


### PR DESCRIPTION
# Why
Fix - https://sentry.io/organizations/showtime-l3/issues/3130841259/?environment=production&project=5860034&query=is%3Aunresolved

- Add a null check before calling playAsync
