### PR TITLE
fix: update trending page header styles

### DIFF
--- a/packages/app/components/trending.tsx
+++ b/packages/app/components/trending.tsx
@@ -73,7 +73,7 @@ export const Trending = () => {
       <Tabs.Root onIndexChange={setSelected} initialIndex={selected} lazy>
         <Tabs.Header>
           {Platform.OS !== "android" && (
-            <View tw={`h-[${headerHeight}px] bg-black`} />
+            <View tw={`h-[${headerHeight}px] bg-white dark:bg-black`} />
           )}
           <View tw="bg-white dark:bg-black pt-4 pl-4 pb-[3px]">
             <Text


### PR DESCRIPTION
# Why

In trending page, even if the theme is light, there is black header.
<img width="469" alt="Screen Shot 2022-04-21 at 15 56 22" src="https://user-images.githubusercontent.com/19428358/164462754-9a3161f5-cd7b-449f-8302-9a7c107af498.png">

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
