### PR TITLE
revert: remove edition size frontend hack (do not merge this yet)

### DIFF
--- a/packages/app/components/claim/claim-button.tsx
+++ b/packages/app/components/claim/claim-button.tsx
@@ -43,15 +43,10 @@ export const ClaimButton = ({
     isExpired = new Date() > new Date(edition.time_limit);
   }
 
-  // TODO: remove this once API returns accurace claimed edition count
-  let totalClaimedCount = 0;
-  if (edition && typeof edition.total_claimed_count === "number") {
-    totalClaimedCount = edition.total_claimed_count + 1;
-  }
-
   const status =
     edition &&
-    totalClaimedCount === edition.creator_airdrop_edition?.edition_size
+    edition.total_claimed_count ===
+      edition.creator_airdrop_edition?.edition_size
       ? "soldout"
       : edition.is_already_claimed
       ? "claimed"


### PR DESCRIPTION
# Why
- this seems to be an indexer issue. Claimed count won't be always less by 1 than actual count. So the hack may not work for all cases. https://showtime-rq88331.slack.com/archives/C02PXGK3V8D/p1655598050596599
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- remove the less by 1 hack
<!--
How did you build this feature or fix this bug and why?
-->

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
