### PR TITLE
refactor: launch sign-screen on comment icon press when customer not logged in

### DIFF
--- a/packages/app/components/comments/comment-row.tsx
+++ b/packages/app/components/comments/comment-row.tsx
@@ -104,7 +104,7 @@ function CommentRowComponent({
     if (reply) {
       reply(comment);
     }
-  }, [reply, comment]);
+  }, [reply, comment, isAuthenticated]);
   //#endregion
 
   return (

--- a/packages/app/components/comments/comment-row.tsx
+++ b/packages/app/components/comments/comment-row.tsx
@@ -96,6 +96,11 @@ function CommentRowComponent({
     setDisplayedRepliesCount((state) => state + REPLIES_PER_BATCH);
   }, []);
   const handleOnReplyPress = useCallback(() => {
+    if (!isAuthenticated) {
+      router.push("/login");
+      return;
+    }
+
     if (reply) {
       reply(comment);
     }


### PR DESCRIPTION
# Why

This is a follow up PR for #941 , this added a functionality to launch the sign-in screen when customer is not logged-in.

# How

https://user-images.githubusercontent.com/4061838/161338278-689a7b93-79c3-4907-93f4-c256083f6641.mov

# Test Plan

- Install the app
- Select any post
- Tap on comment icon
  - App should launch sign-in screen

