### PR TITLE
Fix comments loading

### DIFF
--- a/packages/app/hooks/api/use-comments.ts
+++ b/packages/app/hooks/api/use-comments.ts
@@ -55,7 +55,7 @@ export const useComments = (nftId: number) => {
     function fetchCommentsURL(index) {
       // TODO: uncomment when pagination is fixed.
       // return `/v2/comments/${nftId}?limit=10&page=${index + 1}`;
-      return `/v2/comments/${nftId}`;
+      return nftId ? `/v2/comments/${nftId}` : null;
     },
     [nftId]
   );


### PR DESCRIPTION
# Why

Comments are throwing a 404 when opening the modal because the NFT id is null while we query the NFT details

# How

Return `null` as fetch URL if we don't have the NFT id yet

# Test Plan

Run the app and open the Comments modal
