### PR TITLE
feat: remove blurred media background on the (show2-778)

### DIFF
--- a/packages/app/components/swipe-list.tsx
+++ b/packages/app/components/swipe-list.tsx
@@ -290,7 +290,7 @@ export const FeedItem = memo(
 
     return (
       <LikeContextProvider nft={nft}>
-        <BlurView style={tw.style("flex-1 w-full")} tint={tint} intensity={85}>
+        <View tw="w-full flex-1">
           {Platform.OS !== "web" && (
             <View>
               {nft.blurhash ? (
@@ -359,7 +359,7 @@ export const FeedItem = memo(
               />
             </BlurView>
           </Reanimated.View>
-        </BlurView>
+        </View>
       </LikeContextProvider>
     );
   }


### PR DESCRIPTION
# Why

There was bg between media items and blurred images on mobile feed. Also on some images nft action buttons was showing a little opaque.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Removed bg and added opaque bg to blur the view. Also needed to remove parent BlurView, it causes child blur view acting unexpectedly.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Check on mobile and web.
| iOS  |  Web |
|---| --- |
|  <img width="300" alt="Screen Shot 2022-05-09 at 19 24 25" src="https://user-images.githubusercontent.com/19428358/167454484-c815f185-66f8-4fdd-9baa-042b7832d567.png"> |  <img width="300" alt="Screen Shot 2022-05-09 at 19 24 12" src="https://user-images.githubusercontent.com/19428358/167454501-b39ec111-315f-48c2-b86f-053da1af45a3.png">|

> On Android the package `expo-blur` doesn't support blur views. Maybe this can be replaced with Skia (not sure its ok with it, Android is really bad ad blur views.. I'll handle it another task


<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
