### PR TITLE
rever: menu item order

### DIFF
--- a/patches/@react-native-menu+menu+0.5.2.patch
+++ b/patches/@react-native-menu+menu+0.5.2.patch
@@ -1,15 +1,8 @@
 diff --git a/node_modules/@react-native-menu/menu/ios/MenuView.swift b/node_modules/@react-native-menu/menu/ios/MenuView.swift
-index 4400f47..a130fab 100644
+index 4400f47..72b06bd 100644
 --- a/node_modules/@react-native-menu/menu/ios/MenuView.swift
 +++ b/node_modules/@react-native-menu/menu/ios/MenuView.swift
-@@ -17,12 +17,23 @@ class MenuView: UIButton {
-                 return
-             }
-             _actions.removeAll()
--            actions.forEach { menuAction in
-+            actions.reversed().forEach { menuAction in
-                 _actions.append(RCTMenuAction(details: menuAction).createUIMenuElement({action in self.sendButtonAction(action)}))
-             }
+@@ -23,6 +23,17 @@ class MenuView: UIButton {
              self.setup()
          }
      }
@@ -24,7 +17,7 @@ index 4400f47..a130fab 100644
 +            self.setup()
 +        }
 +    }
- 
+         
      private var _title: String = "";
      @objc var title: NSString? {
 @@ -34,6 +45,7 @@ class MenuView: UIButton {
@@ -39,7 +32,7 @@ diff --git a/node_modules/@react-native-menu/menu/ios/RCTUIMenuManager.m b/node_
 index 45543d8..a61716c 100644
 --- a/node_modules/@react-native-menu/menu/ios/RCTUIMenuManager.m
 +++ b/node_modules/@react-native-menu/menu/ios/RCTUIMenuManager.m
-@@ -20,4 +20,6 @@ RCT_EXPORT_VIEW_PROPERTY(onPressAction, RCTDirectEventBlock);
+@@ -20,4 +20,6 @@ @interface RCT_EXTERN_MODULE(RCTUIMenu, RCTViewManager)
   */
  RCT_EXPORT_VIEW_PROPERTY(shouldOpenOnLongPress, BOOL)
  


### PR DESCRIPTION
## Why?

- Noticed header dropdown is revered in new release. Sign out button shows up on top.
- Seems the menu-item order we fixed was a feature and not a bug. Since menu opens in reverse order in swipe-list (due to less space) it gets reversed. Same menu component in header shows items in right order .
- https://user-images.githubusercontent.com/23293248/163567178-f26431df-e7dc-4d52-91d0-a8a30b1ce64f.MP4

## How?
- Reverts the patch

## Test
- Test menu in swipelist and in header
