### PR TITLE
fix: trending on mobile

### DIFF
--- a/packages/app/components/trending/context.tsx
+++ b/packages/app/components/trending/context.tsx
@@ -1,0 +1,5 @@
+import { createContext } from "react";
+
+export const TrendingContext = createContext<{
+  [index: number]: number;
+}>({});

--- a/packages/app/components/trending/creators-list.tsx
+++ b/packages/app/components/trending/creators-list.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useImperativeHandle, forwardRef } from "react";
 import { useWindowDimensions } from "react-native";
 
+import { tw } from "@showtime-xyz/universal.tailwind";
 import { View } from "@showtime-xyz/universal.view";
 
 import { CreatorPreview } from "app/components/creator-preview";
@@ -9,17 +10,16 @@ import { useTrendingCreators } from "app/hooks/api-hooks";
 import { DataProvider, LayoutProvider } from "app/lib/recyclerlistview";
 import { useRouter } from "app/navigation/use-router";
 
-import { TabRecyclerList } from "design-system/tab-view";
+import { TabRecyclerList, TabScrollView } from "design-system/tab-view";
+import { TabSpinner } from "design-system/tab-view/tab-spinner";
 
-import { ListHeader } from "./list-header";
+import { EmptyPlaceholder } from "../empty-placeholder";
 import { TrendingTabListProps, TrendingTabListRef } from "./tab-list";
-
-const LIST_HEADER_HEIGHT = 64;
 
 export const CreatorsList = forwardRef<
   TrendingTabListRef,
   TrendingTabListProps
->(function CreatorsList({ days, SelectionControl, index }, ref) {
+>(function CreatorsList({ days, index }, ref) {
   const { data, isLoadingMore, isLoading, refresh, fetchMore } =
     useTrendingCreators({
       days,
@@ -42,21 +42,8 @@ export const CreatorsList = forwardRef<
     []
   );
 
-  const ListHeaderComponent = useCallback(
-    () => (
-      <ListHeader
-        isLoading={isLoading}
-        SelectionControl={SelectionControl}
-        length={data?.length}
-      />
-    ),
-    [SelectionControl, data, isLoading]
-  );
-
-  const { width } = useWindowDimensions();
+  const { width, height } = useWindowDimensions();
   const router = useRouter();
-
-  const newData = useMemo(() => ["header", ...data], [data]);
 
   let dataProvider = useMemo(
     () =>
@@ -64,8 +51,8 @@ export const CreatorsList = forwardRef<
         return typeof r1 === "string" && typeof r2 === "string"
           ? r1 !== r2
           : r1.profile_id !== r2.profile_id;
-      }).cloneWithRows(newData),
-    [newData]
+      }).cloneWithRows(data),
+    [data]
   );
 
   const mediaDimension = useWindowDimensions().width / 3;
@@ -76,21 +63,12 @@ export const CreatorsList = forwardRef<
   const _layoutProvider = useMemo(
     () =>
       new LayoutProvider(
-        (index) => {
-          if (index === 0) {
-            return "header";
-          }
-
+        () => {
           return "item";
         },
         (_type, dim) => {
-          if (_type === "item") {
-            dim.width = width;
-            dim.height = cardHeight;
-          } else if (_type === "header") {
-            dim.width = width;
-            dim.height = LIST_HEADER_HEIGHT;
-          }
+          dim.width = width;
+          dim.height = cardHeight;
         }
       ),
     [width, cardHeight]
@@ -98,10 +76,6 @@ export const CreatorsList = forwardRef<
 
   const _rowRenderer = useCallback(
     (_type: any, item: any) => {
-      if (_type === "header") {
-        return <ListHeaderComponent />;
-      }
-
       return (
         <>
           <CreatorPreview
@@ -117,20 +91,41 @@ export const CreatorsList = forwardRef<
         </>
       );
     },
-    [ItemSeparatorComponent, ListHeaderComponent, days, router, mediaDimension]
+    [ItemSeparatorComponent, days, router, mediaDimension]
   );
 
-  return (
-    <View tw="flex-1 bg-white dark:bg-black">
-      <TabRecyclerList
-        layoutProvider={_layoutProvider}
-        dataProvider={dataProvider}
-        rowRenderer={_rowRenderer}
-        onEndReached={fetchMore}
-        style={{ flex: 1 }}
-        renderFooter={ListFooterComponent}
+  const layoutSize = useMemo(
+    () => ({
+      width,
+      height,
+    }),
+    [width, height]
+  );
+  if (isLoading) {
+    return <TabSpinner index={index} />;
+  }
+
+  if (data.length === 0 && !isLoading) {
+    return (
+      <TabScrollView
+        contentContainerStyle={tw.style("mt-12 items-center")}
         index={index}
-      />
-    </View>
+      >
+        <EmptyPlaceholder title="No results found" hideLoginBtn />
+      </TabScrollView>
+    );
+  }
+
+  return (
+    <TabRecyclerList
+      layoutProvider={_layoutProvider}
+      dataProvider={dataProvider}
+      rowRenderer={_rowRenderer}
+      onEndReached={fetchMore}
+      layoutSize={layoutSize}
+      style={{ flex: 1 }}
+      renderFooter={ListFooterComponent}
+      index={index}
+    />
   );
 });

--- a/packages/app/components/trending/nfts-list.tsx
+++ b/packages/app/components/trending/nfts-list.tsx
@@ -11,13 +11,12 @@ import { useRouter } from "app/navigation/use-router";
 
 import { TabRecyclerList } from "design-system/tab-view";
 
-import { ListHeader } from "./list-header";
 import { TrendingTabListProps, TrendingTabListRef } from "./tab-list";
 
 const GAP_BETWEEN_ITEMS = 1;
 
 export const NFTSList = forwardRef<TrendingTabListRef, TrendingTabListProps>(
-  function NFTSList({ days, SelectionControl, index }, ref) {
+  function NFTSList({ days, index }, ref) {
     const router = useRouter();
     const { data, isLoadingMore, isLoading, refresh, fetchMore } =
       useTrendingNFTS({
@@ -34,37 +33,21 @@ export const NFTSList = forwardRef<TrendingTabListRef, TrendingTabListProps>(
       () => <ListFooter isLoading={isLoadingMore} />,
       [isLoadingMore]
     );
-    const newData = useMemo(() => ["header", ...data], [data]);
 
     const numColumns = 3;
-
-    const ListHeaderComponent = useCallback(
-      () => (
-        <ListHeader
-          isLoading={isLoading}
-          SelectionControl={SelectionControl}
-          length={data?.length}
-        />
-      ),
-      [SelectionControl, data, isLoading]
-    );
 
     let dataProvider = useMemo(
       () =>
         new DataProvider((r1, r2) => {
           return r1.profile_id !== r2.profile_id;
-        }).cloneWithRows(newData),
-      [newData]
+        }).cloneWithRows(data),
+      [data]
     );
 
-    const _layoutProvider = useNFTCardsListLayoutProvider({ newData });
+    const _layoutProvider = useNFTCardsListLayoutProvider({ newData: data });
 
     const _rowRenderer = useCallback(
       (_type: any, item: any, index: number) => {
-        if (_type === "header") {
-          return <ListHeaderComponent />;
-        }
-
         return (
           <Card
             nft={item}
@@ -80,7 +63,7 @@ export const NFTSList = forwardRef<TrendingTabListRef, TrendingTabListProps>(
           />
         );
       },
-      [ListHeaderComponent, router, days]
+      [router, days]
     );
 
     return (

--- a/packages/app/hooks/use-tab-state.tsx
+++ b/packages/app/hooks/use-tab-state.tsx
@@ -4,14 +4,14 @@ import { createParam } from "app/navigation/use-param";
 
 import { Route } from "design-system/tab-view/src/types";
 
-type Query = {
-  tab: number;
-};
-const { useParam } = createParam<Query>();
+const { useParam } = createParam();
 
-export function useTabState<PageRef>(routesProps: Route[]) {
+export function useTabState<PageRef, T = Route>(
+  routesProps: T[],
+  params = "tab"
+) {
   const [isRefreshing, setIsRefreshing] = useState(false);
-  const [index, setIndex] = useParam("tab", {
+  const [index, setIndex] = useParam(params, {
     parse: (v) => Number(v ?? 0),
     initial: 0,
   });

--- a/packages/design-system/select/lib/select-item.tsx
+++ b/packages/design-system/select/lib/select-item.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, forwardRef } from "react";
+import React, { useCallback, useMemo } from "react";
 import { Pressable, GestureResponderEvent } from "react-native";
 
 import Animated, { useAnimatedStyle } from "react-native-reanimated";
@@ -22,9 +22,7 @@ const BACKGROUND_MAPPER = {
   hover: [colors.gray[800], colors.gray[200]],
 };
 
-export const SelectItem = forwardRef(SelectItemComponent);
-
-function SelectItemComponent<T>({
+export function SelectItem<T>({
   label,
   value,
   disabled,

--- a/packages/design-system/tab-view/index.tsx
+++ b/packages/design-system/tab-view/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, forwardRef } from "react";
+import { useCallback } from "react";
 import { StatusBar } from "react-native";
 
 import {
@@ -26,12 +26,10 @@ type TabBarProps<T extends Route> = HeaderTabViewProps<T> & {
 };
 const StatusBarHeight = StatusBar.currentHeight ?? 0;
 
-export const HeaderTabView = forwardRef(CommonHeaderTabView);
-
-function CommonHeaderTabView<T extends Route>(
-  { autoWidthTabBar, ...props }: TabBarProps<T>,
-  ref: any
-) {
+export function HeaderTabView<T extends Route>({
+  autoWidthTabBar,
+  ...props
+}: TabBarProps<T>) {
   const insets = useSafeAreaInsets();
   const isDark = useIsDarkMode();
   const renderTabBar = useCallback(
@@ -60,7 +58,6 @@ function CommonHeaderTabView<T extends Route>(
       minHeaderHeight={insets.top + StatusBarHeight}
       refreshControlColor={isDark ? colors.gray[400] : colors.gray[700]}
       refreshHeight={60}
-      ref={ref}
       {...props}
     />
   );

--- a/packages/design-system/tab-view/src/create-collapsible-scroll-view.tsx
+++ b/packages/design-system/tab-view/src/create-collapsible-scroll-view.tsx
@@ -16,7 +16,7 @@ export function createCollapsibleScrollView<
     T & {
       index: number;
     }
-  >(function tabView(props, ref) {
+  >(function TabViewScene(props, ref) {
     return (
       <SceneComponent
         {...props}

--- a/packages/design-system/tab-view/src/create-header-tabs.tsx
+++ b/packages/design-system/tab-view/src/create-header-tabs.tsx
@@ -14,12 +14,16 @@ import {
 } from "react-native-tab-view-next/src";
 
 import { GestureContainer, GestureContainerRef } from "./gesture-container";
-import type { CollapsibleHeaderProps, Route } from "./types";
+import type {
+  CollapsibleHeaderProps,
+  Route,
+  TabViewCustomRenders,
+} from "./types";
 
 export type HeaderTabViewRef = {};
 export type HeaderTabViewProps<T extends Route> = Partial<TabViewProps<T>> &
   Pick<TabViewProps<T>, "onIndexChange" | "navigationState" | "renderScene"> &
-  CollapsibleHeaderProps;
+  CollapsibleHeaderProps<T>;
 
 export type ForwardTabViewProps<T extends Route> = HeaderTabViewProps<T> & {
   forwardedRef: React.ForwardedRef<HeaderTabViewRef>;
@@ -75,20 +79,24 @@ function CollapsibleHeaderTabView<T extends Route>({
     [props]
   );
 
-  const renderTabView = (e: { renderTabBarContainer: any }) => {
-    const { Component, ...restProps } = props;
+  const renderTabView = (e: TabViewCustomRenders) => {
+    const { Component, renderScene, ...restProps } = props;
 
     return (
       <Component
         {...restProps}
-        renderTabBar={(tabbarProps) =>
-          e.renderTabBarContainer(_renderTabBar(tabbarProps))
-        }
+        renderTabBar={(
+          tabbarProps: SceneRendererProps & {
+            navigationState: NavigationState<T>;
+          }
+        ) => e.renderTabBarContainer(_renderTabBar(tabbarProps))}
+        renderScene={(props: any) => e.renderSceneHeader(renderScene(props))}
       />
     );
   };
 
   return (
+    //@ts-ignore
     <GestureContainer
       ref={gestureContainerRef}
       initialPage={initialPageRef.current}

--- a/packages/design-system/tab-view/src/scene.tsx
+++ b/packages/design-system/tab-view/src/scene.tsx
@@ -37,18 +37,24 @@ export function SceneComponent<P extends object>({
     curIndexValue,
     refHasChanged,
     updateSceneInfo,
+    scrollStickyHeaderHeight,
   } = useHeaderTabContext();
   const scollViewRef =
     useSharedScrollableRef<Animated.ScrollView>(forwardedRef);
 
   const nativeGestureRef = useRef(Gesture.Native());
   const scrollY = useSharedValue(0);
+
   const { opacityValue, initialPosition } =
     useSyncInitialPosition(scollViewRef);
 
   const calcHeight = useMemo(() => {
     return tabbarHeight + headerHeight;
   }, [tabbarHeight, headerHeight]);
+
+  const scrollViewPaddingTop = useMemo(() => {
+    return calcHeight + scrollStickyHeaderHeight;
+  }, [calcHeight, scrollStickyHeaderHeight]);
 
   const onScrollAnimateEvent = useAnimatedScrollHandler({
     onScroll: (e) => {
@@ -89,6 +95,7 @@ export function SceneComponent<P extends object>({
       opacity: withTiming(opacityValue.value),
     };
   }, [opacityValue]);
+
   return (
     <Animated.View style={[styles.container, sceneStyle]}>
       {/* @ts-ignore */}
@@ -101,7 +108,7 @@ export function SceneComponent<P extends object>({
           // @ts-ignore
           contentContainerStyle={[
             {
-              paddingTop: calcHeight,
+              paddingTop: scrollViewPaddingTop,
               minHeight: expectHeight,
             },
             contentContainerStyle,

--- a/packages/design-system/tab-view/src/types.tsx
+++ b/packages/design-system/tab-view/src/types.tsx
@@ -20,7 +20,7 @@ export enum RefreshTypeEnum {
   Cancel,
 }
 
-export type CollapsibleHeaderProps = {
+export type CollapsibleHeaderProps<T extends Route> = {
   initHeaderHeight?: number;
   renderScrollHeader: () => React.ReactElement | null;
   initTabbarHeight?: number;
@@ -51,15 +51,21 @@ export type CollapsibleHeaderProps = {
    * WEB_ONLY: Insert element into tabbar on Sticky.
    */
   insertStickyTabBarElement?: JSX.Element | null;
+  renderSceneHeader?: (props: T) => JSX.Element | null;
 };
 
-export type GestureContainerProps = Pick<
+export type TabViewCustomRenders = {
+  renderTabBarContainer: (children: any) => JSX.Element;
+  renderSceneHeader: (children: any) => JSX.Element;
+};
+
+export type GestureContainerProps<T extends Route> = Pick<
   TabViewProps<Route>,
   "navigationState"
 > &
-  CollapsibleHeaderProps & {
+  CollapsibleHeaderProps<T> & {
     initialPage: number;
-    renderTabView: any;
+    renderTabView: (e: TabViewCustomRenders) => JSX.Element;
   };
 
 export interface RefreshControlProps {
@@ -99,6 +105,7 @@ export type TabHeaderContext = {
   minHeaderHeight: number;
   tabbarHeight: number;
   headerHeight: number;
+  scrollStickyHeaderHeight: number;
   refreshHeight: number;
   overflowPull: number;
   pullExtendedCoefficient: number;

--- a/packages/design-system/tab-view/src/utils.tsx
+++ b/packages/design-system/tab-view/src/utils.tsx
@@ -51,3 +51,20 @@ export const animateToRefresh = ({
     isRefreshingWithAnimation.value = isToRefresh;
   });
 };
+
+/**
+ *  @summary Clamps a node with a lower and upper bound.
+ *  @example
+    clamp(-1, 0, 100); // 0
+    clamp(1, 0, 100); // 1
+    clamp(101, 0, 100); // 100
+  * @worklet
+  */
+export const clamp = (
+  value: number,
+  lowerBound: number,
+  upperBound: number
+) => {
+  "worklet";
+  return Math.min(Math.max(lowerBound, value), upperBound);
+};

--- a/packages/design-system/tab-view/tab-scene.tsx
+++ b/packages/design-system/tab-view/tab-scene.tsx
@@ -14,7 +14,7 @@ import { RecyclerListViewProps } from "recyclerlistview";
 
 import { RecyclerListView } from "app/lib/recyclerlistview";
 
-import { createCollapsibleScrollView } from "./src/create-collapsible-scrollView";
+import { createCollapsibleScrollView } from "./src/create-collapsible-scroll-view";
 import { SceneComponent } from "./src/scene";
 import { SceneProps } from "./src/types";
 


### PR DESCRIPTION
# Why

- The trending page `SegmentedControl` toggle would disappear for a while.
- The trending mobile web is broken.
- Trending tab `days` props is always 1.

# How

- Improve TabView, support `renderSceneHeader` props.
- Set the width of the`TabView` preset on the web.

# Test Plan

check Trending is works on web/Native.
