### PR TITLE
fix: objects are not valid react child (poor objects)

### DIFF
--- a/apps/expo/App.tsx
+++ b/apps/expo/App.tsx
@@ -107,7 +107,7 @@ function SWRProvider({ children }: { children: React.ReactNode }): JSX.Element {
       value={{
         provider: mmkvProvider,
         onError: (err, key) => {
-          if (err.message) {
+          if (err?.message) {
             toast?.show({
               message: err.message,
               hideAfter: 4000,

--- a/apps/next-react-native/src/pages/_app.tsx
+++ b/apps/next-react-native/src/pages/_app.tsx
@@ -94,7 +94,7 @@ function SWRProvider({ children }: { children: React.ReactNode }): JSX.Element {
       value={{
         provider: isServer ? () => new Map() : localStorageProvider,
         onError: (err, key) => {
-          if (err.message) {
+          if (err?.message) {
             toast?.show({
               message: err.message,
               hideAfter: 4000,


### PR DESCRIPTION
# Why
- Fixes below error. 
- When API fails, the toast that was supposed to show an error was itself causing an error 😂 . This PR fixes it.


<img width="1437" alt="Screenshot 2022-04-28 at 7 17 07 PM" src="https://user-images.githubusercontent.com/23293248/165891214-5231dafb-65a5-4405-9368-a86140fe9b3d.png">

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- The error passed in Toast is an object, so we check if it has message property and pass that instead. I am not sure if it's a perfect solution, but let me know.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Try to fail the API.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
