### PR TITLE
fix: in app links on profile bio (show2-765)

### DIFF
--- a/packages/app/components/profile/profile-top.tsx
+++ b/packages/app/components/profile/profile-top.tsx
@@ -255,16 +255,6 @@ export const ProfileTop = ({
                       <VerificationBadge size={16} />
                     </View>
                   ) : null}
-                  {/* {profileData?.data ? (
-                <View tw="bg-gray-100 dark:bg-gray-900 ml-2 h-[23px] px-2 justify-center rounded-full">
-                  <Text
-                    variant="text-xs"
-                    tw="dark:text-gray-400 text-gray-500 font-semibold"
-                  >
-                    Follows You
-                  </Text>
-                </View>
-              ) : null} */}
                 </View>
               </Skeleton>
             </View>
@@ -288,19 +278,6 @@ export const ProfileTop = ({
                 tw="mt-4"
               />
             </Hidden>
-
-            {/* <View>
-            <View tw="flex-row items-center">
-              <Text tw="text-gray-600 dark:text-gray-400 font-medium text-xs">
-                Followed by{" "}
-              </Text>
-              <Pressable>
-                <Text tw="dark:text-white text-gray-900 font-bold text-xs">
-                  @m1guelpf
-                </Text>
-              </Pressable>
-            </View>
-          </View> */}
           </View>
         </View>
       </View>


### PR DESCRIPTION
# Why

For bio description, we parse string for mentions. But rendering the output as string, this cause the mentions render as `[object Object]`. Fixed that.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
Instead of rendering the parsed text in template literals, rendered directly.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
I was able to test it on web and iOS. But couldn't tested it on Android because of current issues ([hope will be fixed](https://github.com/showtime-xyz/showtime-frontend/pull/1089) thanks to @intergalacticspacehighway, will try again today)

If you can help me to test in on Android, that would be great 🙌🏽
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
<img width="505" alt="Screen Shot 2022-05-05 at 07 31 30" src="https://user-images.githubusercontent.com/19428358/166864839-3af7ee79-30ea-4edf-a584-0456b443b66e.png">
On mobile, checked if there is inline-block issue (that is why there are red bg's). Looks ok.
<img width="518" alt="Screen Shot 2022-05-05 at 07 35 46" src="https://user-images.githubusercontent.com/19428358/166864781-fecd3610-01d1-4722-a93e-b4019ff5f84e.png">
On web
<img width="704" alt="Screen Shot 2022-05-05 at 07 46 15" src="https://user-images.githubusercontent.com/19428358/166864870-fb9ed544-5a0c-467b-8f4e-41293d2dcfed.png">



