### PR TITLE
feat: add bottom gap for modal and sheet

### DIFF
--- a/packages/design-system/bottom-sheet/index.tsx
+++ b/packages/design-system/bottom-sheet/index.tsx
@@ -15,6 +15,8 @@ import {
   BottomSheetTextInput as BottomSheetInput,
 } from "@gorhom/bottom-sheet";
 
+import { useSafeAreaInsets } from "app/lib/safe-area";
+
 import { tw as tailwind } from "design-system/tailwind";
 import type { TW } from "design-system/tailwind/types";
 import { View } from "design-system/view";
@@ -37,8 +39,8 @@ export const BottomSheet = (props: BottomSheetProps) => {
     snapPoints,
     bodyContentTW = "",
   } = props;
-
   const bottomSheetModalRef = useRef<BottomSheetModal>(null);
+  const { bottom: safeAreaBottom } = useSafeAreaInsets();
 
   useEffect(() => {
     if (visible) {
@@ -76,7 +78,9 @@ export const BottomSheet = (props: BottomSheetProps) => {
       )}
       snapPoints={snapPoints ?? defaultSnapPoints}
     >
-      <View tw={["flex-1 pt-6 px-4", bodyContentTW]}>{children}</View>
+      <View tw={[`flex-1 pt-6 px-4 mb-[${safeAreaBottom}px]`, bodyContentTW]}>
+        {children}
+      </View>
     </BottomSheetModal>
   );
 };

--- a/packages/design-system/modal/index.tsx
+++ b/packages/design-system/modal/index.tsx
@@ -1,6 +1,8 @@
 import React, { useMemo } from "react";
 import { KeyboardAvoidingView, Platform, StyleSheet } from "react-native";
 
+import { useSafeAreaInsets } from "app/lib/safe-area";
+
 import { View } from "design-system/view";
 
 import { ModalBackdrop } from "./backdrop";
@@ -45,13 +47,15 @@ export function Modal({
   modalWrapper,
   children,
 }: ModalProps) {
+  const { bottom: safeAreaBottom } = useSafeAreaInsets();
+
   const ModalContainer = useMemo(
     () => createModalContainer(modalWrapper),
     [modalWrapper]
   );
   return (
     <ModalContainer onDismiss={onDismiss}>
-      <View tw={CONTAINER_TW}>
+      <View tw={`${CONTAINER_TW} mb-[${safeAreaBottom}px]`}>
         <ModalBackdrop close={close} />
         <ModalKeyboardAvoidingView
           style={{


### PR DESCRIPTION
# Why

When we open the NFT details modal and if the details are long, the bottom of the details goes under the notch.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Gave extra gap with the safe area values to the both modal and modal sheet.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Opening details with long content in both phones have notch and not.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
