### PR TITLE
fix: dismiss the comments modal when navigating out

### DIFF
--- a/packages/app/components/comments/comment-row.tsx
+++ b/packages/app/components/comments/comment-row.tsx
@@ -1,11 +1,9 @@
 import { Fragment, memo, useCallback, useMemo, useState } from "react";
 import { Platform } from "react-native";
 
-import { useNavigation } from "@react-navigation/native";
-import { StackActions } from "@react-navigation/native";
-
 import { CommentType } from "app/hooks/api/use-comments";
 import { useUser } from "app/hooks/use-user";
+import { useNavigation, StackActions } from "app/lib/react-navigation/native";
 import { useNavigateToLogin } from "app/navigation/use-navigate-to";
 import { useRouter } from "app/navigation/use-router";
 import { formatAddressShort, getRoundedCount } from "app/utilities";


### PR DESCRIPTION
# Why

The current method of navigating from the comments modal is to push a new screen on top of the modal. However, it should close the modal too.

https://linear.app/showtime/issue/SHOW2-828/commentsmodal-not-closing

# How

I have updated the navigate method from `push` to `replace`, however it does NOT work on mobile? - so i had to use dispatch with replace action instead of `useRouter` 

# Test Plan

- Launch the app
- Navigate to any post comments modal
- Tap on any customer profile pic.
  - The app should navigate to customer profile
- Navigate back
  - The modal should be closed.
