### PR TITLE
twitter intent changes and continue transaction post switching

### DIFF
--- a/packages/app/components/claim/claim-form.tsx
+++ b/packages/app/components/claim/claim-form.tsx
@@ -98,7 +98,7 @@ export const ClaimForm = ({ edition }: { edition: CreatorEditionResponse }) => {
               Linking.openURL(
                 getTwitterIntent({
                   url: claimUrl,
-                  message: `I just claimed a free NFT ${nft?.data.item.token_name} by ${nft?.data.item.creator_name} on @Showtime_xyz! 🎁🔗\n\nClaim yours for free here:`,
+                  message: `I just claimed a free NFT "${nft?.data.item.token_name}" by @${nft?.data.item.creator_name} on @Showtime_xyz! 🎁🔗\n\nClaim yours for free here:`,
                 })
               )
             }

--- a/packages/app/components/claim/claim-form.tsx
+++ b/packages/app/components/claim/claim-form.tsx
@@ -98,10 +98,12 @@ export const ClaimForm = ({ edition }: { edition: CreatorEditionResponse }) => {
               Linking.openURL(
                 getTwitterIntent({
                   url: claimUrl,
-                  message: `Claim ${nft?.data.item.token_name} by ${nft?.data.item.creator_name}`,
+                  message: `I just claimed a free NFT ${nft?.data.item.token_name} by ${nft?.data.item.creator_name} on @Showtime_xyz! 🎁🔗\n\nClaim yours for free here:`,
                 })
               )
             }
+            tw="bg-[#00ACEE]"
+            variant="text"
           >
             Share on Twitter
           </Button>

--- a/packages/app/components/drop/drop-form.tsx
+++ b/packages/app/components/drop/drop-form.tsx
@@ -142,10 +142,12 @@ export const DropForm = () => {
               Linking.openURL(
                 getTwitterIntent({
                   url: claimUrl,
-                  message: `Claim ${state.edition?.name} by ${user.user?.data.profile.name}`,
+                  message: `I just dropped a free NFT ${state.edition?.name} by ${user.user?.data.profile.username} on @Showtime_xyz! 🎁🔗\n\nClaim yours for free here:`,
                 })
               )
             }
+            tw="bg-[#00ACEE]"
+            variant="text"
           >
             Share on Twitter
           </Button>

--- a/packages/app/components/drop/drop-form.tsx
+++ b/packages/app/components/drop/drop-form.tsx
@@ -142,7 +142,7 @@ export const DropForm = () => {
               Linking.openURL(
                 getTwitterIntent({
                   url: claimUrl,
-                  message: `I just dropped a free NFT ${state.edition?.name} by ${user.user?.data.profile.username} on @Showtime_xyz! 🎁🔗\n\nClaim yours for free here:`,
+                  message: `I just dropped a free NFT "${state.edition?.name}" by @${user.user?.data.profile.username} on @Showtime_xyz! 🎁🔗\n\nClaim yours for free here:`,
                 })
               )
             }

--- a/packages/app/hooks/use-claim-nft.ts
+++ b/packages/app/hooks/use-claim-nft.ts
@@ -129,7 +129,8 @@ export const useClaimNFT = () => {
         dispatch({ type: "error", error: "polling timed out" });
       } else {
         Alert.alert(
-          "Wallet seems to be disconnected. Try signing out and signing in."
+          "Wallet disconnected",
+          "Please logout and login again to complete the transaction"
         );
       }
     } catch (e: any) {

--- a/packages/app/hooks/use-drop-nft.ts
+++ b/packages/app/hooks/use-drop-nft.ts
@@ -149,7 +149,8 @@ export const useDropNFT = () => {
         await pollTransaction(relayerResponse.relayed_transaction_id);
       } else {
         Alert.alert(
-          "Wallet seems to be disconnected. Try signing out and signing in."
+          "Wallet disconnected",
+          "Please logout and login again to complete the transaction"
         );
       }
     } catch (e: any) {

--- a/packages/app/hooks/use-sign-typed-data.web.ts
+++ b/packages/app/hooks/use-sign-typed-data.web.ts
@@ -28,7 +28,7 @@ export const useSignTypedData = () => {
         resolve(result);
       } catch (e) {
         // Assuming transaction failed due to wrong network because checking error code is buggy
-        // Putting it in catch block as Rainbow doesn't require switching network while signing chain id
+        // Putting it in error as Rainbow doesn't require switching network while signing chain
         if (activeChain?.id !== parseInt(EXPECTED_CHAIN_ID)) {
           Alert.alert(
             "Switch network",

--- a/packages/app/hooks/use-sign-typed-data.web.ts
+++ b/packages/app/hooks/use-sign-typed-data.web.ts
@@ -13,48 +13,69 @@ const EXPECTED_CHAIN_ID =
   CHAIN_IDENTIFIERS[process.env.NEXT_PUBLIC_CHAIN_ID || "polygon"];
 
 export const useSignTypedData = () => {
-  const { activeChain, switchNetwork } = useNetwork();
+  const { activeChain, switchNetworkAsync } = useNetwork();
   const Alert = useAlert();
   const { signTypedDataAsync } = useWagmiSignTypedData();
 
   const signTypedData = async (
     domain: TypedDataDomain,
     types: Record<string, Array<TypedDataField>>,
-    value: Record<string, any>,
-    onError: (e: string) => void
+    value: Record<string, any>
   ) => {
-    if (activeChain?.id !== parseInt(EXPECTED_CHAIN_ID)) {
-      onError(
-        "Wallet must point to polygon network to complete the transaction"
-      );
-      Alert.alert(
-        "Switch network",
-        "Wallet must point to polygon network to complete the transaction",
-        [
-          {
-            text: "Cancel",
-            style: "cancel",
-          },
-          {
-            text: "Switch chain",
-            onPress: async () => {
-              try {
-                switchNetwork?.(parseInt(EXPECTED_CHAIN_ID));
-              } catch (e) {
-                Alert.alert(
-                  "Network switching failed",
-                  "Please switch network to polygon in your wallet and try again."
-                );
-              }
-            },
-          },
-        ]
-      );
-      return null;
-    } else {
-      const result = await signTypedDataAsync({ domain, types, value });
-      return result;
-    }
+    return new Promise(async (resolve, reject) => {
+      try {
+        const result = await signTypedDataAsync({ domain, types, value });
+        resolve(result);
+      } catch (e) {
+        // Assuming transaction failed due to wrong network because checking error code is buggy
+        // Putting it in catch block as Rainbow doesn't require switching network while signing chain id
+        if (activeChain?.id !== parseInt(EXPECTED_CHAIN_ID)) {
+          Alert.alert(
+            "Switch network",
+            "Wallet must point to polygon network to complete the transaction",
+            [
+              {
+                text: "Cancel",
+                style: "cancel",
+                onPress: () => {
+                  reject(
+                    new Error(
+                      "Please switch network to polygon in your wallet and try again"
+                    )
+                  );
+                },
+              },
+              {
+                text: "Switch chain",
+                onPress: async () => {
+                  try {
+                    await switchNetworkAsync?.(parseInt(EXPECTED_CHAIN_ID));
+                    const result = await signTypedDataAsync({
+                      domain,
+                      types,
+                      value,
+                    });
+                    resolve(result);
+                  } catch (e) {
+                    reject(
+                      new Error(
+                        "Please switch network to polygon in your wallet and try again"
+                      )
+                    );
+                    Alert.alert(
+                      "Network switching failed",
+                      "Please switch network to polygon in your wallet and try again."
+                    );
+                  }
+                },
+              },
+            ]
+          );
+        } else {
+          reject(e);
+        }
+      }
+    });
   };
 
   return signTypedData;

--- a/packages/app/providers/wallet-provider.web.tsx
+++ b/packages/app/providers/wallet-provider.web.tsx
@@ -1,17 +1,13 @@
 import { getDefaultWallets, RainbowKitProvider } from "@rainbow-me/rainbowkit";
 import "@rainbow-me/rainbowkit/styles.css";
-import { chain, configureChains, createClient, WagmiConfig } from "wagmi";
+import { configureChains, createClient, allChains, WagmiConfig } from "wagmi";
 import { alchemyProvider } from "wagmi/providers/alchemy";
 import { publicProvider } from "wagmi/providers/public";
 
-const { chains, provider } = configureChains(
-  [chain.polygon],
-  [
-    alchemyProvider({ alchemyId: process.env.NEXT_PUBLIC_ALCHEMY_ID }),
-    publicProvider(),
-  ]
-);
-
+const { chains, provider } = configureChains(allChains, [
+  alchemyProvider({ alchemyId: process.env.NEXT_PUBLIC_ALCHEMY_ID }),
+  publicProvider(),
+]);
 const { connectors } = getDefaultWallets({
   appName: "Showtime",
   chains,


### PR DESCRIPTION
# Why
- Implements twitter intent changes
- Continue drop/claim transaction after switching network
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->


<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Try drop/claim with wrong network.
- Switch popup should appear
- Transaction should continue after switching network instead of showing error
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
