### PR TITLE
Improve Create modal on web

### DIFF
--- a/packages/app/components/header.tsx
+++ b/packages/app/components/header.tsx
@@ -5,7 +5,6 @@ import { HeaderDropdown } from "app/components/header-dropdown";
 import { useUser } from "app/hooks/use-user";
 import { Link } from "app/navigation/link";
 import {
-  CameraTabBarIcon,
   ShowtimeTabBarIcon,
   TrendingTabBarIcon,
 } from "app/navigation/tab-bar-icons";
@@ -14,7 +13,7 @@ import { useRouter } from "app/navigation/use-router";
 
 import { Button, Pressable, View } from "design-system";
 import { useBlurredBackgroundColor, useIsDarkMode } from "design-system/hooks";
-import { ArrowLeft, Search } from "design-system/icon";
+import { ArrowLeft, Plus, Search } from "design-system/icon";
 import { Input } from "design-system/input";
 import { tw } from "design-system/tailwind";
 import { breakpoints } from "design-system/theme";
@@ -40,10 +39,37 @@ const HeaderRight = () => {
                 />
               </View>
               <View tw="mx-2">
-                <CameraTabBarIcon
-                  color={isDark ? "white" : "black"}
-                  focused={false}
-                />
+                <Pressable
+                  onPress={() => {
+                    router.push(
+                      Platform.select({
+                        native: "/camera",
+                        web: {
+                          pathname: router.pathname,
+                          query: { ...router.query, createModal: true },
+                        },
+                      }),
+                      Platform.select({
+                        native: "/camera",
+                        web: router.asPath === "/" ? "/create" : router.asPath,
+                      }),
+                      { shallow: true }
+                    );
+                  }}
+                >
+                  <View
+                    tw={[
+                      "rounded-full h-12 w-12 justify-center items-center",
+                      "bg-black dark:bg-white",
+                    ]}
+                  >
+                    <Plus
+                      width={24}
+                      height={24}
+                      color={isDark ? "black" : "white"}
+                    />
+                  </View>
+                </Pressable>
               </View>
             </>
           )}

--- a/packages/app/components/transfer.tsx
+++ b/packages/app/components/transfer.tsx
@@ -174,13 +174,14 @@ function Transfer({ nft }: { nft?: NFT }) {
                   width={14}
                 />
                 <Text tw="text-gray-500 font-bold pl-1" variant="text-xs">
-                  {nft?.token_created &&
-                    `Minted ${formatDistanceToNowStrict(
-                      new Date(nft?.token_created),
-                      {
-                        addSuffix: true,
-                      }
-                    )}`}
+                  {nft?.token_created
+                    ? `Minted ${formatDistanceToNowStrict(
+                        new Date(nft?.token_created),
+                        {
+                          addSuffix: true,
+                        }
+                      )}`
+                    : null}
                 </Text>
               </View>
             </View>

--- a/packages/app/navigation/tab-bar-icons.tsx
+++ b/packages/app/navigation/tab-bar-icons.tsx
@@ -1,22 +1,19 @@
-import { Suspense } from "react";
 import { Platform, useWindowDimensions } from "react-native";
 
-import { ErrorBoundary } from "app/components/error-boundary";
 import { useCurrentUserAddress } from "app/hooks/use-current-user-address";
-import { useNotifications } from "app/hooks/use-notifications";
 import { useUser } from "app/hooks/use-user";
 import { Link } from "app/navigation/link";
 
 import { Avatar } from "design-system/avatar";
 import {
-  Home,
-  HomeFilled,
-  Compass,
-  CompassFilled,
-  Hot,
-  HotFilled,
   Bell,
   BellFilled,
+  Compass,
+  CompassFilled,
+  Home,
+  HomeFilled,
+  Hot,
+  HotFilled,
   Plus,
   Showtime,
 } from "design-system/icon";
@@ -109,8 +106,15 @@ export const ShowtimeTabBarIcon = ({ customTw }: TabBarIconProps) => {
 };
 
 export const CameraTabBarIcon = ({ color, focused }: TabBarIconProps) => {
+  const { width } = useWindowDimensions();
+
   return (
-    <TabBarIcon tab={Platform.select({ default: "/camera", web: "/create" })}>
+    <TabBarIcon
+      tab={Platform.select({
+        default: "/camera",
+        web: width >= breakpoints["md"] ? "/create" : "/camera",
+      })}
+    >
       <View
         tw={[
           "rounded-full h-12 w-12 justify-center items-center",

--- a/packages/app/pages/create.tsx
+++ b/packages/app/pages/create.tsx
@@ -1,3 +1,3 @@
-import { CreateScreen } from "app/screens/create";
+import { HomeScreen } from "app/screens/home";
 
-export default CreateScreen;
+export default HomeScreen;

--- a/packages/design-system/modal-screen/with-modal-screen.web.tsx
+++ b/packages/design-system/modal-screen/with-modal-screen.web.tsx
@@ -1,9 +1,9 @@
-import { FC, useCallback, useRef } from "react";
-
 import { useRouter } from "app/navigation/use-router";
-
 import { ModalMethods } from "design-system/modal";
 import { ModalScreen } from "design-system/modal/modal.screen";
+import { FC, useCallback, useRef } from "react";
+
+
 
 function withModalScreen<P>(
   Screen: FC<P>,
@@ -16,7 +16,7 @@ function withModalScreen<P>(
     const router = useRouter();
 
     const onClose = useCallback(() => {
-      if (router.asPath === "/login") {
+      if (router.asPath === "/login" || router.asPath === "/create") {
         router.push("/");
       } else {
         router.pop();

--- a/packages/design-system/modal/modal.container.web.tsx
+++ b/packages/design-system/modal/modal.container.web.tsx
@@ -19,6 +19,7 @@ const MODAL_CONTAINER_TW = [
   "bg-white dark:bg-black",
   "shadow-xl shadow-black dark:shadow-white",
   "rounded-t-[32px] rounded-b-0 sm:rounded-b-[32px]",
+  "max-h-100vh",
 ];
 
 const MODAL_BODY_TW = "flex-1 overflow-scroll";


### PR DESCRIPTION
# Why

We had to finish some leftovers from our recent work on the Create modal / flow

# How

- Improve the way we handle `/create` → only change the route when on the home page, otherwise we need to use the query params only
- Review design after modals update
- Mobile web should behave like native

# Test Plan

Run the web app and check the Create modal / flow on desktop and mobile