### PR TITLE
fix: added pathname to useRouter

### DIFF
--- a/packages/app/navigation/use-router.ts
+++ b/packages/app/navigation/use-router.ts
@@ -1,11 +1,25 @@
+import {
+  useNavigation as useNativeRouter,
+  NavigationState,
+} from "@react-navigation/native";
 import { useRouter as SolitoRouter } from "solito/router";
 
+const getPath = (navigationState: NavigationState) => {
+  return (
+    navigationState?.routes?.[navigationState?.index]?.path ??
+    navigationState?.routes?.[navigationState?.index]?.state?.routes[0]?.path ??
+    "/"
+  );
+};
+
 export function useRouter() {
+  const { getState } = useNativeRouter();
   const solitoRouter = SolitoRouter();
   return {
     ...solitoRouter,
     pop: () => {
       solitoRouter.back();
     },
+    pathname: getPath(getState()),
   };
 }

--- a/packages/app/navigation/use-router.web.ts
+++ b/packages/app/navigation/use-router.web.ts
@@ -1,0 +1,15 @@
+import { useRouter as useNextRouter } from "next/router";
+import { useRouter as SolitoRouter } from "solito/router";
+
+export function useRouter() {
+  const { pathname } = useNextRouter();
+  const solitoRouter = SolitoRouter();
+
+  return {
+    ...solitoRouter,
+    pop: () => {
+      solitoRouter.back();
+    },
+    pathname,
+  };
+}


### PR DESCRIPTION
# Why

#956 introduce a crash on when trying to access `useRouter() -> pathname` in `Creator` & ` LikedBy` components. 

# How

I have added pathname from react navigation and next router to the use router.

# Test Plan

- Launch tha app.
- Tap on any NFT post.
- App should not crash.
