### PR TITLE
fix(tailwind): remove redundant configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,6 @@
     "source.fixAll.eslint": true,
     "source.organizeImports": false
   },
-  "tailwindCSS.classAttributes": ["class", "className", "ngClass", "tw"],
   "tailwindCSS.experimental.classRegex": [
     "tw`([^`]*)", // tw`...`
     "tw=\"([^\"]*)", // <View tw="..." />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->
`tailwindCSS.classAttributes` and `tailwindCSS.experimental.classRegex` are redundant, removed `classAttributes` to fixed.

# How

<!--
How did you build this feature or fix this bug and why?
-->
Edit `vscode`'s setting.json config.
# Test Plan

No testing required.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
### Snapshot 

Before: 
![image](https://user-images.githubusercontent.com/37520667/163547453-05816e15-02aa-4955-b6a0-4e2d0a1f2c31.png)

After:
![image](https://user-images.githubusercontent.com/37520667/163547491-13796f2f-fa60-44c1-a5c3-fe6c2322bbc7.png)

