### PR TITLE
fix: web feed glitch

### DIFF
--- a/packages/app/components/feed/feed.md.tsx
+++ b/packages/app/components/feed/feed.md.tsx
@@ -14,7 +14,8 @@ import { Card } from "design-system/card";
 import { tw } from "design-system/tailwind";
 import { View } from "design-system/view";
 
-const CARD_HEIGHT = 790;
+const CARD_HEIGHT = 740;
+const CARD_WIDTH = 490;
 
 export const Feed = () => {
   return (
@@ -129,7 +130,10 @@ const NFTScrollList = ({
     return (
       <View tw="w-full flex-row" nativeID="334343">
         <View tw="flex-2" />
-        <Card nft={item} tw={`w-35% mb-4 ml-auto`} />
+        <Card
+          nft={item}
+          tw={`w-[${CARD_WIDTH}px] h-[${CARD_HEIGHT}px] mb-4 ml-auto`}
+        />
         <View tw="flex-1" />
       </View>
     );

--- a/packages/design-system/tabs/tablib/components.tsx
+++ b/packages/design-system/tabs/tablib/components.tsx
@@ -47,7 +47,7 @@ export const TabItem = ({ name, count }: TabItemProps) => {
           height: "100%",
           paddingHorizontal: TAB_ITEM_PADDING_HORIZONTAL,
         },
-        animatedStyle,
+        Platform.OS === "web" ? { opacity: 1 } : animatedStyle,
       ]}
     >
       <RNText


### PR DESCRIPTION
## Why?
- Fixes below glitch in web feed

<img width="1728" alt="Screenshot 2022-04-20 at 16 38 11" src="https://user-images.githubusercontent.com/23293248/164278490-d7b284d7-c290-4280-80b6-dfc07ab44531.png">

 - Something is wrong with recycler list (useWindowScroll and forceNonDeterministicRendering) props. Providing deterministing dimensions fixes the issue.

## Test
- Try toggling authenticated/unauthenticated feed on web