### PR TITLE
fix: other user profile not loading

### DIFF
--- a/packages/app/components/profile/profile-top.tsx
+++ b/packages/app/components/profile/profile-top.tsx
@@ -79,9 +79,9 @@ export const ProfileTop = ({
   const colorMode = useColorScheme();
   const { width } = useWindowDimensions();
   const { isFollowing } = useMyInfo();
-  const bottomTabBarHeight = useBottomTabBarHeight();
   const tabBarHeight = useContext(BottomTabBarHeightContext)
-    ? bottomTabBarHeight
+    ? // eslint-disable-next-line react-hooks/rules-of-hooks
+      useBottomTabBarHeight()
     : 0;
   const profileId = profileData?.data.profile.profile_id;
   const isFollowingUser = useMemo(

--- a/packages/app/hooks/use-platform-bottom-height.ts
+++ b/packages/app/hooks/use-platform-bottom-height.ts
@@ -13,9 +13,9 @@ export const usePlatformBottomHeight = () => {
   const insets = useSafeAreaInsets();
   const { width } = useWindowDimensions();
   const isMdWidth = width >= breakpoints["md"];
-  const bottomTabBarHeight = useBottomTabBarHeight();
   const nativeBottomTabBarHeight = useContext(BottomTabBarHeightContext)
-    ? bottomTabBarHeight
+    ? // eslint-disable-next-line react-hooks/rules-of-hooks
+      useBottomTabBarHeight()
     : insets.bottom;
   const webBottomTabBarHeight = isMdWidth ? insets.bottom : insets.bottom + 64;
 


### PR DESCRIPTION
# Why
- Profile screen is not always into bottom navigator so the bottom bar height hook throws an error, so we need a conditional hook 😞. We can use context to avoid it tho. Got introduced in this [fix](https://github.com/showtime-xyz/showtime-frontend/pull/1104/files)
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Open profile screen for other users
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
