### PR TITLE
fix: web profile tabs

### DIFF
--- a/packages/design-system/tabs/tablib/index.web.tsx
+++ b/packages/design-system/tabs/tablib/index.web.tsx
@@ -3,6 +3,8 @@ import { ScrollView, FlatList, SectionList, Animated } from "react-native";
 
 import * as RadixTabs from "@radix-ui/react-tabs";
 
+import { flattenChildren } from "app/utilities";
+
 import { tw } from "../../tailwind";
 import { View } from "../../view";
 import { TabRootProps } from "./types";
@@ -46,13 +48,14 @@ const Root = ({
       let tabContents = [];
       let headerChild;
       let listChild = {};
-      React.Children.forEach(children, (c) => {
+
+      flattenChildren(children).forEach((c) => {
         if (React.isValidElement(c)) {
           //@ts-ignore
           if (c.type === List) {
             listChild = c;
             //@ts-ignore
-            React.Children.map(c.props.children, (c) => {
+            flattenChildren(c.props.children).forEach((c) => {
               if (React.isValidElement(c) && c && c.type === Trigger) {
                 tabTriggers.push(c);
               }
@@ -63,7 +66,7 @@ const Root = ({
             //@ts-ignore
           } else if (c.type === Pager) {
             //@ts-ignore
-            React.Children.map(c.props.children, (c) => {
+            flattenChildren(c.props.children).forEach((c) => {
               tabContents.push(c);
             });
           }


### PR DESCRIPTION
# Why
Fixes profile tabs on web. FlatList lacks the window scroll like Recyclerlist. Maybe we should migrate to Recyclerlist. Have also seen better performance on native with it.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- Flatten children
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Navigate to profile, tabs should load
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
