### PR TITLE
fix: add sentry in transformIgnorePatterns

### DIFF
--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -251,7 +251,7 @@
       "@testing-library/jest-native/extend-expect"
     ],
     "transformIgnorePatterns": [
-      "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|dripsy|@dripsy/.*|@walletconnect/.*|@motify/.*|moti|@biconomy/.*)"
+      "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|@sentry/.*|native-base|react-native-svg|dripsy|@dripsy/.*|@walletconnect/.*|@motify/.*|moti|@biconomy/.*)"
     ]
   }
 }


### PR DESCRIPTION
# Why
Currently, test command is failing as sentry module is not transformed and it includes some types.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
Add @sentry/* in transformIgnorePatterns
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
run `yarn test`

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
