### PR TITLE
nit: edit profile done button logic

### DIFF
--- a/packages/app/components/edit-profile.tsx
+++ b/packages/app/components/edit-profile.tsx
@@ -174,7 +174,7 @@ export const EditProfile = () => {
       mutate(MY_INFO_ENDPOINT);
       mutate(USER_PROFILE_KEY + user?.data.profile.wallet_addresses[0]);
 
-      router.replace(`/profile/${user?.data.profile.wallet_addresses[0]}`);
+      router.pop();
     } catch (e) {
       setError("submitError", { message: "Something went wrong" });
       console.error("edit profile failed ", e);


### PR DESCRIPTION
# Why
Current logic stacks the profile screen on top of edit screen. We just need to pop the edit screen.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# Test Plan
- Go to edit profile and press submit button
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
