### PR TITLE
feat(web): Link support href attrs.

### DIFF
--- a/packages/app/navigation/link/link.tsx
+++ b/packages/app/navigation/link/link.tsx
@@ -8,9 +8,17 @@ import type { TW } from "design-system/tailwind/types";
 import { Text } from "design-system/text";
 import { View } from "design-system/view";
 
-type LinkProps = Props & { viewProps?: ViewProps; tw?: TW };
+type LinkProps = Props & {
+  viewProps?: ViewProps;
+  tw?: TW;
+  // react-native-web only types
+  hrefAttrs?: {
+    rel: "noreferrer";
+    target?: "_blank";
+  };
+};
 
-function Link({ viewProps, tw, ...props }: LinkProps) {
+function Link({ viewProps, tw, hrefAttrs, ...props }: LinkProps) {
   return (
     <LinkCore
       {...props}
@@ -18,7 +26,11 @@ function Link({ viewProps, tw, ...props }: LinkProps) {
         web: View,
         default: Pressable as any,
       })}
-      componentProps={{ ...viewProps, tw }}
+      componentProps={{
+        ...viewProps,
+        tw,
+        hrefAttrs,
+      }}
     />
   );
 }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->
Link component does not yet support `_blank` mode.
# How

<!--
How did you build this feature or fix this bug and why?
-->
- View the source code of [solito](https://github.com/nandorojo/solito/blob/ad5e470bf3da7aaa9e2a6f768d3bd6bf6116ef9d/example-monorepos/blank/packages/app/rnw-overrides.tsx#L17) and add according to nandorojo's example. 

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
Web is work well!