### PR TITLE
Fix bump version script

### DIFF
--- a/apps/expo/scripts/bump-version.mjs
+++ b/apps/expo/scripts/bump-version.mjs
@@ -42,16 +42,11 @@ const hasPlatform = (fileDiffList, reactNativeConfig, configuration) => {
 const bumpVersion = async (versionType) => {
   const inCI = process.env.CI;
   if (inCI) {
-    const versionUpdateResponse = await $`yarn version ${versionType}`
-    console.log(versionUpdateResponse);
-    const newVersion = versionUpdateResponse.stdout.split('➤ ')[1].replace('YN0000: showtime@workspace:.: Bumped to ', '').trim()
+    // --tag
+    const versionUpdateResponse = await $`npx bumpp ${versionType} --all --commit "release v" --push`
+    console.log(versionUpdateResponse)
+    const newVersion = versionUpdateResponse.stdout.split("✔")[1].replace('Updated package.json to ', '').trim()
     console.log(`${chalk.green(newVersion)}`)
-
-    const gitCommitResponse = await $`git commit -am "v${newVersion}"`
-    console.log(gitCommitResponse.stdout)
-
-    const gitPushResponse = await $`git push`
-    console.log(gitPushResponse.stdout)
 
     // Use the version type in the GitHub Action to trigger
     // an EAS Update (patch) or an EAS Build (major)
@@ -77,22 +72,22 @@ try {
   console.log(`The starting working directory is ${chalk.blue(startingWorkingDirectory)}`)
   console.log(`The current working directory is ${chalk.blue(currentWorkingDirectory)}`)
 
-  // const lastReleaseCommitIdResponse = await $`git log -1 --grep=version --pretty=format:%h`
-  // const lastReleaseCommitId = lastReleaseCommitIdResponse.stdout
+  const lastReleaseCommitIdResponse = await $`git log -1 --grep=release --pretty=format:%h`
+  const lastReleaseCommitId = lastReleaseCommitIdResponse.stdout
 
-  // const currentCommitHeadIdResponse = await $`git log -1 --pretty=format:%h`
-  // const currentCommitHeadId = currentCommitHeadIdResponse.stdout
+  const currentCommitHeadIdResponse = await $`git log -1 --pretty=format:%h`
+  const currentCommitHeadId = currentCommitHeadIdResponse.stdout
 
-  // const sameCommit = lastReleaseCommitId === currentCommitHeadId
+  const sameCommit = lastReleaseCommitId === currentCommitHeadId
 
-  // console.log(`Current Commit ID: ${chalk.blue(currentCommitHeadId)}`)
-  // console.log(`Last Release Commit ID: ${chalk.blue(lastReleaseCommitId)}`)
+  console.log(`Current Commit ID: ${chalk.blue(currentCommitHeadId)}`)
+  console.log(`Last Release Commit ID: ${chalk.blue(lastReleaseCommitId)}`)
 
-  // if (sameCommit) {
-  //   console.log("No new commits since the last release, no action needed")
-  //   // Exit code 1 to fail the GitHub Action and prevent an unnecessary deployment
-  //   await $`exit 1`
-  // }
+  if (sameCommit) {
+    console.log("No new commits since the last release, no action needed")
+    // Exit code 1 to fail the GitHub Action and prevent an unnecessary deployment
+    await $`exit 1`
+  }
 
   /**
    * If file at path "apps/expo/package.json" has been modified within the commit range then it's possible
@@ -145,7 +140,6 @@ try {
     await bumpVersion("patch")
   }
 } catch (error) {
-  console.log(`Exit code: ${error.exitCode}`);
-  console.log(`Error: ${error.stderr}`);
+  console.error(`Error: ${error.stderr}`);
   await $`exit ${error.exitCode}`
 }


### PR DESCRIPTION
# Why

The bump version script is not working

# How

Use [`bumpp`](https://github.com/antfu/bumpp) to bump the version, commit and push

# Test Plan

Run the script in the Expo Production GitHub Action