### PR TITLE
Notifications leftovers

### DIFF
--- a/packages/app/components/header.tsx
+++ b/packages/app/components/header.tsx
@@ -179,7 +179,7 @@ const NotificationsInHeader = () => {
         onCloseAutoFocus={(e) => e.preventDefault()}
       >
         <View
-          tw="mt-2 rounded-3xl bg-white shadow-lg shadow-black dark:bg-black dark:shadow-white"
+          tw="mt-2 overflow-hidden rounded-3xl bg-white shadow-lg shadow-black dark:bg-black dark:shadow-white"
           style={Platform.select({
             web: { maxHeight: "calc(50vh - 64px)" },
             default: {},

--- a/packages/app/components/notifications.tsx
+++ b/packages/app/components/notifications.tsx
@@ -3,6 +3,7 @@ import { FlatList } from "react-native";
 
 // import { formatDistanceToNowStrict } from "date-fns";
 import { Avatar } from "@showtime-xyz/universal.avatar";
+import { useColorScheme } from "@showtime-xyz/universal.color-scheme";
 import {
   HeartFilled,
   MarketFilled,
@@ -36,6 +37,7 @@ export const Notifications = () => {
     useNotifications();
   const { refetchMyInfo } = useMyInfo();
   const bottomBarHeight = useBottomTabBarHeight();
+  const { colorScheme } = useColorScheme();
 
   const [users, setUsers] = useState([]);
 
@@ -49,11 +51,15 @@ export const Notifications = () => {
 
   const ListFooter = useCallback(() => {
     return isLoadingMore ? (
-      <Skeleton height={bottomBarHeight} width="100%" />
+      <Skeleton
+        colorMode={colorScheme as "dark" | "light"}
+        height={bottomBarHeight}
+        width="100%"
+      />
     ) : (
       <View tw={`h-${bottomBarHeight}px`} />
     );
-  }, [isLoadingMore, bottomBarHeight]);
+  }, [isLoadingMore, bottomBarHeight, colorScheme]);
 
   const Separator = useCallback(
     () => <View tw={`h-[1px] bg-gray-100 dark:bg-gray-800`} />,
@@ -62,8 +68,10 @@ export const Notifications = () => {
 
   const ListEmptyComponent = useCallback(
     () => (
-      <View tw="h-full items-center justify-center">
-        <Text tw="text-gray-900 dark:text-gray-100">No new notifications</Text>
+      <View tw="items-center justify-center">
+        <Text tw="p-20 text-gray-900 dark:text-gray-100">
+          No new notifications
+        </Text>
       </View>
     ),
     []
@@ -147,7 +155,6 @@ const NotificationDescription = ({
     return (
       <View>
         <Text
-          //@ts-ignore
           tw="text-13 max-w-[69vw] text-gray-600 dark:text-gray-400"
           ellipsizeMode="tail"
         >

--- a/packages/app/navigation/tab-bar-icons.tsx
+++ b/packages/app/navigation/tab-bar-icons.tsx
@@ -165,7 +165,7 @@ export const NotificationsTabBarIcon = ({
   onPress,
 }: TabBarIconProps) => {
   return (
-    <TabBarIcon tab="/notifications" onPress={onPress}>
+    <TabBarIcon tab={onPress ? "" : "/notifications"} onPress={onPress}>
       {focused ? (
         <BellFilled
           style={tw.style("z-1")}


### PR DESCRIPTION
# Why

Got some feedback after re-implementing the notifications

# How

- Make the overflow hidden so we hide the separators on desktop
- Improve loading state (color scheme)
- Improve empty state (padding)

# Test Plan

Run the app and check the notifications on large screens