### PR TITLE
fix: remove video previewOnly from web

### DIFF
--- a/packages/app/context/video-config-context.ts
+++ b/packages/app/context/video-config-context.ts
@@ -1,4 +1,5 @@
 import React, { createContext } from "react";
+import { Platform } from "react-native";
 
 type VideoConfigContextType = {
   isMuted: boolean;
@@ -9,7 +10,8 @@ type VideoConfigContextType = {
 export const VideoConfigContext = createContext<VideoConfigContextType | null>({
   isMuted: true,
   useNativeControls: false,
-  previewOnly: true,
+  // Always play the video on web
+  previewOnly: Platform.OS !== "web",
 });
 
 export const useVideoConfig = () => {

--- a/packages/design-system/video/index.web.tsx
+++ b/packages/design-system/video/index.web.tsx
@@ -49,6 +49,7 @@ function Video({ tw, blurhash, resizeMode, ...props }: VideoProps) {
             source={props.source}
             ref={videoRef}
             shouldPlay
+            isLooping
             isMuted={videoConfig?.isMuted}
             {...props}
           />


### PR DESCRIPTION
# Why
- we disabled videos on grid cards but we can enable it on web. It was also causing to videos not playing in detail screen
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- set previewOnly to false in video context for web
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- run app and go to profile where there are video NFTs
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
