### PR TITLE
Fix header height on web

### DIFF
--- a/packages/app/components/profile.tsx
+++ b/packages/app/components/profile.tsx
@@ -185,7 +185,7 @@ const Profile = ({ address }: { address?: string }) => {
         lazy
       >
         <Tabs.Header>
-          {Platform.OS !== "android" && <View tw={`h-[${headerHeight}px]`} />}
+          {Platform.OS === "ios" && <View tw={`h-[${headerHeight}px]`} />}
           <ProfileTop address={address} isBlocked={isBlocked} />
         </Tabs.Header>
         {data?.data.lists ? (

--- a/packages/app/components/search/index.tsx
+++ b/packages/app/components/search/index.tsx
@@ -42,7 +42,7 @@ export const Search = () => {
 
   return (
     <>
-      {Platform.OS !== "android" && <View tw={`h-[${headerHeight}px]`} />}
+      {Platform.OS === "ios" && <View tw={`h-[${headerHeight}px]`} />}
       <View tw="p-4">
         <Input
           placeholder="Search for @username or name.eth"

--- a/packages/app/components/settings/index.tsx
+++ b/packages/app/components/settings/index.tsx
@@ -82,7 +82,7 @@ const SettingsTabs = () => {
         lazy
       >
         <Tabs.Header>
-          {Platform.OS !== "android" && <View tw={`h-[${headerHeight}px]`} />}
+          {Platform.OS === "ios" && <View tw={`h-[${headerHeight}px]`} />}
           <View tw="bg-white dark:bg-black pt-4 px-4 pb-[3px] flex-row justify-between">
             <Text
               variant="text-2xl"

--- a/packages/app/components/trending.tsx
+++ b/packages/app/components/trending.tsx
@@ -72,7 +72,7 @@ export const Trending = () => {
     <View tw="bg-white dark:bg-black flex-1">
       <Tabs.Root onIndexChange={setSelected} initialIndex={selected} lazy>
         <Tabs.Header>
-          {Platform.OS !== "android" && (
+          {Platform.OS === "ios" && (
             <View tw={`h-[${headerHeight}px] bg-white dark:bg-black`} />
           )}
           <View tw="bg-white dark:bg-black pt-4 pl-4 pb-[3px]">

--- a/packages/app/lib/react-navigation/elements/index.web.ts
+++ b/packages/app/lib/react-navigation/elements/index.web.ts
@@ -1,5 +1,4 @@
-// TODO: Approx header height on web!
-const HEADER_HEIGHT = 100;
+const HEADER_HEIGHT = 64;
 
 const useHeaderHeight = () => {
   return HEADER_HEIGHT;

--- a/packages/app/screens/edit-profile.tsx
+++ b/packages/app/screens/edit-profile.tsx
@@ -10,7 +10,7 @@ export const EditProfileScreen = () => {
 
   return (
     <>
-      {Platform.OS !== "android" && <View tw={`h-[${headerHeight}px]`} />}
+      {Platform.OS === "ios" && <View tw={`h-[${headerHeight}px]`} />}
       <EditProfile />
     </>
   );

--- a/packages/app/screens/notifications.tsx
+++ b/packages/app/screens/notifications.tsx
@@ -13,7 +13,7 @@ const NotificationsScreen = withColorScheme(() => {
 
   return (
     <>
-      {Platform.OS !== "android" && <View tw={`h-[${headerHeight}px]`} />}
+      {Platform.OS === "ios" && <View tw={`h-[${headerHeight}px]`} />}
       {/* <ErrorBoundary>
         <Suspense
           fallback={


### PR DESCRIPTION
# Why

The latest changes fucked up the header height logic on web

# How

- Set the header height to 64px
- Don't apply "padding" for header on web

# Test Plan

Run the web app and check if everything is OK