### PR TITLE
fix: set immediate gesture handler error

### DIFF
--- a/packages/design-system/pinch-to-zoom/index.web.tsx
+++ b/packages/design-system/pinch-to-zoom/index.web.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import type { ViewProps } from "react-native";
+
+import Animated from "react-native-reanimated";
+
+type Props = {
+  children: React.ReactNode;
+  minimumZoomScale?: number;
+  maximumZoomScale?: number;
+  onPinchStart?: () => void;
+  onPinchEnd?: () => void;
+  disabled?: boolean;
+} & ViewProps;
+
+export function PinchToZoom(props: Props) {
+  return <Animated.View {...props} />;
+}


### PR DESCRIPTION
# Why
Using GestureDetector on web is throwing an error.  Could be a bug in gesture handler
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- Adds noop pinch to zoom on web

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Run webapp
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
