### PR TITLE
fix: home feed list empty bug.

### DIFF
--- a/packages/app/components/feed/feed.md.tsx
+++ b/packages/app/components/feed/feed.md.tsx
@@ -230,7 +230,7 @@ const NFTScrollList = ({
     }),
     []
   );
-  if (data?.length === 0)
+  if (data?.length === 0) {
     return (
       <View
         tw="w-full justify-center mt-4 h-60vh rounded-2xl"
@@ -245,6 +245,7 @@ const NFTScrollList = ({
         />
       </View>
     );
+  }
   return (
     <VideoConfigContext.Provider value={videoConfig}>
       <View


### PR DESCRIPTION
# Why

home feed tab list UI will be broken when the home list is empty.

# How
- set parent `View` width and add `EmptyPlaceholder` component. (for aesthetics, I made a little modification)

# Test Plan 

- check if the style is normal when the list is empty

![image](https://user-images.githubusercontent.com/37520667/169507659-07464b21-0184-4cc1-938b-73a042eb4e42.png)



