### PR TITLE
refactor: update bump version script

### DIFF
--- a/apps/expo/scripts/bump-version.mjs
+++ b/apps/expo/scripts/bump-version.mjs
@@ -58,7 +58,7 @@ try {
   const rootPath = "./apps/expo"
   const monorepoRootPath = "../.."
   const dirtyPath = "apps/expo/package.json";
-  const reactNativeConfigPath = "./node_modules/.bin/react-native"
+  const reactNativeConfigPath = "../../node_modules/.bin/react-native"
   const currentApplicationVersion = applicationPackage.version
 
   // As a monorepo the version must be bumped from the root directory not the working project.
@@ -104,7 +104,7 @@ try {
       console.log(`Since last release there have ${chalk.green("been")} changes to ${chalk.green(dirtyPath)}`)
       
       // Returns the string diff of the package.json with just the lines added and removed 
-      const fileDiffResponse = await $`git diff ${lastReleaseCommitId} ${currentCommitHeadId}  --unified=0 ${dirtyPath} | grep '^[+|-][^+|-]'`
+      const fileDiffResponse = await $`git diff ${lastReleaseCommitId} ${currentCommitHeadId} --unified=0 ${dirtyPath} | grep '^[+|-][^+|-]'`
       // Sanitizes the diff string into an array of strings that are the "keys" for just added lines
       const fileDiffSanitized = fileDiffResponse.stdout
         .split('\n')


### PR DESCRIPTION
# Why

Bump version script trying to run `react-native config` command in the `/apps/expo` root. But the actual can be run in the root. 

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Changing the `reactNativeConfigPath` to go to the root. 
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Running actions again :D 
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
