### PR TITLE
Always display Play icon on videos in grid

### DIFF
--- a/packages/design-system/media/index.tsx
+++ b/packages/design-system/media/index.tsx
@@ -48,7 +48,11 @@ function Media({
       ]}
     >
       {item?.mime_type?.startsWith("image") ? (
-        <PinchToZoom onPinchStart={onPinchStart} onPinchEnd={onPinchEnd}>
+        <PinchToZoom
+          onPinchStart={onPinchStart}
+          onPinchEnd={onPinchEnd}
+          disabled={numColumns > 1}
+        >
           {numColumns > 1 && item?.mime_type === "image/gif" && (
             <View tw="bg-transparent absolute z-1 bottom-1 right-1">
               <Play height={24} width={24} color="white" />
@@ -69,7 +73,11 @@ function Media({
       ) : null}
 
       {item?.mime_type?.startsWith("video") ? (
-        <PinchToZoom onPinchStart={onPinchStart} onPinchEnd={onPinchEnd}>
+        <PinchToZoom
+          onPinchStart={onPinchStart}
+          onPinchEnd={onPinchEnd}
+          disabled={numColumns > 1}
+        >
           {numColumns > 1 && (
             <View tw="bg-transparent absolute z-1 bottom-1 right-1">
               <Play height={24} width={24} color="white" />

--- a/packages/design-system/pinch-to-zoom/index.tsx
+++ b/packages/design-system/pinch-to-zoom/index.tsx
@@ -14,7 +14,19 @@ import Animated, {
 
 import { useLayout } from "../hooks";
 
-export const PinchToZoom = ({ children, onPinchStart, onPinchEnd }) => {
+type Props = {
+  children: React.ReactNode;
+  onPinchStart?: () => void;
+  onPinchEnd?: () => void;
+  disabled?: boolean;
+};
+
+export const PinchToZoom = ({
+  children,
+  onPinchStart,
+  onPinchEnd,
+  disabled,
+}: Props) => {
   const scale = useSharedValue(1);
   const zIndex = useSharedValue(1);
   const origin = { x: useSharedValue(0), y: useSharedValue(0) };
@@ -113,7 +125,7 @@ export const PinchToZoom = ({ children, onPinchStart, onPinchEnd }) => {
   }, [imageTopForSettingTransformOrigin, imageLeftForSettingTransformOrigin]);
 
   return (
-    <PinchGestureHandler onGestureEvent={handler}>
+    <PinchGestureHandler onGestureEvent={handler} enabled={!disabled}>
       <Animated.View onLayout={onLayout} style={animatedStyles}>
         {children}
       </Animated.View>


### PR DESCRIPTION
# Why

Quick PR to fix the Play icon 

# How

- Changed the view architecture
- Disabled the pinch to zoom when in grid

# Test Plan

Run the app and check a profile with videos