### PR TITLE
feat: add horizontal gesture swipeable gesture handler

### DIFF
--- a/packages/design-system/tabs/tablib/calculations.ts
+++ b/packages/design-system/tabs/tablib/calculations.ts
@@ -1,0 +1,77 @@
+import { PanGestureHandlerEventPayload } from "react-native-gesture-handler";
+import { SharedValue, withSpring } from "react-native-reanimated";
+
+import {
+  MIN_VELOCITY_Y_TO_ACTIVATE,
+  SNAP_POINTS_HORIZONTAL_AS_ARRAY,
+  SPRING_CONFIG,
+  SCREEN_WIDTH,
+} from "./constants";
+
+type handleOnUpdateHorizontalProps = {
+  e: PanGestureHandlerEventPayload;
+  startX: SharedValue<number>;
+  offsetX: SharedValue<number>;
+};
+
+const getNextSnapPoint = (offset: number) => {
+  "worklet";
+
+  let nextSnapPointAvailable = false;
+  let snapPoint = 0;
+
+  for (let i = 0; i < 5; i += 2) {
+    if (
+      offset <= SNAP_POINTS_HORIZONTAL_AS_ARRAY[i - 1] &&
+      offset >= SNAP_POINTS_HORIZONTAL_AS_ARRAY[i + 1]
+    ) {
+      snapPoint = SNAP_POINTS_HORIZONTAL_AS_ARRAY[i];
+      nextSnapPointAvailable = true;
+    }
+  }
+
+  return nextSnapPointAvailable ? snapPoint : 0;
+};
+
+export const handleOnEndHorizontal = ({
+  e,
+  startX,
+  offsetX,
+}: handleOnUpdateHorizontalProps & {
+  destination: SharedValue<number>;
+}) => {
+  "worklet";
+
+  const velocity = Math.abs(e.velocityX);
+  const nextXValue =
+    e.translationX < 0
+      ? offsetX.value - SCREEN_WIDTH
+      : offsetX.value + SCREEN_WIDTH;
+
+  startX.value = startX.value + e.translationX;
+  let nextSnapPoint;
+
+  if (velocity > MIN_VELOCITY_Y_TO_ACTIVATE) {
+    nextSnapPoint = getNextSnapPoint(nextXValue);
+    if (nextSnapPoint !== -1) {
+      offsetX.value = withSpring(nextSnapPoint, {
+        ...SPRING_CONFIG,
+        velocity,
+      });
+      startX.value = withSpring(nextSnapPoint, {
+        ...SPRING_CONFIG,
+        velocity,
+      });
+    }
+  } else {
+    nextSnapPoint = getNextSnapPoint(offsetX.value + e.translationX);
+    offsetX.value = withSpring(nextSnapPoint, {
+      ...SPRING_CONFIG,
+      velocity,
+    });
+    startX.value = withSpring(nextSnapPoint, {
+      ...SPRING_CONFIG,
+      velocity,
+    });
+  }
+};

--- a/packages/design-system/tabs/tablib/constants.ts
+++ b/packages/design-system/tabs/tablib/constants.ts
@@ -1,0 +1,32 @@
+import { Dimensions } from "react-native";
+
+const { width, height } = Dimensions.get("screen");
+
+export const SCREEN_WIDTH = width;
+export const SCREEN_HEIGHT = height;
+
+export const MIN_VELOCITY_Y_TO_ACTIVATE = 100;
+
+export const SPRING_CONFIG = {
+  damping: 500,
+  stiffness: 1000,
+  mass: 3,
+  overshootClamping: true,
+  restDisplacementThreshold: 10,
+  restSpeedThreshold: 10,
+};
+
+export const SNAP_POINTS_HORIZONTAL = {
+  ORIGIN: 0,
+  FIRST_PAGE_HALF: SCREEN_WIDTH / -2,
+  SECOND_PAGE: SCREEN_WIDTH * -1,
+  SECOND_PAGE_HALF: (SCREEN_WIDTH * -3) / 2,
+};
+
+export const SNAP_POINTS_HORIZONTAL_AS_ARRAY = [
+  0,
+  SCREEN_WIDTH / -2,
+  SCREEN_WIDTH * -1,
+  (SCREEN_WIDTH * -3) / 2,
+  SCREEN_WIDTH * -2,
+];

--- a/packages/design-system/tabs/tablib/useGestureHandler.ts
+++ b/packages/design-system/tabs/tablib/useGestureHandler.ts
@@ -1,0 +1,42 @@
+import { Gesture } from "react-native-gesture-handler";
+import { SharedValue, useSharedValue } from "react-native-reanimated";
+
+import { handleGestureOnEnd, handleGestureOnUpdate } from "./utils";
+
+type useGestureHandlerProps = {
+  startX: SharedValue<number>;
+  offsetX: SharedValue<number>;
+  offsetY?: SharedValue<number>;
+};
+
+const useGestureHandler = ({
+  startX,
+  offsetX,
+  offsetY,
+}: useGestureHandlerProps) => {
+  const destination = useSharedValue(0);
+
+  const swipeableProviderGesture = Gesture.Pan()
+    .onStart((e) => {})
+    .onUpdate((e) => {
+      handleGestureOnUpdate({
+        e,
+        startX,
+        offsetX,
+        offsetY,
+      });
+    })
+    .onEnd((e) => {
+      handleGestureOnEnd({
+        e,
+        startX,
+        offsetX,
+        offsetY,
+        destination,
+      });
+    });
+
+  return { swipeableProviderGesture };
+};
+
+export default useGestureHandler;

--- a/packages/design-system/tabs/tablib/useSwipeableProvider.ts
+++ b/packages/design-system/tabs/tablib/useSwipeableProvider.ts
@@ -1,0 +1,45 @@
+import { useAnimatedStyle, useSharedValue } from "react-native-reanimated";
+
+import { SNAP_POINTS_HORIZONTAL } from "./constants";
+import useGestureHandler from "./useGestureHandler";
+
+const useSwipeableProvider = () => {
+  const offsetY = useSharedValue(0);
+  const offsetX = useSharedValue(0);
+  const startX = useSharedValue(0);
+  const { swipeableProviderGesture } = useGestureHandler({
+    offsetY,
+    offsetX,
+    startX,
+  });
+
+  const animatedContainerStyles = useAnimatedStyle(() => {
+    return {
+      transform: [{ translateY: offsetY.value }],
+    };
+  });
+
+  const animatedTabStyles = useAnimatedStyle(() => {
+    return {
+      transform: [
+        {
+          translateX: Math.min(
+            Math.max(offsetX.value, SNAP_POINTS_HORIZONTAL.SECOND_PAGE),
+            SNAP_POINTS_HORIZONTAL.ORIGIN
+          ),
+        },
+      ],
+    };
+  }, [offsetX]);
+
+  return {
+    offsetY,
+    offsetX,
+    startX,
+    animatedContainerStyles,
+    animatedTabStyles,
+    swipeableProviderGesture,
+  };
+};
+
+export default useSwipeableProvider;

--- a/packages/design-system/tabs/tablib/utils.ts
+++ b/packages/design-system/tabs/tablib/utils.ts
@@ -1,0 +1,36 @@
+import { PanGestureHandlerEventPayload } from "react-native-gesture-handler";
+import { cancelAnimation, SharedValue } from "react-native-reanimated";
+
+import { handleOnEndHorizontal } from "./calculations";
+
+type GestureHandlerProps = {
+  e: PanGestureHandlerEventPayload;
+  offsetY?: SharedValue<number>;
+  startX: SharedValue<number>;
+  offsetX: SharedValue<number>;
+};
+
+export const handleGestureOnUpdate = ({
+  offsetX,
+  startX,
+  e,
+}: GestureHandlerProps) => {
+  "worklet";
+  cancelAnimation(startX);
+  offsetX.value = e.translationX + startX.value;
+};
+
+export const handleGestureOnEnd = ({
+  offsetX,
+  startX,
+  e,
+  destination,
+}: GestureHandlerProps & { destination: SharedValue<number> }) => {
+  "worklet";
+  handleOnEndHorizontal({
+    e,
+    startX,
+    offsetX,
+    destination,
+  });
+};


### PR DESCRIPTION
# Why

In the Login screen, when we press the 'Sign In' button, the modal sheet is opened but the screen in the background is not animating. When I search for the reason, realized that the animated component with the PagerView is (from the `react-native-pager-view`) causing this (`tabs>tablib>index.tsx>line 312`). Looked for the reasons but couldn't figure it out. Then I tried to create a custom horizontal swipeable view with Gesture Handlers. 

Tab component is used in different places and also on the web. My solution can break something. Even if not, this way takes more effort to complete. If I cannot find to fix it with the current usage, I can complete my solution and test it on the other screens and on the web. This is just a workaround. We might need to review the changes together. Just opening this draft PR to discuss. 

Added @gorhom and @intergalacticspacehighway as reviewers. You probably worked on this component together. Would be good to hear your thoughts also.

**Sources**
- [Linear Issue](https://linear.app/showtime/issue/SHOW2-693/when-open-the-auth-modal-background-screen-is-not-animating)

# Test Plan

Opening the login screen and checking if the modal animation works as expected.

https://user-images.githubusercontent.com/19428358/163882039-1129ea50-1f94-4da3-b87f-40104927fd0d.mov
