### PR TITLE
fix: comments modal screen

### DIFF
--- a/packages/design-system/modal/modal.footer.tsx
+++ b/packages/design-system/modal/modal.footer.tsx
@@ -13,10 +13,9 @@ import { useKeyboardOffset } from "./useKeyboardOffset";
 function ModalFooterComponent({ children }: ModalFooterProps) {
   const bottomSheetContext = useBottomSheetInternal(true);
   const { bottom, top } = useSafeAreaInsets();
-
   const animatedContainerStyle = useKeyboardOffset(
     top,
-    bottomSheetContext.animatedKeyboardState
+    bottomSheetContext?.animatedKeyboardState
   );
 
   if (bottomSheetContext == null) {

--- a/packages/design-system/modal/useKeyboardOffset.android.ts
+++ b/packages/design-system/modal/useKeyboardOffset.android.ts
@@ -3,11 +3,11 @@ import { useAnimatedStyle, SharedValue } from "react-native-reanimated";
 
 export const useKeyboardOffset = (
   top: number,
-  keyboardState: SharedValue<KEYBOARD_STATE>
+  keyboardState?: SharedValue<KEYBOARD_STATE>
 ) => {
   const animatedContainerStyle = useAnimatedStyle(
     () => ({
-      paddingBottom: keyboardState.value === KEYBOARD_STATE.SHOWN ? top : 0,
+      paddingBottom: keyboardState?.value === KEYBOARD_STATE.SHOWN ? top : 0,
     }),
     [top, keyboardState]
   );

--- a/packages/design-system/modal/useKeyboardOffset.ts
+++ b/packages/design-system/modal/useKeyboardOffset.ts
@@ -4,5 +4,5 @@ import type { SharedValue } from "react-native-reanimated";
 
 export const useKeyboardOffset = (
   top: number,
-  keyboardState: SharedValue<KEYBOARD_STATE>
+  keyboardState?: SharedValue<KEYBOARD_STATE>
 ) => undefined;


### PR DESCRIPTION
# Why

on iOS, `bottomSheetContext`'s `animatedKeyboardState` maybe is `undefined`, so needs to be compatible. 

![image](https://user-images.githubusercontent.com/37520667/168286055-369f0dbb-f1e4-4816-8617-65f49ea01567.png)

# How

- Set `keyboardState` as an optional parameter.


# Test Plan

iOS/Android/Web have been tested, work well!
