### PR TITLE
refactor: update notification indicator styles

### DIFF
--- a/packages/app/navigation/tab-bar-icons.tsx
+++ b/packages/app/navigation/tab-bar-icons.tsx
@@ -146,14 +146,10 @@ export const NotificationsTabBarIcon = ({
 
 const UnreadNotificationIndicator = () => {
   const { hasUnreadNotification } = useNotifications();
-  const isWeb = Platform.OS === "web";
 
-  return hasUnreadNotification ? (
-    <View
-      tw="w-2 h-2 absolute rounded-full top-2 right-2"
-      style={tw.style(isWeb ? "bg-violet-500" : "bg-amber-500")}
-    />
-  ) : null;
+  return (
+    <View tw="w-2 h-2 absolute rounded-full top-2 right-2 bg-amber-500 dark:bg-violet-500" />
+  );
 };
 
 export const ProfileTabBarIcon = () => {

--- a/packages/app/navigation/tab-bar-icons.tsx
+++ b/packages/app/navigation/tab-bar-icons.tsx
@@ -147,9 +147,9 @@ export const NotificationsTabBarIcon = ({
 const UnreadNotificationIndicator = () => {
   const { hasUnreadNotification } = useNotifications();
 
-  return (
+  return hasUnreadNotification ? (
     <View tw="w-2 h-2 absolute rounded-full top-2 right-2 bg-amber-500 dark:bg-violet-500" />
-  );
+  ) : null;
 };
 
 export const ProfileTabBarIcon = () => {

--- a/packages/app/navigation/tab-bar-icons.tsx
+++ b/packages/app/navigation/tab-bar-icons.tsx
@@ -146,9 +146,13 @@ export const NotificationsTabBarIcon = ({
 
 const UnreadNotificationIndicator = () => {
   const { hasUnreadNotification } = useNotifications();
+  const isWeb = Platform.OS === "web";
 
   return hasUnreadNotification ? (
-    <View tw="w-2 h-2 bg-violet-500 absolute rounded-full bottom-2" />
+    <View
+      tw="w-2 h-2 absolute rounded-full top-2 right-2"
+      style={tw.style(isWeb ? "bg-violet-500" : "bg-amber-500")}
+    />
   ) : null;
 };
 


### PR DESCRIPTION
# Why

Notification indicator location is wrong on mobile and have different styles on web. 

Now;
<img width="148" alt="Screen Shot 2022-04-20 at 13 25 31" src="https://user-images.githubusercontent.com/19428358/164211949-d236e80a-f791-4804-bae1-db8b35e4f684.png">
<img width="91" alt="Screen Shot 2022-04-20 at 13 25 34" src="https://user-images.githubusercontent.com/19428358/164211957-33f4e3ae-4e8e-4fc4-99bb-9d141ee7c2b3.png">


<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Got a new notification or comment the new notification check. 

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
