### PR TITLE
fix: zeego item key error

### DIFF
--- a/packages/app/components/nft-dropdown.tsx
+++ b/packages/app/components/nft-dropdown.tsx
@@ -110,20 +110,21 @@ function NFTDropdown({ nftId, listId, shouldEnableSharing = true }: Props) {
         tw="w-60 rounded-2xl bg-white p-2 shadow dark:bg-gray-900"
       >
         {hasOwnership ? (
-          <>
-            <DropdownMenuItem
-              onSelect={() => {
-                hideNFT(nftId, listId);
-              }}
-              key="details"
-              tw="h-8 flex-1 overflow-hidden rounded-sm p-2"
-            >
-              <DropdownMenuItemTitle tw="font-semibold text-black dark:text-white">
-                Hide
-              </DropdownMenuItemTitle>
-            </DropdownMenuItem>
-            <DropdownMenuSeparator tw="m-1 h-[1px] bg-gray-200 dark:bg-gray-700" />
-          </>
+          <DropdownMenuItem
+            onSelect={() => {
+              hideNFT(nftId, listId);
+            }}
+            key="hide"
+            tw="h-8 flex-1 overflow-hidden rounded-sm p-2"
+          >
+            <DropdownMenuItemTitle tw="font-semibold text-black dark:text-white">
+              Hide
+            </DropdownMenuItemTitle>
+          </DropdownMenuItem>
+        ) : null}
+
+        {hasOwnership ? (
+          <DropdownMenuSeparator tw="m-1 h-[1px] bg-gray-200 dark:bg-gray-700" />
         ) : null}
 
         <DropdownMenuItem


### PR DESCRIPTION
# Why
- Getting a warning related to key in menu items

```
 [zeego] <Item /> is missing a unique key. Pass a unique key string for each item, such as...
```
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- had to move `DropdownMenuItem` out of Fragment. Looks something is off when we wrap it in a Fragment. Will dig

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Open swipe list and the warning should be gone

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
