### PR TITLE
fix: swipelist video in android

### DIFF
--- a/packages/app/components/swipe-list.tsx
+++ b/packages/app/components/swipe-list.tsx
@@ -195,6 +195,7 @@ export const SwipeList = ({
         layoutProvider={_layoutProvider}
         dataProvider={dataProvider}
         rowRenderer={_rowRenderer}
+        disableRecycling={Platform.OS === 'android'}
         ref={listRef}
         initialRenderIndex={initialScrollIndex}
         style={tw.style("dark:bg-gray-900 bg-gray-100")}


### PR DESCRIPTION
# Why
- Recycling feature in swipelist reuses view instead of unmounting which also mounts the video from that view.
- For now, adds disableRecycling which will unmount/mount views (only on swipelist). I don't think this will affect perfomance as our swipelist is full screen and doesn't mount a lot of views. At this point, all I can do is wish list. 😂 
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Test on android [post merging this PR](https://github.com/showtime-xyz/showtime-frontend/pull/1089)
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
