### PR TITLE
fix: nfts not appearing after some scroll on web

### DIFF
--- a/packages/app/components/viewability-tracker-swipe-list.tsx
+++ b/packages/app/components/viewability-tracker-swipe-list.tsx
@@ -65,6 +65,7 @@ export const ViewabilityTrackerRecyclerList = forwardRef(
           rowRenderer={rowRenderer}
           ref={ref}
           onVisibleIndicesChanged={onVisibleIndicesChanged}
+          useWindowScroll={Platform.OS === "web"}
         />
       </ViewabilityItemsContext.Provider>
     );


### PR DESCRIPTION
# Why
NFTs not appearing after some scroll on web. Added a prop `useWindowScroll` that uses the window scroll instead of adding a container. That fixed the issue and I think it's common to use window scroll on web app


# Test Plan
Open feed and scroll. NFTs should be visible
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
