### PR TITLE
feat(SHOW2-575): Comments improvements

### DIFF
--- a/packages/app/components/comments/comment-row.tsx
+++ b/packages/app/components/comments/comment-row.tsx
@@ -105,6 +105,9 @@ function CommentRowComponent({
       reply(comment);
     }
   }, [reply, comment, isAuthenticated]);
+  const handleOnTagPress = useCallback((link: string) => {
+    router.push(`/profile/${link}`);
+  }, []);
   //#endregion
 
   return (
@@ -133,6 +136,7 @@ function CommentRowComponent({
         onLikePress={handleOnLikePress}
         onDeletePress={isMyComment ? handleOnDeletePress : undefined}
         onReplyPress={handleOnReplyPress}
+        onTagPress={handleOnTagPress}
       />
       {!isReply
         ? replies.map((reply, index) => (

--- a/packages/app/components/comments/comment-row.tsx
+++ b/packages/app/components/comments/comment-row.tsx
@@ -105,8 +105,8 @@ function CommentRowComponent({
       reply(comment);
     }
   }, [reply, comment, isAuthenticated]);
-  const handleOnTagPress = useCallback((link: string) => {
-    router.push(`/profile/${link}`);
+  const handleOnUserPress = useCallback((username: string) => {
+    router.push(`/profile/${username}`);
   }, []);
   //#endregion
 
@@ -136,7 +136,8 @@ function CommentRowComponent({
         onLikePress={handleOnLikePress}
         onDeletePress={isMyComment ? handleOnDeletePress : undefined}
         onReplyPress={handleOnReplyPress}
-        onTagPress={handleOnTagPress}
+        onTagPress={handleOnUserPress}
+        onUserPress={handleOnUserPress}
       />
       {!isReply
         ? replies.map((reply, index) => (

--- a/packages/app/navigation/root-stack-navigator.tsx
+++ b/packages/app/navigation/root-stack-navigator.tsx
@@ -69,7 +69,7 @@ export function RootStackNavigator() {
       <Stack.Group
         screenOptions={{
           headerShown: false,
-          animation: Platform.OS === "ios" ? "default" : "fade",
+          animation: Platform.OS === "ios" ? "default" : "none",
           presentation:
             Platform.OS === "ios" ? "formSheet" : "transparentModal",
         }}

--- a/packages/app/screens/comments.tsx
+++ b/packages/app/screens/comments.tsx
@@ -1,7 +1,7 @@
-import { Suspense, useCallback, useRef } from "react";
+import { Suspense, useCallback, useEffect, useRef } from "react";
 import { Platform } from "react-native";
 
-import { GestureHandlerRootView } from "react-native-gesture-handler";
+import { useFocusEffect, useIsFocused } from "@react-navigation/native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { Comments } from "app/components/comments";
@@ -34,6 +34,7 @@ export function CommentsScreen() {
   const wasClosedByUserAction = useRef<boolean | undefined>(undefined);
 
   //#region hooks
+  const isModalFocused = useIsFocused();
   const router = useRouter();
   const { top: topSafeArea } = useSafeAreaInsets();
   // @ts-ignore
@@ -46,15 +47,18 @@ export function CommentsScreen() {
     router.back();
   }, [router]);
   const handleOnClose = useCallback(() => {
+    if (!isModalFocused) {
+      return;
+    }
+
     if (!wasClosedByUserAction.current) {
       wasClosedByUserAction.current = true;
       router.back();
     }
-  }, [router]);
+  }, [router, isModalFocused]);
   //#endregion
 
   const CommentsModal = Platform.OS === "android" ? ModalSheet : Modal;
-
   return (
     <CommentsModal
       title="Comments"
@@ -66,6 +70,7 @@ export function CommentsScreen() {
       bodyTW="bg-white dark:bg-black"
       bodyContentTW="p-0"
       scrollable={false}
+      visible={isModalFocused}
     >
       <Suspense
         fallback={<CommentsStatus isLoading={true} error={undefined} />}

--- a/packages/design-system/button/button-base.tsx
+++ b/packages/design-system/button/button-base.tsx
@@ -81,7 +81,7 @@ export function BaseButton({
             ? iconColor
             : iconColor[isDarkMode ? 1 : 0],
         ...iconSize,
-        ...child.props,
+        ...child?.props,
         tw: [
           ...labelStyle,
           child?.props?.tw

--- a/packages/design-system/messages/message-row.tsx
+++ b/packages/design-system/messages/message-row.tsx
@@ -1,6 +1,10 @@
 import { useMemo } from "react";
 
-import { formatDistanceToNowStrict } from "date-fns";
+import {
+  formatDistanceToNowStrict,
+  differenceInSeconds,
+  formatDistance,
+} from "date-fns";
 
 import { Avatar } from "design-system/avatar";
 import { Button, TextButton } from "design-system/button";
@@ -119,15 +123,19 @@ export function MessageRow({
   onUserPress,
 }: MessageRowProps) {
   //#region variables
-  const createdAtText = useMemo(
-    () =>
-      createdAt
-        ? formatDistanceToNowStrict(new Date(createdAt), {
-            addSuffix: true,
-          })
-        : undefined,
-    [createdAt]
-  );
+  const createdAtText = useMemo(() => {
+    if (!createdAt) return undefined;
+
+    const createdAtDate = new Date(createdAt);
+
+    if (differenceInSeconds(new Date(), createdAtDate) < 10) {
+      return "now";
+    }
+
+    return formatDistanceToNowStrict(new Date(createdAt), {
+      addSuffix: true,
+    });
+  }, [createdAt]);
   const contentWithTags = useMemo(
     () =>
       onTagPress

--- a/packages/design-system/messages/message-row.tsx
+++ b/packages/design-system/messages/message-row.tsx
@@ -1,12 +1,12 @@
 import { useMemo } from "react";
 
 import { formatDistanceToNowStrict } from "date-fns";
+import reactStringReplace from "react-string-replace";
 
 import { Avatar } from "design-system/avatar";
-import { TextButton } from "design-system/button";
-import { Button } from "design-system/button";
+import { Button, TextButton } from "design-system/button";
 import { HeartFilled, Heart, MessageFilled, Message } from "design-system/icon";
-import { Text } from "design-system/text";
+import { Text, linkify } from "design-system/text";
 import { VerificationBadge } from "design-system/verification-badge";
 import { View } from "design-system/view";
 
@@ -88,6 +88,11 @@ interface MessageRowProps {
    * @default undefined
    */
   onReplyPress?: () => void;
+  /**
+   * Defines the content tag press callback
+   * @default undefined
+   */
+  onTagPress?: (tag: string) => void;
 }
 
 export function MessageRow({
@@ -106,6 +111,7 @@ export function MessageRow({
   onLikePress,
   onDeletePress,
   onReplyPress,
+  onTagPress,
 }: MessageRowProps) {
   //#region variables
   const createdAtText = useMemo(
@@ -116,6 +122,21 @@ export function MessageRow({
           })
         : undefined,
     [createdAt]
+  );
+  const contentWithTags = useMemo(
+    () =>
+      onTagPress
+        ? linkify(content, (text: string, link: string) => (
+            <Text
+              key={`link-${link}`}
+              tw="font-bold text-black dark:text-white"
+              onPress={() => onTagPress(link)}
+            >
+              {`@${text} `}
+            </Text>
+          ))
+        : content,
+    [content, onTagPress]
   );
   //#endregion
 
@@ -150,7 +171,7 @@ export function MessageRow({
     }),
     [position, hasParent]
   );
-  //#region
+  //#endregion
   return (
     <View tw="flex flex-row py-4 bg-white dark:bg-black">
       {hasParent && <View tw="ml-8" collapsable={true} />}
@@ -180,7 +201,7 @@ export function MessageRow({
           tw="text-gray-900 dark:text-gray-100"
           sx={{ fontSize: 13, lineHeight: 15 }}
         >
-          {content}
+          {contentWithTags}
         </Text>
 
         <View tw="flex-row ml--2 mt-2 mb--2">

--- a/packages/design-system/messages/message-row.tsx
+++ b/packages/design-system/messages/message-row.tsx
@@ -1,7 +1,6 @@
 import { useMemo } from "react";
 
 import { formatDistanceToNowStrict } from "date-fns";
-import reactStringReplace from "react-string-replace";
 
 import { Avatar } from "design-system/avatar";
 import { Button, TextButton } from "design-system/button";
@@ -93,10 +92,15 @@ interface MessageRowProps {
    * @default undefined
    */
   onTagPress?: (tag: string) => void;
+  /**
+   * Defines the user press callback
+   * @default undefined
+   */
+  onUserPress?: (username: string) => void;
 }
 
 export function MessageRow({
-  username,
+  username = "",
   userAvatar,
   userVerified = false,
   content = "",
@@ -112,6 +116,7 @@ export function MessageRow({
   onDeletePress,
   onReplyPress,
   onTagPress,
+  onUserPress,
 }: MessageRowProps) {
   //#region variables
   const createdAtText = useMemo(
@@ -182,13 +187,22 @@ export function MessageRow({
             <View tw={replyVerticalLineTW} />
           </>
         )}
-        <Avatar url={userAvatar} size={24} />
+        <Button
+          variant="secondary"
+          size="small"
+          tw="h-[24px] w-[24px]"
+          onPress={onUserPress ? () => onUserPress(username) : undefined}
+          iconOnly
+        >
+          <Avatar url={userAvatar} size={24} />
+        </Button>
       </View>
       <View tw="flex-1 ml-2">
         <View tw="mb-3 h-[12px] flex-row items-center">
           <Text
             sx={{ fontSize: 13, lineHeight: 15 }}
             tw="text-gray-900 dark:text-white font-semibold"
+            onPress={onUserPress ? () => onUserPress(username) : undefined}
           >
             @{username}
           </Text>

--- a/packages/design-system/modal-sheet/index.tsx
+++ b/packages/design-system/modal-sheet/index.tsx
@@ -33,8 +33,8 @@ export function ModalSheet({ visible = true, bodyContentTW, ...props }: Props) {
         title={props.title}
         close={() => {
           // TODO: extract `onClose` to a proper unmount transition completion event.
-          props.close();
-          props.onClose();
+          props.close?.();
+          props.onClose?.();
         }}
       >
         {props.children}

--- a/packages/design-system/text/index.tsx
+++ b/packages/design-system/text/index.tsx
@@ -95,3 +95,5 @@ export const Text = forwardRef<TextType, Props>(
 );
 
 Text.displayName = "Text";
+
+export { linkify } from "./linkify";

--- a/packages/design-system/text/linkify.ts
+++ b/packages/design-system/text/linkify.ts
@@ -1,0 +1,17 @@
+import { ReactNode } from "react";
+
+const regex = /\[(\w.+)\]\((\w.+)\)/;
+
+export const linkify = (
+  text: string,
+  renderComponent: (text: string, link: string) => ReactNode
+) => {
+  const result = text.split(" ").map((word) => {
+    if (!regex.test(word)) {
+      return word + " ";
+    }
+    const match = [...word.match(regex)!];
+    return renderComponent(match[1], match[2]);
+  });
+  return result;
+};


### PR DESCRIPTION
# Why

This PR will introduce:

- Added `now` to comment creation time.
- Added tap events on comment owner avatar and username.
- Added `linkify` utility method to parse markdown links in comment content.

https://linear.app/showtime/issue/SHOW2-575/comments-improvements

# How

https://user-images.githubusercontent.com/4061838/162047253-f10d551b-fcc8-47c7-a5f2-30dc11718088.mov

# Test Plan

- Install and launch the app
- Select any post with comments
- Tap on any comment username
  - It should navigate to username profile
- Tap on any comment avatar
  - It should navigate to username profile
- Add a new comment 
  - it should indicate `now` as creation time
