### PR TITLE
fix: skip redirection on native

### DIFF
--- a/packages/app/components/drop/drop-form.tsx
+++ b/packages/app/components/drop/drop-form.tsx
@@ -183,7 +183,10 @@ export const DropForm = () => {
           <Button
             variant="tertiary"
             tw="mt-4"
-            onPress={() => router.push(claimUrl)}
+            onPress={Platform.select({
+              web: () => router.push(claimUrl),
+              default: router.pop,
+            })}
           >
             Skip for now
           </Button>


### PR DESCRIPTION
# Why
- skip for now button redirects to web app
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
we don't have deeplink support on native yet, so it should just close the modal instead  of redirecting.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- create a drop, press skip for now on success screen
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
