### PR TITLE
refactor: nft card goes under bottom navigation

### DIFF
--- a/packages/app/components/swipe-list.tsx
+++ b/packages/app/components/swipe-list.tsx
@@ -430,7 +430,7 @@ export const FeedItem = memo(
 
           <Reanimated.View
             style={[
-              tw.style(`z-1 absolute bottom-0 right-0 left-0`),
+              tw.style("z-1 absolute right-0 left-0"),
               detailStyle,
               { bottom: bottomMargin },
             ]}

--- a/packages/app/components/swipe-list.tsx
+++ b/packages/app/components/swipe-list.tsx
@@ -264,6 +264,7 @@ export const FeedItem = memo(
   ({
     nft,
     bottomPadding = 0,
+    bottomMargin = 0,
     itemHeight,
     hideHeader,
     showHeader,
@@ -277,6 +278,7 @@ export const FeedItem = memo(
     hideHeader: any;
     toggleHeader: any;
     bottomPadding: number;
+    bottomMargin?: number;
     itemHeight: number;
     listId?: number;
   }) => {
@@ -428,8 +430,9 @@ export const FeedItem = memo(
 
           <Reanimated.View
             style={[
-              tw.style("z-1 absolute bottom-0 right-0 left-0"),
+              tw.style(`z-1 absolute bottom-0 right-0 left-0`),
               detailStyle,
+              { bottom: bottomMargin },
             ]}
           >
             <BlurView

--- a/packages/app/screens/nft.tsx
+++ b/packages/app/screens/nft.tsx
@@ -13,6 +13,7 @@ import { ErrorBoundary } from "app/components/error-boundary";
 import { FeedItem } from "app/components/swipe-list";
 import { useNFTListings } from "app/hooks/api/use-nft-listings";
 import { useNFTDetailByTokenId } from "app/hooks/use-nft-detail-by-token-id";
+import { useUser } from "app/hooks/use-user";
 import { useTrackPageViewed } from "app/lib/analytics";
 import { useHeaderHeight } from "app/lib/react-navigation/elements";
 import { createParam } from "app/navigation/use-param";
@@ -25,6 +26,7 @@ type Query = {
 
 const { useParam } = createParam<Query>();
 const { height: screenHeight, width: screenWidth } = Dimensions.get("screen");
+const BOTTOM_GAP = 128;
 
 function NftScreen() {
   useTrackPageViewed({ name: "NFT" });
@@ -70,7 +72,8 @@ const NFTDetail = () => {
   const headerHeight = useHeaderHeight();
   const { bottom: safeAreaBottom } = useSafeAreaInsets();
   const { height: safeAreaFrameHeight } = useSafeAreaFrame();
-  const { height: windowHeight } = useWindowDimensions();
+  const { height: windowHeight, width: windowWidth } = useWindowDimensions();
+  const { user } = useUser();
 
   const nftWithListing = useMemo(() => {
     return {
@@ -85,6 +88,8 @@ const NFTDetail = () => {
       : Platform.OS === "android"
       ? safeAreaFrameHeight - headerHeight
       : screenHeight;
+  const bottomMargin =
+    Platform.OS === "web" && windowWidth < 768 && !!user ? BOTTOM_GAP : 0;
   const nft = data?.data?.item;
 
   if (nft) {
@@ -92,6 +97,7 @@ const NFTDetail = () => {
       <FeedItem
         itemHeight={itemHeight}
         bottomPadding={safeAreaBottom}
+        bottomMargin={bottomMargin}
         nft={nftWithListing}
       />
     );


### PR DESCRIPTION
# Why

In the NFT details screen on mobile web, the NFT details card was placed under the bottom navigator. Needed to give bottom value.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Checking NFT details page on the mobile web.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
