### PR TITLE
fix: display error message from API

### DIFF
--- a/packages/app/hooks/use-drop-nft.ts
+++ b/packages/app/hooks/use-drop-nft.ts
@@ -101,16 +101,16 @@ export const useDropNFT = () => {
 
         const fileMetaData = await getFileMeta(params.file);
 
-        if (
-          fileMetaData &&
-          typeof fileMetaData.size === "number" &&
-          fileMetaData.size > MAX_FILE_SIZE
-        ) {
-          Alert.alert(
-            `This file is too big. Please use a file smaller than 50 MB.`
-          );
-          return;
-        }
+        // if (
+        //   fileMetaData &&
+        //   typeof fileMetaData.size === "number" &&
+        //   fileMetaData.size > MAX_FILE_SIZE
+        // ) {
+        //   Alert.alert(
+        //     `This file is too big. Please use a file smaller than 50 MB.`
+        //   );
+        //   return;
+        // }
 
         dispatch({ type: "loading" });
         const ipfsHash = await uploadMedia(params.file);

--- a/packages/app/hooks/use-drop-nft.ts
+++ b/packages/app/hooks/use-drop-nft.ts
@@ -101,16 +101,16 @@ export const useDropNFT = () => {
 
         const fileMetaData = await getFileMeta(params.file);
 
-        // if (
-        //   fileMetaData &&
-        //   typeof fileMetaData.size === "number" &&
-        //   fileMetaData.size > MAX_FILE_SIZE
-        // ) {
-        //   Alert.alert(
-        //     `This file is too big. Please use a file smaller than 50 MB.`
-        //   );
-        //   return;
-        // }
+        if (
+          fileMetaData &&
+          typeof fileMetaData.size === "number" &&
+          fileMetaData.size > MAX_FILE_SIZE
+        ) {
+          Alert.alert(
+            `This file is too big. Please use a file smaller than 50 MB.`
+          );
+          return;
+        }
 
         dispatch({ type: "loading" });
         const ipfsHash = await uploadMedia(params.file);

--- a/packages/app/lib/axios.ts
+++ b/packages/app/lib/axios.ts
@@ -64,7 +64,7 @@ const axiosAPI = async ({
     Logger.error(error);
 
     if (error.response?.data?.error?.message) {
-      throw new Error(error.response?.data?.error.message);
+      throw new Error(error.response.data.error.message);
     }
 
     throw error;

--- a/packages/app/lib/axios.ts
+++ b/packages/app/lib/axios.ts
@@ -2,6 +2,7 @@ import axios from "axios";
 import type { Method, AxiosRequestHeaders } from "axios";
 
 import { getAccessToken } from "app/lib/access-token";
+import { Logger } from "app/lib/logger";
 
 export type AxiosOverrides = {
   forceAccessTokenAuthorization?: boolean;
@@ -58,9 +59,14 @@ const axiosAPI = async ({
 
   try {
     return await axios(request).then((res) => res.data);
-  } catch (error) {
-    console.log("Failed request:", request);
-    console.error(error);
+  } catch (error: any) {
+    Logger.log("Failed request:", request);
+    Logger.error(error);
+
+    if (error.response?.data?.error?.message) {
+      throw new Error(error.response?.data?.error.message);
+    }
+
     throw error;
   }
 };


### PR DESCRIPTION
# Why
When there's an error, user is shown generic axios message like request failed with 500 code.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
Get the message from API and throw a new error with that message.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
Tested on drop, tried upload >50mb and verified if appropriate error message is shown.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
