### PR TITLE
fix: scrolling issue on mobile and bottom gap

### DIFF
--- a/packages/app/components/search/index.tsx
+++ b/packages/app/components/search/index.tsx
@@ -26,7 +26,7 @@ export const Search = () => {
     () => <View tw="h-[1px] bg-gray-200 dark:bg-gray-800" />,
     []
   );
-  const isOS = Platform.OS === "ios";
+  const isiOS = Platform.OS === "ios";
 
   const renderItem = useCallback(({ item }) => {
     return <SearchItem item={item} />;
@@ -41,7 +41,7 @@ export const Search = () => {
 
   return (
     <>
-      {isOS ? <View tw={`h-[${headerHeight}px]`} /> : null}
+      {isiOS ? <View tw={`h-[${headerHeight}px]`} /> : null}
       <View tw="px-4 py-2">
         <Input
           placeholder="Search for @username or name.eth"
@@ -87,7 +87,7 @@ export const Search = () => {
           data={data}
           contentContainerStyle={tw.style(`pb-[${headerHeight}px]`)}
           ListFooterComponent={
-            isOS ? <View tw={`h-[${headerHeight}px]`} /> : null
+            isiOS ? <View tw={`h-[${headerHeight}px]`} /> : null
           }
           renderItem={renderItem}
           ItemSeparatorComponent={Separator}


### PR DESCRIPTION
# Why

The bottom gap needed to scroll to see the last items on the search screen. 

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Added gap to the bottom as header height. 

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Searching and scrolling on all platforms

| Result |
|---|
| https://user-images.githubusercontent.com/19428358/167866980-5c7c910a-fcd6-4141-b180-3be3ca0637f2.mov |




<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
