### PR TITLE
fix: webp memory crash

### DIFF
--- a/apps/expo/plugins/with-fast-image-webp-support-ios.js
+++ b/apps/expo/plugins/with-fast-image-webp-support-ios.js
@@ -12,8 +12,11 @@ const RNFI_EXPO_WEBP_DID_FINISH_LAUNCHING_IDENTIFIER = `- (BOOL)application:(UIA
 {`;
 
 const RNFI_EXPO_WEBP_DID_FINISH_LAUNCHING_CODE = `
-[SDImageCodersManager.sharedManager addCoder:SDImageWebPCoder.sharedCoder];
-[[SDWebImageDownloader sharedDownloader] setValue:@"image/webp,image/*,*/*;q=0.8" forHTTPHeaderField:@"Accept"];
+if (@available(iOS 14, *)) {
+} else {
+  [SDImageCodersManager.sharedManager addCoder:SDImageWebPCoder.sharedCoder];
+  [[SDWebImageDownloader sharedDownloader] setValue:@"image/webp,image/*,*/*;q=0.8" forHTTPHeaderField:@"Accept"];
+}
 `;
 
 function modifyAppDelegate(appDelegate) {

--- a/apps/storybook-react-native/plugins/with-fast-image-webp-support-ios.js
+++ b/apps/storybook-react-native/plugins/with-fast-image-webp-support-ios.js
@@ -12,8 +12,11 @@ const RNFI_EXPO_WEBP_DID_FINISH_LAUNCHING_IDENTIFIER = `- (BOOL)application:(UIA
 {`;
 
 const RNFI_EXPO_WEBP_DID_FINISH_LAUNCHING_CODE = `
-[SDImageCodersManager.sharedManager addCoder:SDImageWebPCoder.sharedCoder];
-[[SDWebImageDownloader sharedDownloader] setValue:@"image/webp,image/*,*/*;q=0.8" forHTTPHeaderField:@"Accept"];
+if (@available(iOS 14, *)) {
+} else {
+  [SDImageCodersManager.sharedManager addCoder:SDImageWebPCoder.sharedCoder];
+  [[SDWebImageDownloader sharedDownloader] setValue:@"image/webp,image/*,*/*;q=0.8" forHTTPHeaderField:@"Accept"];
+}
 `;
 
 function modifyAppDelegate(appDelegate) {

--- a/packages/app/components/viewability-tracker-flatlist.tsx
+++ b/packages/app/components/viewability-tracker-flatlist.tsx
@@ -1,9 +1,9 @@
 import { createContext, forwardRef, useCallback, useMemo } from "react";
-import { FlatList, FlatListProps, ViewToken } from "react-native";
+import { FlatList, FlatListProps } from "react-native";
 
 import Animated, { useSharedValue } from "react-native-reanimated";
 
-const MAX_VIEWABLE_ITEMS = 2;
+import { VideoConfigContext } from "app/context/video-config-context";
 
 type ViewabilityItemsContextType = any[];
 
@@ -30,28 +30,21 @@ export const ViewabilityTrackerFlatlist = forwardRef(
       [_renderItem, keyExtractor]
     );
 
-    const onViewableItemsChanged = useCallback(({ viewableItems }: any) => {
-      visibleItems.value = viewableItems
-        .slice(0, MAX_VIEWABLE_ITEMS)
-        .map((item: any) => item.key);
-    }, []);
+    const videoConfig = useMemo(
+      () => ({
+        isMuted: true,
+        useNativeControls: false,
+        previewOnly: true,
+      }),
+      []
+    );
 
     return (
-      <ViewabilityItemsContext.Provider value={visibleItems}>
-        <FlatList
-          {...props}
-          onViewableItemsChanged={onViewableItemsChanged}
-          ref={ref}
-          viewabilityConfig={useMemo(
-            () => ({
-              itemVisiblePercentThreshold: 50,
-              minimumViewTime: 100,
-            }),
-            []
-          )}
-          renderItem={renderItem}
-        />
-      </ViewabilityItemsContext.Provider>
+      <VideoConfigContext.Provider value={videoConfig}>
+        <ViewabilityItemsContext.Provider value={visibleItems}>
+          <FlatList {...props} ref={ref} renderItem={renderItem} />
+        </ViewabilityItemsContext.Provider>
+      </VideoConfigContext.Provider>
     );
   }
 );

--- a/packages/app/context/video-config-context.ts
+++ b/packages/app/context/video-config-context.ts
@@ -3,11 +3,13 @@ import React, { createContext } from "react";
 type VideoConfigContextType = {
   isMuted: boolean;
   useNativeControls: boolean;
+  previewOnly?: boolean;
 };
 
 export const VideoConfigContext = createContext<VideoConfigContextType | null>({
   isMuted: true,
   useNativeControls: false,
+  previewOnly: false,
 });
 
 export const useVideoConfig = () => {

--- a/packages/design-system/video/index.tsx
+++ b/packages/design-system/video/index.tsx
@@ -23,19 +23,28 @@ function Video({ tw, style, ...props }: VideoProps) {
   return (
     <>
       <View style={[style, tailwind.style(tw)]}>
-        <FastImage
-          //@ts-ignore
-          source={props.posterSource}
-          style={StyleSheet.absoluteFill}
-        />
+        {videoConfig?.previewOnly ? (
+          <FastImage
+            style={StyleSheet.absoluteFill}
+            source={props.posterSource}
+          />
+        ) : (
+          <>
+            <FastImage
+              //@ts-ignore
+              source={props.posterSource}
+              style={StyleSheet.absoluteFill}
+            />
 
-        <ExpoVideo
-          ref={videoRef}
-          style={StyleSheet.absoluteFill}
-          useNativeControls={videoConfig?.useNativeControls}
-          resizeMode="cover"
-          posterSource={props.posterSource}
-        />
+            <ExpoVideo
+              ref={videoRef}
+              style={StyleSheet.absoluteFill}
+              useNativeControls={videoConfig?.useNativeControls}
+              resizeMode="cover"
+              posterSource={props.posterSource}
+            />
+          </>
+        )}
 
         {__DEV__ ? (
           <Text


### PR DESCRIPTION
# Why
- Fixes [out of memory crash](https://sentry.io/organizations/showtime-l3/issues/3145254431/?environment=production&project=5860034&query=is%3Aunresolved)
- expo av's play pause leads to frame drops. So, for now showing just preview in grids, we need a player turbo module. I should've continued working on it 😭 

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- Remove SDImageWebPCoder decoder on ios < 14. iOS 14 has built in webp support. Animated webp shows the first frame.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Try opening trending nfts on each tabs, try scrolling and make sure it doesn't crash.

# Todo
- Test performance in iOS < 14 and play with some configs https://github.com/SDWebImage/SDWebImage/wiki/Common-Problems#configuration-to-reduce-memory-pressure-aggressive
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
