### PR TITLE
feature: account tab in settings & tab comp styles refactor (SHOW2-697)

### DIFF
--- a/apps/next-react-native/src/pages/settings/blocked-list.tsx
+++ b/apps/next-react-native/src/pages/settings/blocked-list.tsx
@@ -1,0 +1,3 @@
+import { BlockedListScreen } from "app/screens/blocked-list";
+
+export default BlockedListScreen;

--- a/apps/next-react-native/src/pages/settings/privacy-and-security.tsx
+++ b/apps/next-react-native/src/pages/settings/privacy-and-security.tsx
@@ -1,0 +1,3 @@
+import { PrivacySecuritySettingsScreen } from "app/screens/privacy-and-security-settings";
+
+export default PrivacySecuritySettingsScreen;

--- a/packages/app/components/header.tsx
+++ b/packages/app/components/header.tsx
@@ -1,21 +1,20 @@
 import { useState } from "react";
-import { useWindowDimensions, Platform } from "react-native";
+import { Platform, useWindowDimensions } from "react-native";
 
 import { HeaderDropdown } from "app/components/header-dropdown";
 import { useUser } from "app/hooks/use-user";
 import { Link } from "app/navigation/link";
 import {
-  ShowtimeTabBarIcon,
   CameraTabBarIcon,
+  ShowtimeTabBarIcon,
   TrendingTabBarIcon,
 } from "app/navigation/tab-bar-icons";
 import { useNavigationElements } from "app/navigation/use-navigation-elements";
 import { useRouter } from "app/navigation/use-router";
 
-import { View, Pressable, Button } from "design-system";
-import { useIsDarkMode } from "design-system/hooks";
-import { useBlurredBackgroundColor } from "design-system/hooks";
-import { Search, ArrowLeft } from "design-system/icon";
+import { Button, Pressable, View } from "design-system";
+import { useBlurredBackgroundColor, useIsDarkMode } from "design-system/hooks";
+import { ArrowLeft, Search } from "design-system/icon";
 import { Input } from "design-system/input";
 import { tw } from "design-system/tailwind";
 import { breakpoints } from "design-system/theme";
@@ -165,7 +164,7 @@ const Header = ({ canGoBack }: { canGoBack: boolean }) => {
         style={{
           position: "sticky",
         }}
-        tw="bg-white dark:bg-black top-0 right-0 left-0 z-50 h-16 flex-row items-center justify-between px-4 py-2 shadow-sm"
+        tw="bg-white dark:bg-black top-0 right-0 left-0 z-50 h-16 flex-row items-center justify-between px-4 py-2"
       >
         <View tw="items-start">
           <Link href="/">

--- a/packages/app/components/header.tsx
+++ b/packages/app/components/header.tsx
@@ -165,7 +165,7 @@ const Header = ({ canGoBack }: { canGoBack: boolean }) => {
         style={{
           position: "sticky",
         }}
-        tw="bg-white dark:bg-black top-0 right-0 left-0 z-50 h-16 flex-row items-center justify-between px-4 py-2 shadow-sm"
+        tw="bg-white dark:bg-black top-0 right-0 left-0 z-50 h-16 flex-row items-center justify-between px-4 py-2"
       >
         <View tw="items-start">
           <Link href="/">

--- a/packages/app/components/header.tsx
+++ b/packages/app/components/header.tsx
@@ -165,7 +165,7 @@ const Header = ({ canGoBack }: { canGoBack: boolean }) => {
         style={{
           position: "sticky",
         }}
-        tw="bg-white dark:bg-black top-0 right-0 left-0 z-50 h-16 flex-row items-center justify-between px-4 py-2"
+        tw="bg-white dark:bg-black top-0 right-0 left-0 z-50 h-16 flex-row items-center justify-between px-4 py-2 shadow-sm"
       >
         <View tw="items-start">
           <Link href="/">
@@ -191,7 +191,7 @@ const Header = ({ canGoBack }: { canGoBack: boolean }) => {
         backdropFilter: "blur(20px)",
         backgroundColor: blurredBackgroundColor,
       }}
-      tw="top-0 right-0 left-0 z-50 h-16 flex-row items-center justify-between px-4 py-2"
+      tw="top-0 right-0 left-0 z-50 h-16 flex-row items-center justify-between px-4 py-2 shadow-sm"
     >
       <View tw="w-20 items-start">
         <HeaderLeft canGoBack={canGoBack} />

--- a/packages/app/components/list/listing-form.tsx
+++ b/packages/app/components/list/listing-form.tsx
@@ -47,7 +47,12 @@ const defaultListingValues = {
   currency: defaultCurrency,
 };
 
-const options: SelectOption[] = [];
+const options: SelectOption[] = Object.entries(CURRENCY_NAMES).map(
+  (currency) => {
+    const [value, label] = currency;
+    return { value, label } as { value: string; label: string };
+  }
+);
 
 export const ListingForm = (props: Props) => {
   const nft = props.nft;

--- a/packages/app/components/list/listing-form.tsx
+++ b/packages/app/components/list/listing-form.tsx
@@ -47,12 +47,7 @@ const defaultListingValues = {
   currency: defaultCurrency,
 };
 
-const options: SelectOption[] = Object.entries(CURRENCY_NAMES).map(
-  (currency) => {
-    const [value, label] = currency;
-    return { value, label } as { value: string; label: string };
-  }
-);
+const options: SelectOption[] = [];
 
 export const ListingForm = (props: Props) => {
   const nft = props.nft;

--- a/packages/app/components/settings/blocked-list.tsx
+++ b/packages/app/components/settings/blocked-list.tsx
@@ -54,8 +54,6 @@ const HeaderSection = () => {
 };
 
 export const UserItem = (props: UserItemProps) => {
-  const router = useRouter();
-
   return (
     <View tw="flex-1 flex-row w-full px-4 py-2 items-center">
       <View tw="mr-2 rounded-xl w-6 h-6 bg-gray-200">
@@ -71,7 +69,7 @@ export const UserItem = (props: UserItemProps) => {
         size="small"
         variant="danger"
         onPress={() => {
-          // TODO(enes): unblock action
+          // TODO(enes): implement unblocking logics
         }}
       >
         <ButtonLabel>Unblock</ButtonLabel>
@@ -91,7 +89,12 @@ export const BlockedList = () => {
     <ScrollView>
       {Platform.OS !== "android" && <View tw={`h-[${headerHeight}px]`} />}
       <HeaderSection />
-      {list.map(renderUserItem)}
+      <View tw="flex-1 px-4">
+        <Text tw="font-semibold text-gray-600 dark:text-gray-400">
+          🚧 Coming soon
+        </Text>
+      </View>
+      {/* // TODO(enes): implement unblocking logics */}
     </ScrollView>
   );
 };

--- a/packages/app/components/settings/blocked-list.tsx
+++ b/packages/app/components/settings/blocked-list.tsx
@@ -4,21 +4,14 @@ import { FlatList, Platform } from "react-native";
 import { useHeaderHeight } from "app/lib/react-navigation/elements";
 import { useRouter } from "app/navigation/use-router";
 
-import { View, Text, Button, ButtonLabel, Image } from "design-system";
-
-import { SettingSubTitle } from "./settings-subtitle";
-
-export const SettingAccountSlotHeader = () => {
-  return (
-    <View>
-      <SettingSubTitle>
-        <Text tw="text-gray-900 dark:text-white font-bold text-xl">
-          Privacy & Security
-        </Text>
-      </SettingSubTitle>
-    </View>
-  );
-};
+import {
+  View,
+  Text,
+  Button,
+  ButtonLabel,
+  Image,
+  ScrollView,
+} from "design-system";
 
 export type UserItemProps = {
   id: number | string;
@@ -46,6 +39,19 @@ const list = [
       "http://lh3.googleusercontent.com/HoSAPydLhYadm-jdgAE83mou5Fi5qbwbhv9UqcQuaHHfZreVsykcbFNLBuQhawIWLEa883DeBDprMM76oTHTAvPIrACxBHRK05h5Dw",
   },
 ];
+
+const HeaderSection = () => {
+  return (
+    <View tw="bg-white dark:bg-black pt-4 px-4 pb-[3px] flex-row justify-between mb-4">
+      <Text
+        variant="text-2xl"
+        tw="text-gray-900 dark:text-white font-extrabold"
+      >
+        Blocked List
+      </Text>
+    </View>
+  );
+};
 
 export const UserItem = (props: UserItemProps) => {
   const router = useRouter();
@@ -77,22 +83,15 @@ export const UserItem = (props: UserItemProps) => {
 export const BlockedList = () => {
   const headerHeight = useHeaderHeight();
 
-  const renderUserItem = useCallback(({ item }) => {
+  const renderUserItem = (item: UserItemProps) => {
     return <UserItem {...item} />;
-  }, []);
+  };
 
   return (
-    <View tw="bg-white dark:bg-black h-[100vh]">
+    <ScrollView>
       {Platform.OS !== "android" && <View tw={`h-[${headerHeight}px]`} />}
-      <View tw="bg-white dark:bg-black pt-4 px-4 pb-[3px] flex-row justify-between mb-4">
-        <Text
-          variant="text-2xl"
-          tw="text-gray-900 dark:text-white font-extrabold"
-        >
-          Blocked List
-        </Text>
-      </View>
-      <FlatList data={list} renderItem={renderUserItem} />
-    </View>
+      <HeaderSection />
+      {list.map(renderUserItem)}
+    </ScrollView>
   );
 };

--- a/packages/app/components/settings/blocked-list.tsx
+++ b/packages/app/components/settings/blocked-list.tsx
@@ -1,0 +1,98 @@
+import { useCallback } from "react";
+import { FlatList, Platform } from "react-native";
+
+import { useHeaderHeight } from "app/lib/react-navigation/elements";
+import { useRouter } from "app/navigation/use-router";
+
+import { View, Text, Button, ButtonLabel, Image } from "design-system";
+
+import { SettingSubTitle } from "./settings-subtitle";
+
+export const SettingAccountSlotHeader = () => {
+  return (
+    <View>
+      <SettingSubTitle>
+        <Text tw="text-gray-900 dark:text-white font-bold text-xl">
+          Privacy & Security
+        </Text>
+      </SettingSubTitle>
+    </View>
+  );
+};
+
+export type UserItemProps = {
+  id: number | string;
+  title: string;
+  image_url?: string;
+};
+
+const list = [
+  {
+    id: 1,
+    title: "Enes",
+    image_url:
+      "http://lh3.googleusercontent.com/HoSAPydLhYadm-jdgAE83mou5Fi5qbwbhv9UqcQuaHHfZreVsykcbFNLBuQhawIWLEa883DeBDprMM76oTHTAvPIrACxBHRK05h5Dw",
+  },
+  {
+    id: 1,
+    title: "Axel",
+    image_url:
+      "http://lh3.googleusercontent.com/HoSAPydLhYadm-jdgAE83mou5Fi5qbwbhv9UqcQuaHHfZreVsykcbFNLBuQhawIWLEa883DeBDprMM76oTHTAvPIrACxBHRK05h5Dw",
+  },
+  {
+    id: 1,
+    title: "Alan",
+    image_url:
+      "http://lh3.googleusercontent.com/HoSAPydLhYadm-jdgAE83mou5Fi5qbwbhv9UqcQuaHHfZreVsykcbFNLBuQhawIWLEa883DeBDprMM76oTHTAvPIrACxBHRK05h5Dw",
+  },
+];
+
+export const UserItem = (props: UserItemProps) => {
+  const router = useRouter();
+
+  return (
+    <View tw="flex-1 flex-row w-full px-4 py-2 items-center">
+      <View tw="mr-2 rounded-xl w-6 h-6 bg-gray-200">
+        <Image
+          tw={"w-full h-full rounded-full"}
+          source={{ uri: props.image_url }}
+        />
+      </View>
+      <View tw="flex-1 flex flex-col items-start justify-center">
+        <Text tw="text-gray-900 dark:text-white">{props.title}</Text>
+      </View>
+      <Button
+        size="small"
+        variant="danger"
+        onPress={() => {
+          // TODO(enes): unblock action
+        }}
+      >
+        <ButtonLabel>Unblock</ButtonLabel>
+      </Button>
+    </View>
+  );
+};
+
+export const BlockedList = () => {
+  const headerHeight = useHeaderHeight();
+
+  const renderUserItem = useCallback(({ item }) => {
+    return <UserItem {...item} />;
+  }, []);
+
+  return (
+    <View tw="bg-white dark:bg-black h-[100vh]">
+      {Platform.OS !== "android" && <View tw={`h-[${headerHeight}px]`} />}
+      <View tw="bg-white dark:bg-black pt-4 px-4 pb-[3px] flex-row justify-between mb-4">
+        <Text
+          variant="text-2xl"
+          tw="text-gray-900 dark:text-white font-extrabold"
+        >
+          Blocked List
+        </Text>
+      </View>
+      <FlatList data={list} renderItem={renderUserItem} />
+    </View>
+  );
+};

--- a/packages/app/components/settings/blocked-list.tsx
+++ b/packages/app/components/settings/blocked-list.tsx
@@ -19,27 +19,6 @@ export type UserItemProps = {
   image_url?: string;
 };
 
-const list = [
-  {
-    id: 1,
-    title: "Enes",
-    image_url:
-      "http://lh3.googleusercontent.com/HoSAPydLhYadm-jdgAE83mou5Fi5qbwbhv9UqcQuaHHfZreVsykcbFNLBuQhawIWLEa883DeBDprMM76oTHTAvPIrACxBHRK05h5Dw",
-  },
-  {
-    id: 1,
-    title: "Axel",
-    image_url:
-      "http://lh3.googleusercontent.com/HoSAPydLhYadm-jdgAE83mou5Fi5qbwbhv9UqcQuaHHfZreVsykcbFNLBuQhawIWLEa883DeBDprMM76oTHTAvPIrACxBHRK05h5Dw",
-  },
-  {
-    id: 1,
-    title: "Alan",
-    image_url:
-      "http://lh3.googleusercontent.com/HoSAPydLhYadm-jdgAE83mou5Fi5qbwbhv9UqcQuaHHfZreVsykcbFNLBuQhawIWLEa883DeBDprMM76oTHTAvPIrACxBHRK05h5Dw",
-  },
-];
-
 const HeaderSection = () => {
   return (
     <View tw="bg-white dark:bg-black pt-4 px-4 pb-[3px] flex-row justify-between mb-4">
@@ -80,14 +59,12 @@ export const UserItem = (props: UserItemProps) => {
 
 export const BlockedList = () => {
   const headerHeight = useHeaderHeight();
-
-  const renderUserItem = (item: UserItemProps) => {
-    return <UserItem {...item} />;
-  };
+  const shouldRenderHeaderGap =
+    Platform.OS !== "web" && Platform.OS !== "android";
 
   return (
     <ScrollView>
-      {Platform.OS !== "android" && <View tw={`h-[${headerHeight}px]`} />}
+      {shouldRenderHeaderGap && <View tw={`h-[${headerHeight}px]`} />}
       <HeaderSection />
       <View tw="flex-1 px-4">
         <Text tw="font-semibold text-gray-600 dark:text-gray-400">

--- a/packages/app/components/settings/index.tsx
+++ b/packages/app/components/settings/index.tsx
@@ -64,6 +64,7 @@ const SettingsTabs = () => {
   const { user, isAuthenticated } = useUser();
   const headerHeight = useHeaderHeight();
   const router = useRouter();
+  const isWeb = Platform.OS === "web";
 
   // TODO: Include wallets with `phone number flag` after backend implementation
   const emailWallets = useMemo(
@@ -111,12 +112,14 @@ const SettingsTabs = () => {
             >
               Settings
             </Text>
-            <Text
-              variant="text-2xl"
-              tw="text-gray-100 dark:text-gray-900 font-extrabold"
-            >
-              v{Constants?.manifest?.version ?? packageJson?.version}
-            </Text>
+            {!isWeb ? (
+              <Text
+                variant="text-2xl"
+                tw="text-gray-100 dark:text-gray-900 font-extrabold"
+              >
+                v{Constants?.manifest?.version ?? packageJson?.version}
+              </Text>
+            ) : null}
           </View>
         </Tabs.Header>
         <Tabs.List

--- a/packages/app/components/settings/index.tsx
+++ b/packages/app/components/settings/index.tsx
@@ -15,6 +15,12 @@ import { tw } from "design-system/tailwind";
 
 import packageJson from "../../../../package.json";
 import {
+  SettingAccountSlotHeader,
+  SettingAccountSlotFooter,
+  AccountSettingItem,
+  AccountSettingItemProps,
+} from "./settings-account-slot";
+import {
   EmailSlotProps,
   SettingsEmailSlot,
   SettingEmailSlotHeader,
@@ -28,6 +34,10 @@ import {
   SettingsWalletSlotPlaceholder,
 } from "./settings-wallet-slot";
 import { SlotSeparator } from "./slot-separator";
+
+const renderSetting = ({ item }: { item: AccountSettingItemProps }) => {
+  return <AccountSettingItem {...item} />;
+};
 
 const renderEmail = ({ item }: { item: EmailSlotProps }) => {
   const email = item.email;
@@ -62,6 +72,17 @@ const SettingsTabs = () => {
         (wallet) => wallet.is_email
       ),
     [user?.data.profile.wallet_addresses_v2]
+  );
+  const accountSettings = useMemo(
+    () => [
+      {
+        id: 1,
+        title: "Privacy & Security",
+        icon: "lock",
+        subRoute: "privacy-and-security",
+      },
+    ],
+    []
   );
   const wallets = user?.data.profile.wallet_addresses_excluding_email_v2;
   const keyExtractor = (wallet: WalletAddressesV2) => wallet.address;
@@ -110,6 +131,9 @@ const SettingsTabs = () => {
           <Tabs.Trigger>
             <TabItem name="Email Addresses" selected={selected === 1} />
           </Tabs.Trigger>
+          <Tabs.Trigger>
+            <TabItem name="Account" selected={selected === 2} />
+          </Tabs.Trigger>
           <SelectedTabIndicator />
         </Tabs.List>
         <Tabs.Pager>
@@ -148,6 +172,18 @@ const SettingsTabs = () => {
                 hasEmail={Boolean(emailWallets?.length)}
               />
             }
+            alwaysBounceVertical={false}
+            minHeight={Dimensions.get("window").height}
+            ItemSeparatorComponent={() => <SlotSeparator />}
+          />
+
+          <Tabs.FlatList
+            data={accountSettings}
+            keyExtractor={keyExtractor}
+            renderItem={renderSetting}
+            removeClippedSubviews={Platform.OS !== "web"}
+            ListHeaderComponent={<SettingAccountSlotHeader />}
+            ListFooterComponent={<SettingAccountSlotFooter />}
             alwaysBounceVertical={false}
             minHeight={Dimensions.get("window").height}
             ItemSeparatorComponent={() => <SlotSeparator />}

--- a/packages/app/components/settings/index.tsx
+++ b/packages/app/components/settings/index.tsx
@@ -186,7 +186,7 @@ const SettingsTabs = () => {
             renderItem={renderSettingRoutes}
             removeClippedSubviews={Platform.OS !== "web"}
             ListHeaderComponent={<SettingAccountSlotHeader />}
-            // ListFooterComponent={<SettingAccountSlotFooter />}
+            ListFooterComponent={<SettingAccountSlotFooter />}
             alwaysBounceVertical={false}
             minHeight={Dimensions.get("window").height}
             ItemSeparatorComponent={() => <SlotSeparator />}

--- a/packages/app/components/settings/index.tsx
+++ b/packages/app/components/settings/index.tsx
@@ -183,7 +183,7 @@ const SettingsTabs = () => {
             renderItem={renderSettingRoutes}
             removeClippedSubviews={Platform.OS !== "web"}
             ListHeaderComponent={<SettingAccountSlotHeader />}
-            ListFooterComponent={<SettingAccountSlotFooter />}
+            // ListFooterComponent={<SettingAccountSlotFooter />}
             alwaysBounceVertical={false}
             minHeight={Dimensions.get("window").height}
             ItemSeparatorComponent={() => <SlotSeparator />}

--- a/packages/app/components/settings/index.tsx
+++ b/packages/app/components/settings/index.tsx
@@ -35,7 +35,7 @@ import {
 } from "./settings-wallet-slot";
 import { SlotSeparator } from "./slot-separator";
 
-const renderSetting = ({ item }: { item: AccountSettingItemProps }) => {
+const renderSettingRoutes = ({ item }: { item: AccountSettingItemProps }) => {
   return <AccountSettingItem {...item} />;
 };
 
@@ -179,8 +179,8 @@ const SettingsTabs = () => {
 
           <Tabs.FlatList
             data={accountSettings}
-            keyExtractor={keyExtractor}
-            renderItem={renderSetting}
+            keyExtractor={(item) => item.id}
+            renderItem={renderSettingRoutes}
             removeClippedSubviews={Platform.OS !== "web"}
             ListHeaderComponent={<SettingAccountSlotHeader />}
             ListFooterComponent={<SettingAccountSlotFooter />}

--- a/packages/app/components/settings/privacy-and-security.tsx
+++ b/packages/app/components/settings/privacy-and-security.tsx
@@ -1,26 +1,11 @@
-import { useCallback } from "react";
-import { FlatList, Platform } from "react-native";
+import { Platform } from "react-native";
 
 import { useHeaderHeight } from "app/lib/react-navigation/elements";
 import { useRouter } from "app/navigation/use-router";
 
-import { View, Text, Pressable } from "design-system";
+import { View, Text, Pressable, ScrollView } from "design-system";
 import ChevronRight from "design-system/icon/ChevronRight";
 import { tw } from "design-system/tailwind";
-
-import { SettingSubTitle } from "./settings-subtitle";
-
-export const SettingAccountSlotHeader = () => {
-  return (
-    <View>
-      <SettingSubTitle>
-        <Text tw="text-gray-900 dark:text-white font-bold text-xl">
-          Privacy & Security
-        </Text>
-      </SettingSubTitle>
-    </View>
-  );
-};
 
 export type SettingItemProps = {
   id: number | string;
@@ -37,6 +22,19 @@ const list = [
     route: "blocked-list",
   },
 ];
+
+export const HeaderSection = () => {
+  return (
+    <View tw="bg-white dark:bg-black pt-4 px-4 pb-[3px] flex-row justify-between mb-4">
+      <Text
+        variant="text-2xl"
+        tw="text-gray-900 dark:text-white font-extrabold"
+      >
+        Privacy & Security
+      </Text>
+    </View>
+  );
+};
 
 export const AccountSettingItem = (props: SettingItemProps) => {
   const router = useRouter();
@@ -63,22 +61,20 @@ export const AccountSettingItem = (props: SettingItemProps) => {
 export const PrivacyAndSecuritySettings = () => {
   const headerHeight = useHeaderHeight();
 
-  const renderSetting = useCallback(({ item }) => {
-    return <AccountSettingItem {...item} />;
-  }, []);
+  const renderSetting = (item: SettingItemProps) => {
+    return (
+      <AccountSettingItem
+        key={`privacy-and-security-setting-${item.id}`}
+        {...item}
+      />
+    );
+  };
 
   return (
-    <View tw="bg-white dark:bg-black h-[100vh]">
+    <ScrollView>
       {Platform.OS !== "android" && <View tw={`h-[${headerHeight}px]`} />}
-      <View tw="bg-white dark:bg-black pt-4 px-4 pb-[3px] flex-row justify-between mb-4">
-        <Text
-          variant="text-2xl"
-          tw="text-gray-900 dark:text-white font-extrabold"
-        >
-          Privacy & Security
-        </Text>
-      </View>
-      <FlatList data={list} renderItem={renderSetting} />
-    </View>
+      <HeaderSection />
+      {list.map(renderSetting)}
+    </ScrollView>
   );
 };

--- a/packages/app/components/settings/privacy-and-security.tsx
+++ b/packages/app/components/settings/privacy-and-security.tsx
@@ -1,10 +1,12 @@
+import { useCallback } from "react";
+import { FlatList, Platform } from "react-native";
+
+import { useHeaderHeight } from "app/lib/react-navigation/elements";
 import { useRouter } from "app/navigation/use-router";
 
-import { View, Text, Button, ButtonLabel, Pressable } from "design-system";
+import { View, Text, Pressable } from "design-system";
 import ChevronRight from "design-system/icon/ChevronRight";
 import { tw } from "design-system/tailwind";
-import { useCallback } from "react";
-import { FlatList } from "react-native";
 
 import { SettingSubTitle } from "./settings-subtitle";
 
@@ -28,26 +30,24 @@ export type SettingItemProps = {
 };
 
 const list = [
-    {
-        id: 1,
-        title: "Blocked Accounts",
-        description: "Block accounts from sending you money",
-        icon: "lock",
-        route: "privacy-and-security",
-      },
-    ]
+  {
+    id: 1,
+    title: "Blocked Accounts",
+    icon: "lock",
+    route: "blocked-list",
+  },
+];
 
 export const AccountSettingItem = (props: SettingItemProps) => {
   const router = useRouter();
 
   return (
     <Pressable
-      tw="flex-1 flex-row justify-between w-full p-4 items-center"
+      tw="flex-1 flex-row justify-between w-full p-4 items-cente"
       onPress={() => router.push(`/settings/${props.route}`)}
     >
-      <View tw="flex flex-col items-start">
+      <View tw="flex flex-col items-start justify-center">
         <Text tw="text-gray-900 dark:text-white pb-3">{props.title}</Text>
-        <Text tw="text-gray-900 dark:text-white pb-3">{props.description}</Text>
       </View>
       <View tw="w-8 h-8">
         <ChevronRight
@@ -60,15 +60,25 @@ export const AccountSettingItem = (props: SettingItemProps) => {
   );
 };
 
-export const SettingList = ()=>{
-    const renderSetting = useCallback(({item})=>{
-        return (
-            <AccountSettingItem {...item}/>
-        )
-    }, [])
-    
-    return (<FlatList
-    data={}
-    renderItem={renderSetting}
-    />)
-}
+export const PrivacyAndSecuritySettings = () => {
+  const headerHeight = useHeaderHeight();
+
+  const renderSetting = useCallback(({ item }) => {
+    return <AccountSettingItem {...item} />;
+  }, []);
+
+  return (
+    <View tw="bg-white dark:bg-black h-[100vh]">
+      {Platform.OS !== "android" && <View tw={`h-[${headerHeight}px]`} />}
+      <View tw="bg-white dark:bg-black pt-4 px-4 pb-[3px] flex-row justify-between mb-4">
+        <Text
+          variant="text-2xl"
+          tw="text-gray-900 dark:text-white font-extrabold"
+        >
+          Privacy & Security
+        </Text>
+      </View>
+      <FlatList data={list} renderItem={renderSetting} />
+    </View>
+  );
+};

--- a/packages/app/components/settings/privacy-and-security.tsx
+++ b/packages/app/components/settings/privacy-and-security.tsx
@@ -1,0 +1,74 @@
+import { useRouter } from "app/navigation/use-router";
+
+import { View, Text, Button, ButtonLabel, Pressable } from "design-system";
+import ChevronRight from "design-system/icon/ChevronRight";
+import { tw } from "design-system/tailwind";
+import { useCallback } from "react";
+import { FlatList } from "react-native";
+
+import { SettingSubTitle } from "./settings-subtitle";
+
+export const SettingAccountSlotHeader = () => {
+  return (
+    <View>
+      <SettingSubTitle>
+        <Text tw="text-gray-900 dark:text-white font-bold text-xl">
+          Privacy & Security
+        </Text>
+      </SettingSubTitle>
+    </View>
+  );
+};
+
+export type SettingItemProps = {
+  id: number | string;
+  title: string;
+  description?: string;
+  route: string;
+};
+
+const list = [
+    {
+        id: 1,
+        title: "Blocked Accounts",
+        description: "Block accounts from sending you money",
+        icon: "lock",
+        route: "privacy-and-security",
+      },
+    ]
+
+export const AccountSettingItem = (props: SettingItemProps) => {
+  const router = useRouter();
+
+  return (
+    <Pressable
+      tw="flex-1 flex-row justify-between w-full p-4 items-center"
+      onPress={() => router.push(`/settings/${props.route}`)}
+    >
+      <View tw="flex flex-col items-start">
+        <Text tw="text-gray-900 dark:text-white pb-3">{props.title}</Text>
+        <Text tw="text-gray-900 dark:text-white pb-3">{props.description}</Text>
+      </View>
+      <View tw="w-8 h-8">
+        <ChevronRight
+          width={24}
+          height={24}
+          color={tw.style("dark:bg-gray-700 bg-gray-300").backgroundColor}
+        />
+      </View>
+    </Pressable>
+  );
+};
+
+export const SettingList = ()=>{
+    const renderSetting = useCallback(({item})=>{
+        return (
+            <AccountSettingItem {...item}/>
+        )
+    }, [])
+    
+    return (<FlatList
+    data={}
+    renderItem={renderSetting}
+    />)
+}

--- a/packages/app/components/settings/privacy-and-security.tsx
+++ b/packages/app/components/settings/privacy-and-security.tsx
@@ -60,6 +60,8 @@ export const AccountSettingItem = (props: SettingItemProps) => {
 
 export const PrivacyAndSecuritySettings = () => {
   const headerHeight = useHeaderHeight();
+  const shouldRenderHeaderGap =
+    Platform.OS !== "web" && Platform.OS !== "android";
 
   const renderSetting = (item: SettingItemProps) => {
     return (
@@ -72,7 +74,7 @@ export const PrivacyAndSecuritySettings = () => {
 
   return (
     <ScrollView>
-      {Platform.OS !== "android" && <View tw={`h-[${headerHeight}px]`} />}
+      {shouldRenderHeaderGap && <View tw={`h-[${headerHeight}px]`} />}
       <HeaderSection />
       {list.map(renderSetting)}
     </ScrollView>

--- a/packages/app/components/settings/settings-account-slot.tsx
+++ b/packages/app/components/settings/settings-account-slot.tsx
@@ -1,3 +1,4 @@
+import { Link } from "app/navigation/link";
 import { useRouter } from "app/navigation/use-router";
 
 import { View, Text, Button, ButtonLabel, Pressable } from "design-system";
@@ -19,7 +20,6 @@ export const SettingAccountSlotHeader = () => {
 };
 
 export const SettingAccountSlotFooter = () => {
-  // TODO(enes): implement delete account logics
   return (
     <View tw="px-4 mt-4">
       <View tw="flex flex-col items-start">
@@ -30,9 +30,11 @@ export const SettingAccountSlotFooter = () => {
           This action cannot be undone.
         </Text>
         <View tw="flex flex-row">
-          <Button variant="danger" size="small">
-            <ButtonLabel>Delete Account</ButtonLabel>
-          </Button>
+          <Link href="mailto:support@tryshowtime.com">
+            <Button variant="danger" size="small">
+              <ButtonLabel>Delete Account</ButtonLabel>
+            </Button>
+          </Link>
         </View>
       </View>
     </View>

--- a/packages/app/components/settings/settings-account-slot.tsx
+++ b/packages/app/components/settings/settings-account-slot.tsx
@@ -1,9 +1,10 @@
-import { Alert, Linking } from "react-native";
+import { Linking } from "react-native";
 
 import { Link } from "app/navigation/link";
 import { useRouter } from "app/navigation/use-router";
 
-import { View, Text, Button, ButtonLabel, Pressable } from "design-system";
+import { Button, ButtonLabel, Pressable, Text, View } from "design-system";
+import { useAlert } from "design-system/alert";
 import ChevronRight from "design-system/icon/ChevronRight";
 import { tw } from "design-system/tailwind";
 
@@ -23,6 +24,7 @@ export const SettingAccountSlotHeader = () => {
 
 export const SettingAccountSlotFooter = () => {
   const supportMailURL = "mailto:help@tryshowtime.com";
+  const Alert = useAlert();
 
   const handleDeleteAccount = async () => {
     try {

--- a/packages/app/components/settings/settings-account-slot.tsx
+++ b/packages/app/components/settings/settings-account-slot.tsx
@@ -19,6 +19,7 @@ export const SettingAccountSlotHeader = () => {
 };
 
 export const SettingAccountSlotFooter = () => {
+  // TODO(enes): implement delete account logics
   return (
     <View tw="px-4 mt-4">
       <View tw="flex flex-col items-start">

--- a/packages/app/components/settings/settings-account-slot.tsx
+++ b/packages/app/components/settings/settings-account-slot.tsx
@@ -1,3 +1,5 @@
+import { Alert, Linking } from "react-native";
+
 import { Link } from "app/navigation/link";
 import { useRouter } from "app/navigation/use-router";
 
@@ -20,6 +22,21 @@ export const SettingAccountSlotHeader = () => {
 };
 
 export const SettingAccountSlotFooter = () => {
+  const supportMailURL = "mailto:help@tryshowtime.com";
+
+  const handleDeleteAccount = async () => {
+    try {
+      const canOpenUrl = await Linking.canOpenURL(supportMailURL);
+      if (canOpenUrl) {
+        Linking.openURL(supportMailURL);
+      } else {
+        Alert.alert("Error", "Could not find a mail client on your device.");
+      }
+    } catch (error) {
+      Alert.alert("Error", "Something went wrong. Please try again later.");
+    }
+  };
+
   return (
     <View tw="px-4 mt-4">
       <View tw="flex flex-col items-start">
@@ -31,7 +48,7 @@ export const SettingAccountSlotFooter = () => {
         </Text>
         <View tw="flex flex-row">
           <Link href="mailto:support@tryshowtime.com">
-            <Button variant="danger" size="small">
+            <Button variant="danger" size="small" onPress={handleDeleteAccount}>
               <ButtonLabel>Delete Account</ButtonLabel>
             </Button>
           </Link>

--- a/packages/app/components/settings/settings-account-slot.tsx
+++ b/packages/app/components/settings/settings-account-slot.tsx
@@ -21,7 +21,7 @@ export const SettingAccountSlotHeader = () => {
 export const SettingAccountSlotFooter = () => {
   return (
     <View tw="px-4 mt-4">
-      <View style="flex flex-col items-start">
+      <View tw="flex flex-col items-start">
         <Text tw="text-gray-900 dark:text-white font-bold text-base">
           Delete Account
         </Text>

--- a/packages/app/components/settings/settings-account-slot.tsx
+++ b/packages/app/components/settings/settings-account-slot.tsx
@@ -1,0 +1,71 @@
+import { useRouter } from "app/navigation/use-router";
+
+import { View, Text, Button, ButtonLabel, Pressable } from "design-system";
+import ChevronRight from "design-system/icon/ChevronRight";
+import { tw } from "design-system/tailwind";
+
+import { SettingSubTitle } from "./settings-subtitle";
+
+export const SettingAccountSlotHeader = () => {
+  return (
+    <View>
+      <SettingSubTitle>
+        <Text tw="text-gray-900 dark:text-white font-bold text-xl">
+          Account
+        </Text>
+      </SettingSubTitle>
+    </View>
+  );
+};
+
+export const SettingAccountSlotFooter = () => {
+  return (
+    <View tw="px-4 mt-4">
+      <View style="flex flex-col items-start">
+        <Text tw="text-gray-900 dark:text-white font-bold text-base">
+          Delete Account
+        </Text>
+        <Text tw="text-gray-500 dark:text-white text-base mt-1 mb-2">
+          This action cannot be undone.
+        </Text>
+        <View tw="flex flex-row">
+          <Button variant="danger" size="small">
+            <ButtonLabel>Delete Account</ButtonLabel>
+          </Button>
+        </View>
+      </View>
+    </View>
+  );
+};
+
+export type AccountSettingItemProps = {
+  id: number | string;
+  title: string;
+  subRoute: string;
+};
+
+export const AccountSettingItem = (props: AccountSettingItemProps) => {
+  const router = useRouter();
+
+  const handleOnPressItem = (route: string) => {
+    router.push(`/settings/${route}`);
+  };
+
+  return (
+    <Pressable
+      tw="flex-1 flex-row justify-between w-full p-4 items-center"
+      onPress={() => handleOnPressItem(props.subRoute)}
+    >
+      <View tw="flex flex-col">
+        <Text tw="text-gray-900 dark:text-white pb-3">{props.title}</Text>
+      </View>
+      <View tw="w-8 h-8">
+        <ChevronRight
+          width={24}
+          height={24}
+          color={tw.style("dark:bg-gray-700 bg-gray-300").backgroundColor}
+        />
+      </View>
+    </Pressable>
+  );
+};

--- a/packages/app/components/trending.tsx
+++ b/packages/app/components/trending.tsx
@@ -66,15 +66,14 @@ export const Trending = () => {
   const [selected, setSelected] = useState(0);
   const isDark = useIsDarkMode();
   const headerHeight = useHeaderHeight();
+  const isWeb = Platform.OS === "web";
 
   return (
     <View tw="bg-white dark:bg-black flex-1">
       <Tabs.Root onIndexChange={setSelected} initialIndex={selected} lazy>
         <Tabs.Header>
-          {Platform.OS === "ios" && (
-            <View tw={`h-[${headerHeight}px] bg-white dark:bg-black`} />
-          )}
-          <View tw="bg-white dark:bg-black pt-4 pl-4 pb-[3px]">
+          {Platform.OS === "ios" && <View tw={`h-[${headerHeight}px]`} />}
+          <View tw="bg-white dark:bg-black pt-4 px-4 pb-[3px] flex-row justify-between">
             <Text
               //@ts-ignore
               variant="text-2xl"
@@ -96,15 +95,15 @@ export const Trending = () => {
           )}
           contentContainerStyle={tw.style("w-full")}
         >
-          <Tabs.Trigger style={{ flex: 1 }}>
+          <Tabs.Trigger style={isWeb ? { height: "100%" } : { flex: 1 }}>
             <TabItem name="Today" selected={selected === 0} />
           </Tabs.Trigger>
 
-          <Tabs.Trigger style={{ flex: 1 }}>
+          <Tabs.Trigger style={isWeb ? { height: "100%" } : { flex: 1 }}>
             <TabItem name="This week" selected={selected === 1} />
           </Tabs.Trigger>
 
-          <Tabs.Trigger style={{ flex: 1 }}>
+          <Tabs.Trigger style={isWeb ? { height: "100%" } : { flex: 1 }}>
             <TabItem name="This month" selected={selected === 2} />
           </Tabs.Trigger>
 

--- a/packages/app/navigation/linking.ts
+++ b/packages/app/navigation/linking.ts
@@ -34,6 +34,9 @@ const linking: LinkingOptions<ReactNavigation.RootParamList> = {
       profile: "profile/:username",
       editProfile: "profile/edit",
       settings: "settings",
+      privacySecuritySettings: "settings/privacy-and-security",
+      notificationSettings: "settings/notifications",
+      blockedList: "settings/blocked-list",
       swipeList: "list",
       bottomTabs: {
         screens: {

--- a/packages/app/navigation/root-stack-navigator.tsx
+++ b/packages/app/navigation/root-stack-navigator.tsx
@@ -3,6 +3,7 @@ import { Platform } from "react-native";
 import { useSafeAreaInsets } from "app/lib/safe-area";
 import { screenOptions } from "app/navigation/navigator-screen-options";
 import { ActivitiesScreen } from "app/screens/activities";
+import { BlockedListScreen } from "app/screens/blocked-list";
 import { CommentsScreen } from "app/screens/comments";
 import { CreateScreen } from "app/screens/create";
 import { DeleteScreen } from "app/screens/delete";
@@ -11,6 +12,8 @@ import { EditProfileScreen } from "app/screens/edit-profile";
 import { ListScreen } from "app/screens/list";
 import { LoginScreen } from "app/screens/login";
 import { NftScreen } from "app/screens/nft";
+import { NotificationSettingsScreen } from "app/screens/notification-settings";
+import { PrivacySecuritySettingsScreen } from "app/screens/privacy-and-security-settings";
 import { ProfileScreen } from "app/screens/profile";
 import { SearchScreen } from "app/screens/search";
 import { SettingsScreen } from "app/screens/settings";
@@ -49,6 +52,15 @@ export function RootStackNavigator() {
           getId={({ params }) => params?.username}
         />
         <Stack.Screen name="settings" component={SettingsScreen} />
+        <Stack.Screen
+          name="privacySecuritySettings"
+          component={PrivacySecuritySettingsScreen}
+        />
+        <Stack.Screen
+          name="notificationSettings"
+          component={NotificationSettingsScreen}
+        />
+        <Stack.Screen name="blockedList" component={BlockedListScreen} />
         <Stack.Screen
           name="search"
           component={SearchScreen}

--- a/packages/app/screens/blocked-list.tsx
+++ b/packages/app/screens/blocked-list.tsx
@@ -3,12 +3,14 @@ import { useEffect } from "react";
 import { withColorScheme } from "app/components/memo-with-theme";
 import { mixpanel } from "app/lib/mixpanel";
 
+import { BlockedList } from "../components/settings/blocked-list";
+
 const BlockedListScreen = withColorScheme(() => {
   useEffect(() => {
     mixpanel.track("Blocket List screen");
   }, []);
 
-  return null;
+  return <BlockedList />;
 });
 
 export { BlockedListScreen };

--- a/packages/app/screens/blocked-list.tsx
+++ b/packages/app/screens/blocked-list.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+
+import { withColorScheme } from "app/components/memo-with-theme";
+import { mixpanel } from "app/lib/mixpanel";
+
+const BlockedListScreen = withColorScheme(() => {
+  useEffect(() => {
+    mixpanel.track("Blocket List screen");
+  }, []);
+
+  return null;
+});
+
+export { BlockedListScreen };

--- a/packages/app/screens/notification-settings.tsx
+++ b/packages/app/screens/notification-settings.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+
+import { withColorScheme } from "app/components/memo-with-theme";
+import { mixpanel } from "app/lib/mixpanel";
+
+const NotificationSettingsScreen = withColorScheme(() => {
+  useEffect(() => {
+    mixpanel.track("Notification Settings screen");
+  }, []);
+
+  return null;
+});
+
+export { NotificationSettingsScreen };

--- a/packages/app/screens/privacy-and-security-settings.tsx
+++ b/packages/app/screens/privacy-and-security-settings.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+
+import { withColorScheme } from "app/components/memo-with-theme";
+import { mixpanel } from "app/lib/mixpanel";
+
+const PrivacySecuritySettingsScreen = withColorScheme(() => {
+  useEffect(() => {
+    mixpanel.track("Privacy and Security screen");
+  }, []);
+
+  return null;
+});
+
+export { PrivacySecuritySettingsScreen };

--- a/packages/app/screens/privacy-and-security-settings.tsx
+++ b/packages/app/screens/privacy-and-security-settings.tsx
@@ -3,12 +3,14 @@ import { useEffect } from "react";
 import { withColorScheme } from "app/components/memo-with-theme";
 import { mixpanel } from "app/lib/mixpanel";
 
+import { PrivacyAndSecuritySettings } from "../components/settings/privacy-and-security";
+
 const PrivacySecuritySettingsScreen = withColorScheme(() => {
   useEffect(() => {
     mixpanel.track("Privacy and Security screen");
   }, []);
 
-  return null;
+  return <PrivacyAndSecuritySettings />;
 });
 
 export { PrivacySecuritySettingsScreen };

--- a/packages/design-system/button/constants.ts
+++ b/packages/design-system/button/constants.ts
@@ -34,8 +34,8 @@ const CONTAINER_BACKGROUND_MAPPER = {
     pressed: [colors.gray[300], colors.gray[700]],
   },
   danger: {
-    default: [colors.red[500], colors.gray[300]],
-    pressed: [colors.red[700], colors.gray[300]],
+    default: [colors.red[500], colors.red[500]],
+    pressed: [colors.red[700], colors.red[700]],
   },
 };
 

--- a/packages/design-system/tabs/tablib/index.web.tsx
+++ b/packages/design-system/tabs/tablib/index.web.tsx
@@ -101,6 +101,8 @@ const Root = ({
                   alignItems: "center",
                   paddingHorizontal: 10,
                   height: "100%",
+                  display: "flex",
+                  justifyContent: "flex-end",
                 },
                 tw.style(`bg-white dark:bg-black px-2`),
                 (listChild as any).props?.contentContainerStyle,

--- a/packages/design-system/tabs/tablib/index.web.tsx
+++ b/packages/design-system/tabs/tablib/index.web.tsx
@@ -84,59 +84,61 @@ const Root = ({
 
   return (
     <TabsContext.Provider value={{ position, offset }}>
-      {headerChild}
       <RadixTabs.Root
         value={selected}
         onValueChange={onIndexChange}
         activationMode="manual"
       >
-        <RadixTabs.List aria-label={accessibilityLabel} asChild>
-          <ScrollView
-            {...(listChild as any).props}
-            contentContainerStyle={[
-              {
-                flexDirection: "row",
-                flexWrap: "nowrap",
-                alignItems: "center",
-                paddingHorizontal: 10,
-                height: "100%",
-              },
-              tw.style(`bg-white dark:bg-black px-2`),
-              (listChild as any).props?.contentContainerStyle,
-            ]}
-          >
-            {tabTriggers.map((t, index) => {
-              const value = index.toString();
+        <View tw="flex flex-row justify-between shadow-md">
+          {headerChild}
+          <RadixTabs.List aria-label={accessibilityLabel} asChild>
+            <ScrollView
+              {...(listChild as any).props}
+              contentContainerStyle={[
+                {
+                  flexDirection: "row",
+                  flexWrap: "nowrap",
+                  alignItems: "center",
+                  paddingHorizontal: 10,
+                  height: "100%",
+                },
+                tw.style(`bg-white dark:bg-black px-2`),
+                (listChild as any).props?.contentContainerStyle,
+              ]}
+            >
+              {tabTriggers.map((t, index) => {
+                const value = index.toString();
 
-              return (
-                <RadixTabs.Trigger
-                  value={value}
-                  key={value}
-                  style={radixTriggerStyle}
-                  {...t.props}
-                >
-                  <TabIndexContext.Provider value={{ index }}>
-                    <View
-                      sx={{
-                        alignItems: "center",
-                        borderBottomWidth: 2,
-                        height: "100%",
-                        justifyContent: "center",
-                      }}
-                      tw={
-                        selected === value
-                          ? "border-b-gray-900 dark:border-b-gray-100"
-                          : "border-b-transparent"
-                      }
-                    >
-                      {t}
-                    </View>
-                  </TabIndexContext.Provider>
-                </RadixTabs.Trigger>
-              );
-            })}
-          </ScrollView>
-        </RadixTabs.List>
+                return (
+                  <RadixTabs.Trigger
+                    value={value}
+                    key={value}
+                    style={radixTriggerStyle}
+                    {...t.props}
+                  >
+                    <TabIndexContext.Provider value={{ index }}>
+                      <View
+                        sx={{
+                          alignItems: "center",
+                          borderBottomWidth: 2,
+                          height: "100%",
+                          justifyContent: "center",
+                        }}
+                        tw={
+                          selected === value
+                            ? "border-b-gray-900 dark:border-b-gray-100"
+                            : "border-b-transparent"
+                        }
+                      >
+                        {t}
+                      </View>
+                    </TabIndexContext.Provider>
+                  </RadixTabs.Trigger>
+                );
+              })}
+            </ScrollView>
+          </RadixTabs.List>
+        </View>
         {tabContents.map((c, index) => {
           const value = index.toString();
           return (


### PR DESCRIPTION
# Why

Settings page account tab implementation:
- Account tab in settings
  - Here, the Delete account tab redirects the user to mail `help@tryshowtime.com`
- Privacy & Security subroute
- Blocked List subroute
  - Here, we show under maintain message like notifications.
- Tab lib refactor to match the UI with the designs.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Refactored Tab lib for web (index.web.tsx). Implemented new settings pages like (privacy-security, blocked-list) for both mobile and web.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Run the code on all platforms and make check for missing features, and UI issues. 
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
