### PR TITLE
fix: fixed version of Rudder.

### DIFF
--- a/patches/@rudderstack+rudder-sdk-react-native+1.4.0.patch
+++ b/patches/@rudderstack+rudder-sdk-react-native+1.4.0.patch
@@ -1,0 +1,26 @@
+diff --git a/node_modules/@rudderstack/rudder-sdk-react-native/RNRudderSdk.podspec b/node_modules/@rudderstack/rudder-sdk-react-native/RNRudderSdk.podspec
+index 0df77b4..15e8f68 100644
+--- a/node_modules/@rudderstack/rudder-sdk-react-native/RNRudderSdk.podspec
++++ b/node_modules/@rudderstack/rudder-sdk-react-native/RNRudderSdk.podspec
+@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
+   s.requires_arc = true
+ 
+   s.dependency "React"
+-  s.dependency "Rudder", ">= 1.6.0"
++  s.dependency "Rudder", "1.6.0"
+ end
+ 
+ 
+diff --git a/node_modules/@rudderstack/rudder-sdk-react-native/ios/RNRudderSdkModule.h b/node_modules/@rudderstack/rudder-sdk-react-native/ios/RNRudderSdkModule.h
+index f9020d1..d2cf7c9 100644
+--- a/node_modules/@rudderstack/rudder-sdk-react-native/ios/RNRudderSdkModule.h
++++ b/node_modules/@rudderstack/rudder-sdk-react-native/ios/RNRudderSdkModule.h
+@@ -1,6 +1,6 @@
+ 
+-#if __has_include("RCTBridgeModule.h")
+-#import "RCTBridgeModule.h"
++#if __has_include(<React/RCTBridgeModule.h>)
++#import <React/RCTBridgeModule.h>
+ #else
+ #import <React/RCTBridgeModule.h>
+ #endif


### PR DESCRIPTION
# Why

`rudder-sdk-react-native` build error, because the other day they released a [new version](https://github.com/rudderlabs/rudder-sdk-ios/releases), but `react-native` is not updated, so we can't find some files.



# How

add patch file to fixed iOS `Rudder` SDK version,  waiting for an update from `rudder-sdk-react-native`.

# Test Plan 

try running this command and reinstalling the app, and check if errors.


```sh
yarn
cd apps/expo/ios
pod deintegrate
rm -f Podfile.lock
pod install
cd ..
yarn ios -d
```
