### PR TITLE
refactor: update feed card styles for web

### DIFF
--- a/packages/app/components/card/card.tsx
+++ b/packages/app/components/card/card.tsx
@@ -113,7 +113,7 @@ function Card({ listId, nft, numColumns, tw, onPress, hrefProps }: Props) {
 
           <Owner nft={nft} price={Platform.OS !== "ios"} />
 
-          <View tw="mx-4 h-[1px] bg-gray-100 dark:bg-gray-900" />
+          <View tw="mx-4 mt-2 h-[1px] bg-gray-100 dark:bg-gray-900" />
           <Collection nft={nft} />
         </View>
       </View>

--- a/packages/app/components/feed/feed.md.tsx
+++ b/packages/app/components/feed/feed.md.tsx
@@ -30,7 +30,7 @@ import { Hidden } from "design-system/hidden";
 import { Tabs } from "design-system/tabs";
 import { CARD_DARK_SHADOW } from "design-system/theme";
 
-const CARD_HEIGHT = 890;
+const CARD_HEIGHT = 848;
 const CARD_CONTAINER_WIDTH = 620;
 const HORIZONTAL_GAPS = 24;
 const CARD_WIDTH = CARD_CONTAINER_WIDTH - HORIZONTAL_GAPS;
@@ -90,7 +90,7 @@ export const FeedList = () => {
         {isAuthenticated ? (
           <>
             <View
-              tw="mr-2 w-[375px] self-end rounded-lg bg-white p-4 shadow-lg dark:bg-black"
+              tw="mr-2 mb-2 w-[375px] self-end rounded-lg bg-white p-4 shadow-lg dark:bg-black"
               style={{
                 // @ts-ignore
                 boxShadow: isDark ? CARD_DARK_SHADOW : undefined,
@@ -205,7 +205,7 @@ const NFTScrollList = ({
             pathname: `/nft/${item.chain_name}/${item.contract_address}/${item.token_id}`,
           }}
           nft={item}
-          tw={`w-[${CARD_WIDTH}px] h-[${CARD_HEIGHT - 32}px] my-4`}
+          tw={`w-[${CARD_WIDTH}px] mt-2`}
         />
       </View>
     );

--- a/packages/app/components/profile-dropdown.tsx
+++ b/packages/app/components/profile-dropdown.tsx
@@ -1,4 +1,4 @@
-import { useWindowDimensions, Platform } from "react-native";
+import { useWindowDimensions } from "react-native";
 
 import { Button } from "@showtime-xyz/universal.button";
 import {

--- a/packages/app/components/swipe-list.tsx
+++ b/packages/app/components/swipe-list.tsx
@@ -62,6 +62,8 @@ const { height: screenHeight, width: screenWidth } = Dimensions.get("screen");
 const mediaMaxHeightRelativeToScreen = 1;
 const NFT_DETAIL_WIDTH = 380;
 const SCROLL_BAR_WIDTH = 15;
+const MOBILE_WEB_TABS_HEIGHT = 50;
+const MOBILE_WEB_BOTTOM_NAV_HEIGHT = 64;
 
 type Props = {
   data: NFT[];
@@ -90,9 +92,13 @@ export const SwipeList = ({
   const { height: safeAreaFrameHeight } = useSafeAreaFrame();
   const { height: windowHeight, width: windowWidth } = useWindowDimensions();
 
+  console.log("paddings", windowHeight, headerHeight, bottomPadding);
   const itemHeight =
     Platform.OS === "web"
-      ? windowHeight - headerHeight - bottomPadding
+      ? windowHeight -
+        headerHeight -
+        MOBILE_WEB_BOTTOM_NAV_HEIGHT -
+        MOBILE_WEB_TABS_HEIGHT
       : Platform.OS === "android"
       ? safeAreaFrameHeight - headerHeight
       : screenHeight;

--- a/packages/app/components/swipe-list.tsx
+++ b/packages/app/components/swipe-list.tsx
@@ -49,6 +49,7 @@ import {
 } from "app/hooks/use-creator-collection-detail";
 import { useIsMobileWeb } from "app/hooks/use-is-mobile-web";
 import { useShareNFT } from "app/hooks/use-share-nft";
+import { useUser } from "app/hooks/use-user";
 import { Blurhash } from "app/lib/blurhash";
 import { useHeaderHeight } from "app/lib/react-navigation/elements";
 import { useNavigation, useScrollToTop } from "app/lib/react-navigation/native";
@@ -84,6 +85,7 @@ export const SwipeList = ({
   bottomPadding = 0,
   listId,
 }: Props) => {
+  const { isAuthenticated } = useUser();
   const listRef = useRef<FlatList>(null);
   const headerHeight = useHeaderHeight();
   useScrollToTop(listRef);
@@ -97,8 +99,9 @@ export const SwipeList = ({
     Platform.OS === "web"
       ? windowHeight -
         headerHeight -
-        MOBILE_WEB_BOTTOM_NAV_HEIGHT -
-        MOBILE_WEB_TABS_HEIGHT
+        (isAuthenticated
+          ? MOBILE_WEB_BOTTOM_NAV_HEIGHT + MOBILE_WEB_TABS_HEIGHT
+          : 0)
       : Platform.OS === "android"
       ? safeAreaFrameHeight - headerHeight
       : screenHeight;

--- a/packages/app/components/swipe-list.tsx
+++ b/packages/app/components/swipe-list.tsx
@@ -94,7 +94,6 @@ export const SwipeList = ({
   const { height: safeAreaFrameHeight } = useSafeAreaFrame();
   const { height: windowHeight, width: windowWidth } = useWindowDimensions();
 
-  console.log("paddings", windowHeight, headerHeight, bottomPadding);
   const itemHeight =
     Platform.OS === "web"
       ? windowHeight -

--- a/packages/app/hooks/use-sign-typed-data.web.ts
+++ b/packages/app/hooks/use-sign-typed-data.web.ts
@@ -22,6 +22,7 @@ export const useSignTypedData = () => {
     types: Record<string, Array<TypedDataField>>,
     value: Record<string, any>
   ) => {
+    // eslint-disable-next-line no-async-promise-executor
     return new Promise(async (resolve, reject) => {
       try {
         const result = await signTypedDataAsync({ domain, types, value });


### PR DESCRIPTION
# Why

There were some UI issues with the feed items on both web and mobile web states.

- https://linear.app/showtime/issue/SHOW2-815/nft-card-ui-bug
- https://linear.app/showtime/issue/SHOW2-877/nft-action-buttons-goes-under-bottom-navigation-on-web-mobile

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Refactored styles and handled some calculations for the web.  The bottom navigator height is returning 0 on the web, needed to define it hard coded also. 

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Checking styles on each platform.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
