### PR TITLE
fix: ToolTip onPress

### DIFF
--- a/packages/design-system/tooltip/index.tsx
+++ b/packages/design-system/tooltip/index.tsx
@@ -25,9 +25,9 @@ export const Tooltip: React.FC<TooltipProps> = ({
   const [show, setShow] = useState(false);
   const [triggerRect, setTriggerRect] = useState<PlatformRect>(null);
 
-  const onPress = useCallback(() => {
-    setShow(!show);
-  }, [show, setShow]);
+  const onPress = () => {
+    setShow(current => !current);
+  };
 
   useEffect(() => {
     setShow(Boolean(open));


### PR DESCRIPTION
This memoization is unnecessary. Also, it's better to pass a dispatch function to a state updater when using the existing state.

Does `onTouchStart` still work on Views btw?

# Why

Saw some unnecessary memoization.

# How

🤷‍♂️

# Test Plan

