### PR TITLE
refactor: blur views on mobile safari

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -11,7 +11,7 @@
 {
     "accordion": {
         "scope": "showtime.universal",
-        "version": "0.0.16",
+        "version": "0.0.17",
         "mainFile": "index.tsx",
         "rootDir": "packages/design-system/accordion"
     },
@@ -23,7 +23,7 @@
     },
     "alert": {
         "scope": "showtime.universal",
-        "version": "0.0.20",
+        "version": "0.0.21",
         "mainFile": "index.tsx",
         "rootDir": "packages/design-system/alert"
     },
@@ -35,19 +35,19 @@
     },
     "bottom-sheet": {
         "scope": "showtime.universal",
-        "version": "0.0.19",
+        "version": "0.0.20",
         "mainFile": "index.tsx",
         "rootDir": "packages/design-system/bottom-sheet"
     },
     "button": {
         "scope": "showtime.universal",
-        "version": "0.0.19",
+        "version": "0.0.20",
         "mainFile": "index.tsx",
         "rootDir": "packages/design-system/button"
     },
     "checkbox": {
         "scope": "showtime.universal",
-        "version": "0.0.17",
+        "version": "0.0.18",
         "mainFile": "index.tsx",
         "rootDir": "packages/design-system/checkbox"
     },
@@ -89,13 +89,13 @@
     },
     "fieldset": {
         "scope": "showtime.universal",
-        "version": "0.0.26",
+        "version": "0.0.27",
         "mainFile": "index.tsx",
         "rootDir": "packages/design-system/fieldset"
     },
     "hooks": {
         "scope": "showtime.universal",
-        "version": "0.0.14",
+        "version": "0.0.15",
         "mainFile": "index.ts",
         "rootDir": "packages/design-system/hooks"
     },
@@ -113,7 +113,7 @@
     },
     "input": {
         "scope": "showtime.universal",
-        "version": "0.0.17",
+        "version": "0.0.18",
         "mainFile": "index.tsx",
         "rootDir": "packages/design-system/input"
     },
@@ -131,19 +131,19 @@
     },
     "modal": {
         "scope": "showtime.universal",
-        "version": "0.0.26",
+        "version": "0.0.27",
         "mainFile": "index.tsx",
         "rootDir": "packages/design-system/modal"
     },
     "modal-screen": {
         "scope": "showtime.universal",
-        "version": "0.0.27",
+        "version": "0.0.28",
         "mainFile": "index.ts",
         "rootDir": "packages/design-system/modal-screen"
     },
     "modal-sheet": {
         "scope": "showtime.universal",
-        "version": "0.0.26",
+        "version": "0.0.27",
         "mainFile": "index.tsx",
         "rootDir": "packages/design-system/modal-sheet"
     },
@@ -155,7 +155,7 @@
     },
     "pressable": {
         "scope": "showtime.universal",
-        "version": "0.0.16",
+        "version": "0.0.17",
         "mainFile": "index.tsx",
         "rootDir": "packages/design-system/pressable"
     },
@@ -185,13 +185,13 @@
     },
     "segmented-control": {
         "scope": "showtime.universal",
-        "version": "0.0.16",
+        "version": "0.0.17",
         "mainFile": "index.tsx",
         "rootDir": "packages/design-system/segmented-control"
     },
     "select": {
         "scope": "showtime.universal",
-        "version": "0.0.25",
+        "version": "0.0.26",
         "mainFile": "index.ts",
         "rootDir": "packages/design-system/select"
     },
@@ -203,19 +203,19 @@
     },
     "snackbar": {
         "scope": "showtime.universal",
-        "version": "0.0.26",
+        "version": "0.0.27",
         "mainFile": "index.tsx",
         "rootDir": "packages/design-system/snackbar"
     },
     "spinner": {
         "scope": "showtime.universal",
-        "version": "0.0.14",
+        "version": "0.0.15",
         "mainFile": "index.tsx",
         "rootDir": "packages/design-system/spinner"
     },
     "switch": {
         "scope": "showtime.universal",
-        "version": "0.0.16",
+        "version": "0.0.17",
         "mainFile": "index.tsx",
         "rootDir": "packages/design-system/switch"
     },
@@ -239,13 +239,13 @@
     },
     "toast": {
         "scope": "showtime.universal",
-        "version": "0.0.20",
+        "version": "0.0.21",
         "mainFile": "index.tsx",
         "rootDir": "packages/design-system/toast"
     },
     "tooltip": {
         "scope": "showtime.universal",
-        "version": "0.0.16",
+        "version": "0.0.17",
         "mainFile": "index.tsx",
         "rootDir": "packages/design-system/tooltip"
     },
@@ -257,7 +257,7 @@
     },
     "verification-badge": {
         "scope": "showtime.universal",
-        "version": "0.0.8",
+        "version": "0.0.9",
         "mainFile": "index.tsx",
         "rootDir": "packages/design-system/verification-badge"
     },

--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -81,7 +81,7 @@
     "@showtime-xyz/universal.dropdown-menu": "^0.0.10",
     "@showtime-xyz/universal.extensions.react-native-web": "^0.0.9",
     "@showtime-xyz/universal.fieldset": "^0.0.26",
-    "@showtime-xyz/universal.hooks": "^0.0.14",
+    "@showtime-xyz/universal.hooks": "^0.0.15",
     "@showtime-xyz/universal.icon": "^0.0.22",
     "@showtime-xyz/universal.image": "^0.0.13",
     "@showtime-xyz/universal.input": "^0.0.17",

--- a/packages/app/components/footer/index.tsx
+++ b/packages/app/components/footer/index.tsx
@@ -1,9 +1,5 @@
 import { useWindowDimensions } from "react-native";
 
-import {
-  useBlurredBackgroundColor,
-  useIsDarkMode,
-} from "@showtime-xyz/universal.hooks";
 import { View } from "@showtime-xyz/universal.view";
 
 import { useUser } from "app/hooks/use-user";
@@ -17,6 +13,8 @@ import {
 import { useNavigationElements } from "app/navigation/use-navigation-elements";
 import { useRouter } from "app/navigation/use-router";
 
+import { useBlurredBackgroundStyles, useIsDarkMode } from "design-system/hooks";
+
 import { WebFooter } from "./links-footer.web";
 
 const Footer = () => {
@@ -25,7 +23,7 @@ const Footer = () => {
   const color = isDark ? "white" : "black";
   const { width } = useWindowDimensions();
   const { isAuthenticated } = useUser();
-  const blurredBackgroundColor = useBlurredBackgroundColor(95);
+  const blurredBackgroundStyles = useBlurredBackgroundStyles(95);
   const { isTabBarHidden } = useNavigationElements();
 
   // Todo: on small screens, only 'marketing' page display this.
@@ -42,8 +40,7 @@ const Footer = () => {
       // @ts-expect-error
       style={{
         position: "fixed",
-        backdropFilter: "blur(20px)",
-        backgroundColor: blurredBackgroundColor,
+        ...blurredBackgroundStyles,
       }}
       tw="bottom-0 right-0 left-0 z-50 h-16 flex-row items-center justify-between px-4 py-2"
     >

--- a/packages/app/components/footer/index.tsx
+++ b/packages/app/components/footer/index.tsx
@@ -1,5 +1,9 @@
 import { useWindowDimensions } from "react-native";
 
+import {
+  useBlurredBackgroundStyles,
+  useIsDarkMode,
+} from "@showtime-xyz/universal.hooks";
 import { View } from "@showtime-xyz/universal.view";
 
 import { useUser } from "app/hooks/use-user";
@@ -12,8 +16,6 @@ import {
 } from "app/navigation/tab-bar-icons";
 import { useNavigationElements } from "app/navigation/use-navigation-elements";
 import { useRouter } from "app/navigation/use-router";
-
-import { useBlurredBackgroundStyles, useIsDarkMode } from "design-system/hooks";
 
 import { WebFooter } from "./links-footer.web";
 

--- a/packages/app/components/header.tsx
+++ b/packages/app/components/header.tsx
@@ -10,10 +10,6 @@ import {
 import * as Popover from "@radix-ui/react-popover";
 
 import { Button } from "@showtime-xyz/universal.button";
-import {
-  useBlurredBackgroundColor,
-  useIsDarkMode,
-} from "@showtime-xyz/universal.hooks";
 import { ArrowLeft, Close, Plus, Search } from "@showtime-xyz/universal.icon";
 import { Input } from "@showtime-xyz/universal.input";
 import { PressableScale } from "@showtime-xyz/universal.pressable-scale";
@@ -36,6 +32,7 @@ import { useNavigateToLogin } from "app/navigation/use-navigate-to";
 import { useNavigationElements } from "app/navigation/use-navigation-elements";
 import { useRouter } from "app/navigation/use-router";
 
+import { useBlurredBackgroundStyles, useIsDarkMode } from "design-system/hooks";
 import { breakpoints } from "design-system/theme";
 
 import { withColorScheme } from "./memo-with-theme";
@@ -340,7 +337,7 @@ const HeaderCenter = ({
 const Header = withColorScheme(({ canGoBack }: { canGoBack: boolean }) => {
   const { width } = useWindowDimensions();
   const { isHeaderHidden } = useNavigationElements();
-  const blurredBackgroundColor = useBlurredBackgroundColor(95);
+  const blurredBackgroundStyles = useBlurredBackgroundStyles(95);
   const isDark = useIsDarkMode();
   const isMdWidth = width >= breakpoints["md"];
 
@@ -374,8 +371,7 @@ const Header = withColorScheme(({ canGoBack }: { canGoBack: boolean }) => {
       // @ts-expect-error
       style={{
         position: "sticky",
-        backdropFilter: "blur(20px)",
-        backgroundColor: blurredBackgroundColor,
+        ...blurredBackgroundStyles,
       }}
       tw="top-0 right-0 left-0 z-50 h-16 w-full flex-row items-center justify-between px-4 py-2 shadow-sm"
     >

--- a/packages/app/components/header.tsx
+++ b/packages/app/components/header.tsx
@@ -10,6 +10,10 @@ import {
 import * as Popover from "@radix-ui/react-popover";
 
 import { Button } from "@showtime-xyz/universal.button";
+import {
+  useBlurredBackgroundStyles,
+  useIsDarkMode,
+} from "@showtime-xyz/universal.hooks";
 import { ArrowLeft, Close, Plus, Search } from "@showtime-xyz/universal.icon";
 import { Input } from "@showtime-xyz/universal.input";
 import { PressableScale } from "@showtime-xyz/universal.pressable-scale";
@@ -32,7 +36,6 @@ import { useNavigateToLogin } from "app/navigation/use-navigate-to";
 import { useNavigationElements } from "app/navigation/use-navigation-elements";
 import { useRouter } from "app/navigation/use-router";
 
-import { useBlurredBackgroundStyles, useIsDarkMode } from "design-system/hooks";
 import { breakpoints } from "design-system/theme";
 
 import { withColorScheme } from "./memo-with-theme";

--- a/packages/app/components/swipe-list.tsx
+++ b/packages/app/components/swipe-list.tsx
@@ -17,6 +17,7 @@ import Reanimated, {
 
 import { Divider } from "@showtime-xyz/universal.divider";
 import { useIsDarkMode } from "@showtime-xyz/universal.hooks";
+import { useBlurredBackgroundStyles } from "@showtime-xyz/universal.hooks";
 import { Share } from "@showtime-xyz/universal.icon";
 import { Image } from "@showtime-xyz/universal.image";
 import { useSafeAreaFrame } from "@showtime-xyz/universal.safe-area";
@@ -55,8 +56,6 @@ import { useNavigation, useScrollToTop } from "app/lib/react-navigation/native";
 import { DataProvider, LayoutProvider } from "app/lib/recyclerlistview";
 import type { NFT } from "app/types";
 import { getMediaUrl } from "app/utilities";
-
-import { useBlurredBackgroundStyles } from "design-system/hooks";
 
 import { ViewabilityTrackerRecyclerList } from "./viewability-tracker-swipe-list";
 

--- a/packages/app/components/swipe-list.tsx
+++ b/packages/app/components/swipe-list.tsx
@@ -16,7 +16,10 @@ import Reanimated, {
 } from "react-native-reanimated";
 
 import { Divider } from "@showtime-xyz/universal.divider";
-import { useBlurredBackgroundStyles, useIsDarkMode } from "@showtime-xyz/universal.hooks";
+import {
+  useBlurredBackgroundStyles,
+  useIsDarkMode,
+} from "@showtime-xyz/universal.hooks";
 import { Share } from "@showtime-xyz/universal.icon";
 import { Image } from "@showtime-xyz/universal.image";
 import { useSafeAreaFrame } from "@showtime-xyz/universal.safe-area";

--- a/packages/app/components/swipe-list.tsx
+++ b/packages/app/components/swipe-list.tsx
@@ -16,8 +16,7 @@ import Reanimated, {
 } from "react-native-reanimated";
 
 import { Divider } from "@showtime-xyz/universal.divider";
-import { useIsDarkMode } from "@showtime-xyz/universal.hooks";
-import { useBlurredBackgroundStyles } from "@showtime-xyz/universal.hooks";
+import { useBlurredBackgroundStyles, useIsDarkMode } from "@showtime-xyz/universal.hooks";
 import { Share } from "@showtime-xyz/universal.icon";
 import { Image } from "@showtime-xyz/universal.image";
 import { useSafeAreaFrame } from "@showtime-xyz/universal.safe-area";

--- a/packages/app/components/swipe-list.tsx
+++ b/packages/app/components/swipe-list.tsx
@@ -56,6 +56,8 @@ import { DataProvider, LayoutProvider } from "app/lib/recyclerlistview";
 import type { NFT } from "app/types";
 import { getMediaUrl } from "app/utilities";
 
+import { useBlurredBackgroundStyles } from "design-system/hooks";
+
 import { ViewabilityTrackerRecyclerList } from "./viewability-tracker-swipe-list";
 
 const { height: screenHeight, width: screenWidth } = Dimensions.get("screen");
@@ -281,6 +283,7 @@ export const FeedItem = memo(
     const { data: edition } = useCreatorCollectionDetail(
       nft.creator_airdrop_edition_address
     );
+    const blurredBackgroundStyles = useBlurredBackgroundStyles(95);
 
     const isCreatorDrop = !!nft.creator_airdrop_edition_address;
 
@@ -431,9 +434,13 @@ export const FeedItem = memo(
             <BlurView
               tint={tint}
               intensity={100}
-              style={tw.style(
-                "bg-white bg-opacity-20 dark:bg-black dark:bg-opacity-20"
-              )}
+              style={{
+                // @ts-ignore
+                ...blurredBackgroundStyles,
+                ...tw.style(
+                  "bg-white bg-opacity-20 dark:bg-black dark:bg-opacity-20"
+                ),
+              }}
             >
               <NFTDetails edition={edition} nft={nft} listId={listId} />
               <View

--- a/packages/app/components/trending/nfts-list.tsx
+++ b/packages/app/components/trending/nfts-list.tsx
@@ -18,10 +18,9 @@ const GAP_BETWEEN_ITEMS = 1;
 export const NFTSList = forwardRef<TrendingTabListRef, TrendingTabListProps>(
   function NFTSList({ days, index }, ref) {
     const router = useRouter();
-    const { data, isLoadingMore, isLoading, refresh, fetchMore } =
-      useTrendingNFTS({
-        days,
-      });
+    const { data, isLoadingMore, refresh, fetchMore } = useTrendingNFTS({
+      days,
+    });
     useImperativeHandle(
       ref,
       () => ({

--- a/packages/design-system/hooks/index.ts
+++ b/packages/design-system/hooks/index.ts
@@ -132,10 +132,18 @@ function getBackgroundColor(intensity: number, tint: BlurTint): string {
   }
 }
 
-export function useBlurredBackgroundColor(intensity: number): string {
+export function useBlurredBackgroundStyles(intensity: number): {
+  backgroundColor: string;
+  backdropFilter: string;
+  "-webkit-backdrop-filter": string;
+} {
   const isDark = useIsDarkMode();
 
-  return getBackgroundColor(intensity, isDark ? "dark" : "light");
+  return {
+    backgroundColor: getBackgroundColor(intensity, isDark ? "dark" : "light"),
+    backdropFilter: "blur(20px)",
+    "-webkit-backdrop-filter": "blur(20px)",
+  };
 }
 
 export function useIsMobileWeb() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6746,7 +6746,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@showtime-xyz/universal.hooks@npm:0.0.14, @showtime-xyz/universal.hooks@npm:^0.0.14":
+"@showtime-xyz/universal.hooks@npm:0.0.14":
   version: 0.0.14
   resolution: "@showtime-xyz/universal.hooks@npm:0.0.14"
   dependencies:
@@ -6758,6 +6758,21 @@ __metadata:
     react-native: ^0.64.1
     react-native-web: ^0.16.0
   checksum: f7e8149dd47b6641787299f5abe851cc383ab1e5a36ad6508cc1993e15b9063e5d1c5b150bcc9a0c3cf4c8791452cc579809d3484b9ec62722faca3e10d137fa
+  languageName: node
+  linkType: hard
+
+"@showtime-xyz/universal.hooks@npm:^0.0.15":
+  version: 0.0.15
+  resolution: "@showtime-xyz/universal.hooks@npm:0.0.15"
+  dependencies:
+    "@showtime-xyz/universal.color-scheme": 0.0.5
+    react-native-reanimated: 2.8.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+    react-native: ^0.64.1
+    react-native-web: ^0.16.0
+  checksum: c795096b6ab270f18074b3ae90db3ef9344bd28ce994abfd5795a4250fd0ba511fa4212dd0f0faecee280581195673fd6ffc83fecfc5b8a5ae1d436406bafc98
   languageName: node
   linkType: hard
 
@@ -7303,7 +7318,7 @@ __metadata:
     "@showtime-xyz/universal.dropdown-menu": ^0.0.10
     "@showtime-xyz/universal.extensions.react-native-web": ^0.0.9
     "@showtime-xyz/universal.fieldset": ^0.0.26
-    "@showtime-xyz/universal.hooks": ^0.0.14
+    "@showtime-xyz/universal.hooks": ^0.0.15
     "@showtime-xyz/universal.icon": ^0.0.22
     "@showtime-xyz/universal.image": ^0.0.13
     "@showtime-xyz/universal.input": ^0.0.17


### PR DESCRIPTION
# Why

Blur backgrounds are not working as expected on mobile safari browsers because we are not targeting `webkit` browsers, I tried even using Tailwind but its not adding these prefixes, needed to update the blur background hook.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Checking header, feed item details, bottom nav bar background on mobile web Safari

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
