### PR TITLE
Improve the Expo Production action

### DIFF
--- a/.github/workflows/expo-production.yml
+++ b/.github/workflows/expo-production.yml
@@ -57,6 +57,7 @@ jobs:
           cd ../apps/expo
 
       - name: Application Version Bump
+        id: version
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: yarn bump-application-version
 
@@ -70,7 +71,9 @@ jobs:
           token: ${{ secrets.EXPO_TOKEN }}
 
       - name: EAS Update
+        if: steps.version.outputs.type == 'patch'
         run: NODE_OPTIONS=--max_old_space_size=4096 EXPO_DEBUG=true STAGE=production eas update --branch production --message "Deploy to production"
 
       - name: Build on EAS
+        if: steps.version.outputs.type == 'major'
         run: STAGE=production eas build --platform all --non-interactive --no-wait --auto-submit


### PR DESCRIPTION
# Why

The `/promote` command never worked. https://github.com/tryshowtime/showtime-frontend/pull/987 + https://github.com/tryshowtime/showtime-frontend/commit/b4baab40eb71602a321169753209fa79b85840a7 + this PR is the current work in progress to make it work seamlessly. Note that I also updated the Slack promote copywriting and GitHub access token to prevent any potential issues

# How

Improve bump version script and expo production gh action

# Test Plan

Merge this PR and try to run `/promote native` on Slack