### PR TITLE
Fix notifications in header

### DIFF
--- a/packages/app/components/header.tsx
+++ b/packages/app/components/header.tsx
@@ -167,8 +167,7 @@ const NotificationsInHeader = () => {
         <NotificationsTabBarIcon
           color={isDark ? "white" : "black"}
           focused={router.pathname === "/notifications"}
-          onPress={(e: any) => {
-            e.preventDefault();
+          onPress={() => {
             setIsOpen(!isOpen);
           }}
         />

--- a/packages/app/navigation/tab-bar-icons.tsx
+++ b/packages/app/navigation/tab-bar-icons.tsx
@@ -14,6 +14,7 @@ import {
   Plus,
   Showtime,
 } from "@showtime-xyz/universal.icon";
+import { Pressable } from "@showtime-xyz/universal.pressable";
 import { tw } from "@showtime-xyz/universal.tailwind";
 import type { TW } from "@showtime-xyz/universal.tailwind";
 import { View } from "@showtime-xyz/universal.view";
@@ -30,14 +31,14 @@ type TabBarIconProps = {
   color?: string;
   focused?: boolean;
   customTw?: TW;
-  onPress?: (e: any) => void;
+  onPress?: () => void;
 };
 
 type TabBarButtonProps = {
   tab: string;
   children: React.ReactNode;
   customTw?: TW;
-  onPress?: (e: any) => void;
+  onPress?: () => void;
 };
 
 function TabBarIcon({ tab, children, customTw, onPress }: TabBarButtonProps) {
@@ -46,8 +47,25 @@ function TabBarIcon({ tab, children, customTw, onPress }: TabBarButtonProps) {
   const isMdWidth = width >= breakpoints["md"];
 
   if (isWeb) {
+    if (onPress) {
+      return (
+        <Pressable onPress={onPress} disableHoverEffect={true}>
+          <View
+            tw="h-12 w-12 items-center justify-center rounded-full"
+            style={tw.style(
+              `${
+                isWeb && isMdWidth ? "bg-gray-100 dark:bg-gray-900" : ""
+              } ${customTw}`
+            )}
+          >
+            {children}
+          </View>
+        </Pressable>
+      );
+    }
+
     return (
-      <Link href={tab} onPress={onPress}>
+      <Link href={tab}>
         <View
           tw="h-12 w-12 items-center justify-center rounded-full"
           style={tw.style(
@@ -165,7 +183,7 @@ export const NotificationsTabBarIcon = ({
   onPress,
 }: TabBarIconProps) => {
   return (
-    <TabBarIcon tab={onPress ? "" : "/notifications"} onPress={onPress}>
+    <TabBarIcon tab="/notifications" onPress={onPress}>
       {focused ? (
         <BellFilled
           style={tw.style("z-1")}


### PR DESCRIPTION
# Why

We have a weird bug happening only in production build where Next.js `Link` is navigating to a page. Can't understand why so decided to just use a `Pressable` instead for this use-case

# How

- Used `Pressable` instead of `Link` for `TabBarIcon` if `onPress` callback

# Test Plan

Run the web app in Vercel PR preview and check if clicking on the Notifications icon in the header is working correctly