### PR TITLE
change: pass file uri with context

### DIFF
--- a/packages/app/components/create.tsx
+++ b/packages/app/components/create.tsx
@@ -60,11 +60,7 @@ const createNFTValidationSchema = yup.object({
   description: yup.string(),
 });
 
-interface CreateProps {
-  uri: string;
-}
-
-function Create({ uri }: CreateProps) {
+function Create() {
   const router = useRouter();
   const { user } = useUser();
   const { web3 } = useWeb3();
@@ -76,8 +72,10 @@ function Create({ uri }: CreateProps) {
 
   const handleSubmitForm = (values: Omit<UseMintNFT, "filePath">) => {
     console.log("** Submiting minting form **", values);
-    const valuesWithFilePath = { ...values, filePath: uri };
-    startMinting(valuesWithFilePath);
+    if (state.filePath) {
+      const valuesWithFilePath = { ...values, filePath: state.filePath };
+      startMinting(valuesWithFilePath);
+    }
   };
 
   const {
@@ -93,7 +91,7 @@ function Create({ uri }: CreateProps) {
   //#endregion
 
   const isDark = useIsDarkMode();
-  const fileExtension = uri.split(".").pop();
+  const fileExtension = state.filePath?.split(".").pop();
   const isVideo =
     fileExtension && supportedVideoExtensions.includes(fileExtension);
   const Preview = isVideo ? Video : Image;
@@ -130,12 +128,14 @@ function Create({ uri }: CreateProps) {
             testID="data-private"
           >
             <View tw="z-1">
-              <Preview
-                source={{
-                  uri,
-                }}
-                tw="w-20 h-20 rounded-2xl"
-              />
+              {state.filePath ? (
+                <Preview
+                  source={{
+                    uri: state.filePath,
+                  }}
+                  tw="w-20 h-20 rounded-2xl"
+                />
+              ) : null}
             </View>
             <View tw="ml--2 flex-1">
               <Controller

--- a/packages/app/hooks/use-mint-nft.ts
+++ b/packages/app/hooks/use-mint-nft.ts
@@ -19,6 +19,7 @@ const MAX_FILE_SIZE = 50 * 1024 * 1024; // in bytes
 export type MintNFTStatus =
   | "idle"
   | "mediaUpload"
+  | "setMedia"
   | "mediaUploadError"
   | "mediaUploadSuccess"
   | "nftJSONUpload"
@@ -38,6 +39,7 @@ export type MintNFTType = {
   isMagic?: boolean;
   filePath?: string;
   fileType?: string;
+  fileObject?: File;
 };
 
 export const initialMintNFTState: MintNFTType = {
@@ -59,6 +61,8 @@ export type ActionPayload = {
   isMagic?: boolean;
   filePath?: string;
   fileType?: string;
+  // web-only
+  fileObject?: File;
 };
 
 export const mintNFTReducer = (
@@ -66,6 +70,14 @@ export const mintNFTReducer = (
   action: { type: MintNFTStatus; payload?: ActionPayload }
 ): MintNFTType => {
   switch (action.type) {
+    case "setMedia": {
+      return {
+        ...state,
+        filePath: action.payload?.filePath,
+        fileType: action.payload?.fileType,
+        fileObject: action.payload?.fileObject,
+      };
+    }
     case "mediaUpload":
       return {
         ...state,
@@ -393,5 +405,15 @@ export const useMintNFT = () => {
 
   console.log("minting state ", state);
 
-  return { state, startMinting: mintNFT };
+  const setMedia = ({
+    filePath,
+    fileObject,
+  }: {
+    filePath?: string;
+    fileObject?: File;
+  }) => {
+    dispatch({ type: "setMedia", payload: { filePath, fileObject } });
+  };
+
+  return { state, startMinting: mintNFT, setMedia };
 };

--- a/packages/app/screens/camera.tsx
+++ b/packages/app/screens/camera.tsx
@@ -5,6 +5,7 @@ import { View, Text } from "dripsy";
 import { useTimer } from "use-timer";
 
 import { Camera } from "app/components/camera";
+import { useMintNFT } from "app/hooks/use-mint-nft";
 import { useUser } from "app/hooks/use-user";
 import { useNavigation } from "app/lib/react-navigation/native";
 import { useRouter } from "app/navigation/use-router";
@@ -18,17 +19,20 @@ function CameraScreen() {
   const [photos, setPhotos] = useState([]);
   const [canPop, setCanPop] = useState(true);
   const [isLoading, setIsLoading] = useState(false);
+  const { setMedia } = useMintNFT();
 
   const postPhoto = useCallback(
     (photoURI: string) => {
-      const createPostURL = `/create?uri=${photoURI}`;
+      setMedia({ filePath: photoURI });
+
+      const createPostURL = `/create?form=true`;
       if (isAuthenticated) {
         router.push(
           Platform.select({
             native: createPostURL,
             web: {
               pathname: router.pathname,
-              query: { ...router.query, create: true, uri: photoURI },
+              query: { ...router.query, create: true, form: true },
             },
           }),
           createPostURL,

--- a/packages/app/screens/create.tsx
+++ b/packages/app/screens/create.tsx
@@ -13,17 +13,16 @@ import { withModalScreen } from "app/navigation/with-modal-screen";
 import { Modal, ModalSheet } from "design-system";
 
 type Query = {
-  uri: string;
+  form: string;
 };
 
 const { useParam } = createParam<Query>();
-
 const CreateModal = () => {
   useHideHeader();
   //#region hooks
   const router = useRouter();
   const navigation = useNavigation();
-  const [uri] = useParam("uri");
+  const [form] = useParam("form");
   const { state } = useContext(MintContext);
   //#endregion
 
@@ -73,7 +72,7 @@ const CreateModal = () => {
   }, [navigation, router]);
   //#endregion
 
-  if (!uri) {
+  if (!form) {
     return null;
   }
 
@@ -86,7 +85,7 @@ const CreateModal = () => {
       bodyTW="bg-white dark:bg-black"
       bodyContentTW="p-0"
     >
-      <Create uri={uri} />
+      <Create />
     </ModalComponent>
   );
 };


### PR DESCRIPTION
# Why
- This PR is a part of `create NFT` on web. Want to merge often so I don't break anything on native. 

- Use context state instead of query parameters to pass the file path. On web, we don't get the file path with file picker, instead we get a file object or a data URI which can't be passed with query parameters. (data URI can be passed but are huge, there's some limit AFAIK depending on the browser so we can't rely on query parameters)
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
Use the existing mint-nft context state to set the file path early before opening the create screen.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
Minting should work on mobile.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
