### PR TITLE
fix(comment): disable btn when content is empty

### DIFF
--- a/packages/app/components/messages/message-box-new.tsx
+++ b/packages/app/components/messages/message-box-new.tsx
@@ -4,6 +4,7 @@ import {
   useImperativeHandle,
   useRef,
   useState,
+  useMemo,
 } from "react";
 import { ViewStyle } from "react-native";
 
@@ -39,6 +40,7 @@ export const MessageBox = forwardRef<MessageBoxMethods, MessageBoxProps>(
     //#region variables
     const inputRef = useRef<typeof TextInput>();
     const [value, setValue] = useState("");
+    const disable = useMemo(() => !value || /^\s+$/.test(value), [value]);
     //#endregion
 
     //#region callbacks
@@ -90,9 +92,14 @@ export const MessageBox = forwardRef<MessageBoxMethods, MessageBoxProps>(
             onFocus={onFocus}
             onBlur={onBlur}
           />
-          <Avatar tw="absolute mt-3 ml-3" size={24} url={userAvatar} />
+          <Avatar tw="absolute mt-1 ml-3" size={24} url={userAvatar} />
         </View>
-        <Button size="regular" iconOnly={true} onPress={handleSubmit}>
+        <Button
+          size="regular"
+          iconOnly={true}
+          disabled={disable}
+          onPress={handleSubmit}
+        >
           {submitting ? <Spinner size="small" /> : <Send />}
         </Button>
       </View>

--- a/packages/design-system/button/button-base.tsx
+++ b/packages/design-system/button/button-base.tsx
@@ -1,4 +1,5 @@
 import { Children, cloneElement, useMemo } from "react";
+import { ViewStyle } from "react-native";
 
 import Animated from "react-native-reanimated";
 
@@ -27,6 +28,7 @@ export function BaseButton({
   iconColor = ["white", "black"],
   children,
   asChild,
+  disabled,
   ...props
 }: BaseButtonProps) {
   //#region variables
@@ -44,13 +46,14 @@ export function BaseButton({
     ],
     [tw, size, iconOnly]
   );
-  const containerAnimatedStyle = useMemo(
+  const containerAnimatedStyle = useMemo<ViewStyle>(
     () => ({
       backgroundColor: backgroundColors
         ? backgroundColors["default"][isDarkMode ? 1 : 0]
         : "transparent",
+      opacity: disabled ? 0.4 : 1,
     }),
-    [backgroundColors, isDarkMode]
+    [backgroundColors, disabled, isDarkMode]
   );
 
   const labelStyle = useMemo(
@@ -107,6 +110,7 @@ export function BaseButton({
     <PressableScale
       {...props}
       tw={containerStyle}
+      disabled={disabled}
       style={backgroundColors ? containerAnimatedStyle : undefined}
     >
       {renderChildren}


### PR DESCRIPTION
# Why 

- publish content even if the comment input is empty.
- comment input avatar style is broken.

![image](https://user-images.githubusercontent.com/37520667/173808386-a55b0347-a570-412f-a8a2-ad515ac897a3.png)

# How

- disable btn when content is empty.
- adjust the avatar position.

# Test Plan

check if the comment feature is working.

