### PR TITLE
Update E-mail management within settings 

### DIFF
--- a/packages/app/components/settings/address-menu.tsx
+++ b/packages/app/components/settings/address-menu.tsx
@@ -12,16 +12,17 @@ import {
 import { MoreHorizontal } from "design-system/icon";
 
 type AddressMenuProps = {
-  address?: WalletAddressesExcludingEmailV2["address"];
+  address?: WalletAddressesExcludingEmailV2["address"] | undefined | null;
   email?: WalletAddressesV2["email"];
   ctaCopy: string;
+  isCurrent: boolean;
 };
 
 export const AddressMenu = (props: AddressMenuProps) => {
   const { removeAccount } = useManageAccount();
   const address = props.address;
   const ctaCopy = props.ctaCopy;
-  const disableDelete = !address;
+  const disable = props.isCurrent || props.isCurrent === undefined;
 
   return (
     <DropdownMenuRoot>
@@ -35,9 +36,9 @@ export const AddressMenu = (props: AddressMenuProps) => {
         tw="w-60 p-2 bg-white dark:bg-gray-900 rounded-2xl shadow"
       >
         <DropdownMenuItem
-          disabled={disableDelete}
           // @ts-ignore
           onSelect={() => removeAccount(address)}
+          disabled={disable}
           key="your-profile"
           tw="h-8 rounded-sm overflow-hidden flex-1 p-2"
           destructive

--- a/packages/app/components/settings/index.tsx
+++ b/packages/app/components/settings/index.tsx
@@ -29,7 +29,8 @@ import { SlotSeparator } from "./slot-separator";
 
 const renderEmail = ({ item }: { item: EmailSlotProps }) => {
   const email = item.email;
-  return <SettingsEmailSlot email={email} />;
+  const backendAddress = item.address;
+  return <SettingsEmailSlot email={email} address={backendAddress} />;
 };
 
 const renderWallet = ({ item }: { item: WalletAddressesExcludingEmailV2 }) => {
@@ -51,6 +52,8 @@ const SettingsTabs = () => {
   const { user, isAuthenticated } = useUser();
   const headerHeight = useHeaderHeight();
   const router = useRouter();
+
+  // TODO: Include wallets with `phone number flag` after backend implementation
   const emailWallets = useMemo(
     () =>
       user?.data.profile.wallet_addresses_v2.filter(
@@ -132,7 +135,11 @@ const SettingsTabs = () => {
               }
               return <SettingsEmailSkeletonSlot />;
             }}
-            ListHeaderComponent={<SettingEmailSlotHeader />}
+            ListHeaderComponent={
+              <SettingEmailSlotHeader
+                hasEmail={Boolean(emailWallets?.length)}
+              />
+            }
             alwaysBounceVertical={false}
             minHeight={Dimensions.get("window").height}
             ItemSeparatorComponent={() => <SlotSeparator />}

--- a/packages/app/components/settings/settings-wallet-slot.tsx
+++ b/packages/app/components/settings/settings-wallet-slot.tsx
@@ -1,10 +1,7 @@
-import { useContext } from "react";
-
 import Animated, { FadeIn } from "react-native-reanimated";
 
-import { AppContext } from "app/context/app-context";
+import { useCurrentUserAddress } from "app/hooks/use-current-user-address";
 import { formatAddressShort } from "app/lib/utilities";
-import { useWalletConnect } from "app/lib/walletconnect";
 import { WalletAddressesExcludingEmailV2 } from "app/types";
 
 import { View, Text, Button, Skeleton } from "design-system";
@@ -104,18 +101,17 @@ export const SettingsWalletSlotPlaceholder = () => {
 };
 
 export const SettingsWalletSlot = (props: Props) => {
-  const context = useContext(AppContext);
-  const connector = useWalletConnect();
-  const notMagic = !!context.web3 === false;
   const address = props.address;
   const ensDomain = props.ensDomain;
+
+  const { userAddress } = useCurrentUserAddress();
+
   const mintingEnabled = props.mintingEnabled;
   const display = ensDomain ? ensDomain : formatAddressShort(address);
   const isEthereumAddress = address.startsWith("0x");
-  const [connectedAddress] = connector?.session?.accounts;
 
   const isConnectedAddress =
-    notMagic && connectedAddress?.toLowerCase() === address?.toLowerCase();
+    userAddress.toLowerCase() === address?.toLowerCase();
   const multiplePills = isConnectedAddress && mintingEnabled;
 
   return (
@@ -141,7 +137,11 @@ export const SettingsWalletSlot = (props: Props) => {
         <Text tw="text-gray-900 dark:text-white text-xs pb-3">{address}</Text>
       </View>
       <View tw="flex justify-center">
-        <AddressMenu address={address} ctaCopy="Delete Wallet" />
+        <AddressMenu
+          address={address}
+          ctaCopy="Delete Wallet"
+          isCurrent={isConnectedAddress}
+        />
       </View>
     </View>
   );

--- a/packages/app/hooks/use-current-user-address.ts
+++ b/packages/app/hooks/use-current-user-address.ts
@@ -1,30 +1,33 @@
 import { useState, useContext, useEffect } from "react";
 
-import { AppContext } from "app/context/app-context";
 import { useUser } from "app/hooks/use-user";
+import { useWeb3 } from "app/hooks/use-web3";
 import { useWalletConnect } from "app/lib/walletconnect";
 
+/**
+ * To avoid address collision this hook will maintain the active address.
+ * In the unexpected event of multiple active providers the preference order for address
+ * selection will be 1st wallet connect 2nd magic then if provided the first address in `profile.wallet_addresses_v2`
+ */
 function useCurrentUserAddress() {
   const { user } = useUser();
   const [userAddress, setUserAddress] = useState("");
-  const context = useContext(AppContext);
+  const { web3 } = useWeb3();
   const connector = useWalletConnect();
   const connectedAddress = connector?.session?.accounts[0];
 
   useEffect(() => {
     if (connector.connected && connectedAddress) {
       setUserAddress(connectedAddress);
-    } else if (user?.data && user?.data.profile.wallet_addresses_v2[0]) {
-      setUserAddress(user.data.profile.wallet_addresses_v2[0].address);
-    }
-    // Web3 is initialised for magic users
-    else if (context.web3) {
-      const signer = context.web3.getSigner();
+    } else if (web3) {
+      const signer = web3.getSigner();
       signer.getAddress().then((addr: string) => {
         setUserAddress(addr);
       });
+    } else if (user?.data && user?.data.profile.wallet_addresses_v2[0]) {
+      setUserAddress(user.data.profile.wallet_addresses_v2[0].address);
     }
-  }, [user, context.web3]);
+  }, [user, web3]);
 
   return { userAddress };
 }

--- a/packages/app/hooks/use-manage-account.ts
+++ b/packages/app/hooks/use-manage-account.ts
@@ -2,8 +2,8 @@ import { useCallback } from "react";
 
 import { useSWRConfig } from "swr";
 
-import { USER_API_KEY } from "app/hooks/use-user";
 import { axios } from "app/lib/axios";
+import { MY_INFO_ENDPOINT } from "app/providers/user-provider";
 
 import { useToast } from "design-system/toast";
 
@@ -23,7 +23,7 @@ export function useManageAccount() {
           },
         });
 
-        mutate(USER_API_KEY);
+        mutate(MY_INFO_ENDPOINT);
 
         toast?.show({
           message: "Email added and will soon appear on your profile",
@@ -49,7 +49,7 @@ export function useManageAccount() {
           data: { address },
         });
 
-        mutate(USER_API_KEY);
+        mutate(MY_INFO_ENDPOINT);
 
         toast?.show({
           message: "Account removed and will disappear from your profile soon",


### PR DESCRIPTION
# Why

E-mail tab in the settings page was no adhering to the correct behavior. For reference see the [linear issue](https://linear.app/showtime/issue/SHOW2-494/update-email-tab-settings-page). This PR resolves issues within the settings e-mail tab.

# How

1. Only display `add an email` button on accounts _without_ an e-mail connected
2. Disable removing an e-mail (and address) if it's the current method the user is logged in as. 
3. Refactored to use `useWeb3` to ensure logic checks are correct and aligned with the rest of the app
4. Refactored to use `useCurrentUserAddress` instead of duplicating wallet connect logic
5. Refactored `app/hooks/use-current-user-address.ts` because as it was structured it would in most cases *not* set the magic address even after login in through magic.
- In most cases we will only have an active wallet connect address *or* an active magic address we also get the wallets array from the backend (these can't sign but are associated to the user). 
- In some scenarios it's possible to have both providers existing at the same time. Sometimes wallet connect lingers after disconnecting or the magic instance becomes orphaned... In these scenario `use-current-user-address` should return the address in the preference of 1. Wallet connect 2. Magic.
- For some reason it was instead going by 1. Wallet connect 2. 1st item in backend wallets array 3. Magic. Creating an issue that a logged in user with both an address and magic account would never set the magic address in ``use-current-user-address` 
7. Small copy update

# Test Plan

Tested locally

## Screenshots

### Add an e-mail + remove add option after an email is linked
https://user-images.githubusercontent.com/11730651/160753347-5478748d-8ae9-4108-8c73-a5aba46da9f0.MP4

### Remove an e-mail 
https://user-images.githubusercontent.com/11730651/160753388-b2d18fa2-8976-489e-80f5-69cc9f75fa4f.MP4


