### PR TITLE
fix: handle wallet disconnect during drop/claim

### DIFF
--- a/packages/app/components/claim/claim-form.tsx
+++ b/packages/app/components/claim/claim-form.tsx
@@ -8,9 +8,11 @@ import { tw } from "@showtime-xyz/universal.tailwind";
 import { Text } from "@showtime-xyz/universal.text";
 import { View } from "@showtime-xyz/universal.view";
 
+import { ConnectButton } from "app/components/connect-button";
 import { Media } from "app/components/media";
 import { PolygonScanButton } from "app/components/polygon-scan-button";
 import { useMyInfo } from "app/hooks/api-hooks";
+import { useWallet } from "app/hooks/auth/use-wallet";
 import { useClaimNFT } from "app/hooks/use-claim-nft";
 import {
   CreatorEditionResponse,
@@ -19,7 +21,9 @@ import {
 import { useCurrentUserAddress } from "app/hooks/use-current-user-address";
 import { useNFTDetailByTokenId } from "app/hooks/use-nft-detail-by-token-id";
 import { useShare } from "app/hooks/use-share";
+import { useUser } from "app/hooks/use-user";
 import { track } from "app/lib/analytics";
+import { useNavigateToLogin } from "app/navigation/use-navigate-to";
 import { useRouter } from "app/navigation/use-router";
 import {
   formatAddressShort,
@@ -33,6 +37,9 @@ export const ClaimForm = ({ edition }: { edition: CreatorEditionResponse }) => {
   const router = useRouter();
 
   const { userAddress } = useCurrentUserAddress();
+  const { isAuthenticated } = useUser();
+  const { connected } = useWallet();
+  const navigateToLogin = useNavigateToLogin();
 
   const { data: nft } = useNFTDetailByTokenId({
     //@ts-ignore
@@ -70,6 +77,25 @@ export const ClaimForm = ({ edition }: { edition: CreatorEditionResponse }) => {
   //       });
   //     });
   // }, [web3]);
+
+  if (!isAuthenticated) {
+    return (
+      <View tw="p-4">
+        <Button onPress={navigateToLogin}>Please login to continue</Button>
+      </View>
+    );
+  }
+
+  // TODO: remove this after imperative login modal API in rainbowkit
+  if (!connected) {
+    return (
+      <View tw="p-4">
+        <ConnectButton
+          handleSubmitWallet={({ onOpenConnectModal }) => onOpenConnectModal()}
+        />
+      </View>
+    );
+  }
 
   if (state.status === "success") {
     const claimUrl = `https://showtime.xyz/t/${[

--- a/packages/app/components/connect-button.tsx
+++ b/packages/app/components/connect-button.tsx
@@ -1,3 +1,0 @@
-export const NetworkButton = () => {
-  return null;
-};

--- a/packages/app/components/connect-button/connect-button.tsx
+++ b/packages/app/components/connect-button/connect-button.tsx
@@ -1,0 +1,16 @@
+import { useWalletConnect } from "@walletconnect/react-native-dapp";
+
+import { Button } from "@showtime-xyz/universal.button";
+
+export type ConnectButtonProps = {
+  handleSubmitWallet: ({
+    onOpenConnectModal,
+  }: {
+    onOpenConnectModal: () => void;
+  }) => void;
+};
+
+export const ConnectButton = (_props: ConnectButtonProps) => {
+  const { connect } = useWalletConnect();
+  return <Button onPress={connect}>Connect Wallet</Button>;
+};

--- a/packages/app/components/connect-button/connect-button.web.tsx
+++ b/packages/app/components/connect-button/connect-button.web.tsx
@@ -4,17 +4,10 @@ import { ConnectButton as RainbowConnectButton } from "@rainbow-me/rainbowkit";
 
 import { Button } from "@showtime-xyz/universal.button";
 import { useIsDarkMode } from "@showtime-xyz/universal.hooks";
+import { Alert } from "@showtime-xyz/universal.icon";
 import { View } from "@showtime-xyz/universal.view";
 
-import { Alert } from "design-system/icon";
-
-type ConnectButtonProps = {
-  handleSubmitWallet: ({
-    onOpenConnectModal,
-  }: {
-    onOpenConnectModal: () => void;
-  }) => void;
-};
+import { ConnectButtonProps } from "./connect-button";
 
 export const NetworkButton = () => {
   const { width } = useWindowDimensions();

--- a/packages/app/components/connect-button/index.ts
+++ b/packages/app/components/connect-button/index.ts
@@ -1,0 +1,1 @@
+export { ConnectButton } from "./connect-button";

--- a/packages/app/components/drop/drop-form.tsx
+++ b/packages/app/components/drop/drop-form.tsx
@@ -23,6 +23,7 @@ import { useWallet } from "app/hooks/auth/use-wallet";
 import { UseDropNFT, useDropNFT } from "app/hooks/use-drop-nft";
 import { useShare } from "app/hooks/use-share";
 import { useUser } from "app/hooks/use-user";
+import { useWeb3 } from "app/hooks/use-web3";
 import { track } from "app/lib/analytics";
 import { yup } from "app/lib/yup";
 import { useNavigateToLogin } from "app/navigation/use-navigate-to";
@@ -92,6 +93,7 @@ export const DropForm = () => {
   const user = useUser();
   const { isAuthenticated } = useUser();
   const { connected } = useWallet();
+  const { web3 } = useWeb3();
   const navigateToLogin = useNavigateToLogin();
 
   const onSubmit = (values: UseDropNFT) => {
@@ -129,7 +131,7 @@ export const DropForm = () => {
   }
 
   // TODO: remove this after imperative login modal API in rainbowkit
-  if (!connected) {
+  if (!connected && !web3) {
     return (
       <View tw="p-4">
         <ConnectButton

--- a/packages/app/components/drop/drop-form.tsx
+++ b/packages/app/components/drop/drop-form.tsx
@@ -16,13 +16,16 @@ import { tw } from "@showtime-xyz/universal.tailwind";
 import { Text } from "@showtime-xyz/universal.text";
 import { View } from "@showtime-xyz/universal.view";
 
+import { ConnectButton } from "app/components/connect-button";
 import { PolygonScanButton } from "app/components/polygon-scan-button";
 import { Preview } from "app/components/preview";
+import { useWallet } from "app/hooks/auth/use-wallet";
 import { UseDropNFT, useDropNFT } from "app/hooks/use-drop-nft";
 import { useShare } from "app/hooks/use-share";
 import { useUser } from "app/hooks/use-user";
 import { track } from "app/lib/analytics";
 import { yup } from "app/lib/yup";
+import { useNavigateToLogin } from "app/navigation/use-navigate-to";
 import { useRouter } from "app/navigation/use-router";
 import { getTwitterIntent, getUserDisplayNameFromProfile } from "app/utilities";
 
@@ -87,6 +90,9 @@ export const DropForm = () => {
 
   const { state, dropNFT } = useDropNFT();
   const user = useUser();
+  const { isAuthenticated } = useUser();
+  const { connected } = useWallet();
+  const navigateToLogin = useNavigateToLogin();
 
   const onSubmit = (values: UseDropNFT) => {
     dropNFT(values);
@@ -113,6 +119,25 @@ export const DropForm = () => {
   //     <Text>Loading</Text>
   //   </View>
   // }
+
+  if (!isAuthenticated) {
+    return (
+      <View tw="p-4">
+        <Button onPress={navigateToLogin}>Please login to continue</Button>
+      </View>
+    );
+  }
+
+  // TODO: remove this after imperative login modal API in rainbowkit
+  if (!connected) {
+    return (
+      <View tw="p-4">
+        <ConnectButton
+          handleSubmitWallet={({ onOpenConnectModal }) => onOpenConnectModal()}
+        />
+      </View>
+    );
+  }
 
   if (state.status === "success") {
     const claimUrl = `https://showtime.xyz/t/${[

--- a/packages/app/hooks/auth/use-wallet.ts
+++ b/packages/app/hooks/auth/use-wallet.ts
@@ -1,8 +1,12 @@
+import { useMemo } from "react";
+
+import { useWalletConnect } from "@walletconnect/react-native-dapp";
 import { ethers } from "ethers";
 
 import getWeb3Modal from "app/lib/web3-modal.native";
 
 const useWallet = () => {
+  const { connected, accounts, killSession } = useWalletConnect();
   const signTypedDataAsync = async ({
     domain,
     types,
@@ -18,9 +22,15 @@ const useWallet = () => {
     return await web3.getSigner()._signTypedData(domain, types, value);
   };
 
+  const address = useMemo(
+    () => accounts.find((a) => a.startsWith("0x")),
+    [accounts]
+  );
+
   return {
-    address: "",
-    connected: false,
+    address,
+    disconnect: killSession,
+    connected,
     loggedIn: null,
     networkChanged: null,
     signMessage: null,

--- a/packages/app/hooks/auth/use-wallet.web.ts
+++ b/packages/app/hooks/auth/use-wallet.web.ts
@@ -6,6 +6,7 @@ import {
   useSigner,
   useNetwork,
   useSignTypedData,
+  useDisconnect,
 } from "wagmi";
 
 const useWallet = () => {
@@ -14,6 +15,7 @@ const useWallet = () => {
   const { data: wagmiSigner } = useSigner();
   const { activeChain } = useNetwork();
   const { signTypedDataAsync } = useSignTypedData();
+  const { disconnect } = useDisconnect();
 
   const getAddress = async () => {
     return wagmiData?.address;
@@ -36,6 +38,7 @@ const useWallet = () => {
     connected,
     signed,
     loggedIn,
+    disconnect,
     networkChanged,
     provider: wagmiSigner?.provider,
     signature: wagmiSignData,

--- a/packages/app/hooks/use-claim-nft.ts
+++ b/packages/app/hooks/use-claim-nft.ts
@@ -5,7 +5,7 @@ import { ethers } from "ethers";
 import { useAlert } from "@showtime-xyz/universal.alert";
 
 import { PROFILE_NFTS_QUERY_KEY } from "app/hooks/api-hooks";
-import { useCurrentUserAddress } from "app/hooks/use-current-user-address";
+import { useWallet } from "app/hooks/auth/use-wallet";
 import { useMatchMutate } from "app/hooks/use-match-mutate";
 import { useSignTypedData } from "app/hooks/use-sign-typed-data";
 import { track } from "app/lib/analytics";
@@ -58,18 +58,18 @@ const reducer = (state: State, action: Action): State => {
 
 export const useClaimNFT = () => {
   const signTypedData = useSignTypedData();
-  const { userAddress } = useCurrentUserAddress();
   const [state, dispatch] = useReducer(reducer, initialState);
   const mutate = useMatchMutate();
+  const { address: walletAddress } = useWallet();
   const Alert = useAlert();
 
   const claimNFT = async (props: { minterAddress: string }) => {
     try {
-      if (userAddress) {
+      if (walletAddress) {
         const targetInterface = new ethers.utils.Interface(minterABI);
         dispatch({ type: "loading" });
         const callData = targetInterface.encodeFunctionData("mintEdition", [
-          userAddress,
+          walletAddress,
         ]);
 
         const forwardRequest = await axios({
@@ -77,7 +77,7 @@ export const useClaimNFT = () => {
             callData
           )}&to_address=${encodeURIComponent(
             props.minterAddress
-          )}&from_address=${encodeURIComponent(userAddress)}`,
+          )}&from_address=${encodeURIComponent(walletAddress)}`,
           method: "GET",
         });
 
@@ -99,7 +99,7 @@ export const useClaimNFT = () => {
           data: {
             forward_request: forwardRequest,
             signature,
-            from_address: userAddress,
+            from_address: walletAddress,
           },
         });
 

--- a/packages/app/hooks/use-claim-nft.ts
+++ b/packages/app/hooks/use-claim-nft.ts
@@ -5,7 +5,7 @@ import { ethers } from "ethers";
 import { useAlert } from "@showtime-xyz/universal.alert";
 
 import { PROFILE_NFTS_QUERY_KEY } from "app/hooks/api-hooks";
-import { useWallet } from "app/hooks/auth/use-wallet";
+import { useCurrentUserAddress } from "app/hooks/use-current-user-address";
 import { useMatchMutate } from "app/hooks/use-match-mutate";
 import { useSignTypedData } from "app/hooks/use-sign-typed-data";
 import { track } from "app/lib/analytics";
@@ -60,16 +60,16 @@ export const useClaimNFT = () => {
   const signTypedData = useSignTypedData();
   const [state, dispatch] = useReducer(reducer, initialState);
   const mutate = useMatchMutate();
-  const { address: walletAddress } = useWallet();
+  const { userAddress } = useCurrentUserAddress();
   const Alert = useAlert();
 
   const claimNFT = async (props: { minterAddress: string }) => {
     try {
-      if (walletAddress) {
+      if (userAddress) {
         const targetInterface = new ethers.utils.Interface(minterABI);
         dispatch({ type: "loading" });
         const callData = targetInterface.encodeFunctionData("mintEdition", [
-          walletAddress,
+          userAddress,
         ]);
 
         const forwardRequest = await axios({
@@ -77,7 +77,7 @@ export const useClaimNFT = () => {
             callData
           )}&to_address=${encodeURIComponent(
             props.minterAddress
-          )}&from_address=${encodeURIComponent(walletAddress)}`,
+          )}&from_address=${encodeURIComponent(userAddress)}`,
           method: "GET",
         });
 
@@ -99,7 +99,7 @@ export const useClaimNFT = () => {
           data: {
             forward_request: forwardRequest,
             signature,
-            from_address: walletAddress,
+            from_address: userAddress,
           },
         });
 

--- a/packages/app/hooks/use-drop-nft.ts
+++ b/packages/app/hooks/use-drop-nft.ts
@@ -5,7 +5,7 @@ import { ethers } from "ethers";
 import { useAlert } from "@showtime-xyz/universal.alert";
 
 import { PROFILE_NFTS_QUERY_KEY } from "app/hooks/api-hooks";
-import { useWallet } from "app/hooks/auth/use-wallet";
+import { useCurrentUserAddress } from "app/hooks/use-current-user-address";
 import { useMatchMutate } from "app/hooks/use-match-mutate";
 import { useSignTypedData } from "app/hooks/use-sign-typed-data";
 import { useUploadMediaToPinata } from "app/hooks/use-upload-media-to-pinata";
@@ -89,14 +89,14 @@ export type UseDropNFT = {
 export const useDropNFT = () => {
   const signTypedData = useSignTypedData();
   const uploadMedia = useUploadMediaToPinata();
-  const { address: walletAddress } = useWallet();
+  const { userAddress } = useCurrentUserAddress();
   const [state, dispatch] = useReducer(reducer, initialState);
   const mutate = useMatchMutate();
   const Alert = useAlert();
 
   const dropNFT = async (params: UseDropNFT) => {
     try {
-      if (walletAddress) {
+      if (userAddress) {
         const targetInterface = new ethers.utils.Interface(editionCreatorABI);
 
         const fileMetaData = await getFileMeta(params.file);
@@ -135,7 +135,7 @@ export const useDropNFT = () => {
           )}&to_address=${encodeURIComponent(
             //@ts-ignore
             metaSingleEditionMintableCreator
-          )}&from_address=${walletAddress}`,
+          )}&from_address=${userAddress}`,
           method: "GET",
         });
 
@@ -158,7 +158,7 @@ export const useDropNFT = () => {
           data: {
             forward_request: forwardRequest,
             signature,
-            from_address: walletAddress,
+            from_address: userAddress,
           },
         });
 

--- a/packages/app/hooks/use-drop-nft.ts
+++ b/packages/app/hooks/use-drop-nft.ts
@@ -5,7 +5,7 @@ import { ethers } from "ethers";
 import { useAlert } from "@showtime-xyz/universal.alert";
 
 import { PROFILE_NFTS_QUERY_KEY } from "app/hooks/api-hooks";
-import { useCurrentUserAddress } from "app/hooks/use-current-user-address";
+import { useWallet } from "app/hooks/auth/use-wallet";
 import { useMatchMutate } from "app/hooks/use-match-mutate";
 import { useSignTypedData } from "app/hooks/use-sign-typed-data";
 import { useUploadMediaToPinata } from "app/hooks/use-upload-media-to-pinata";
@@ -89,14 +89,14 @@ export type UseDropNFT = {
 export const useDropNFT = () => {
   const signTypedData = useSignTypedData();
   const uploadMedia = useUploadMediaToPinata();
-  const { userAddress } = useCurrentUserAddress();
+  const { address: walletAddress } = useWallet();
   const [state, dispatch] = useReducer(reducer, initialState);
   const mutate = useMatchMutate();
   const Alert = useAlert();
 
   const dropNFT = async (params: UseDropNFT) => {
     try {
-      if (userAddress) {
+      if (walletAddress) {
         const targetInterface = new ethers.utils.Interface(editionCreatorABI);
 
         const fileMetaData = await getFileMeta(params.file);
@@ -135,7 +135,7 @@ export const useDropNFT = () => {
           )}&to_address=${encodeURIComponent(
             //@ts-ignore
             metaSingleEditionMintableCreator
-          )}&from_address=${userAddress}`,
+          )}&from_address=${walletAddress}`,
           method: "GET",
         });
 
@@ -158,7 +158,7 @@ export const useDropNFT = () => {
           data: {
             forward_request: forwardRequest,
             signature,
-            from_address: userAddress,
+            from_address: walletAddress,
           },
         });
 

--- a/packages/app/providers/auth-provider.web.tsx
+++ b/packages/app/providers/auth-provider.web.tsx
@@ -10,9 +10,13 @@ interface AuthProviderProps {
 
 export function AuthProvider({ children }: AuthProviderProps) {
   const { disconnect } = useDisconnect();
+  const handleDisconnect = () => {
+    disconnect();
+    localStorage.removeItem("walletconnect");
+  };
 
   return (
-    <AuthProviderBase onWagmiDisconnect={disconnect}>
+    <AuthProviderBase onWagmiDisconnect={handleDisconnect}>
       {children}
     </AuthProviderBase>
   );


### PR DESCRIPTION
# Why
we don't handle a case when a wallet is disconnected during drop/claim

# How
During drop/claim
- if user is not logged in, we show a sign in button
- if user's wallet is not connected, we show a connect wallet button
https://showtime-rq88331.slack.com/archives/C02PXGK3V8D/p1655946595060959

This is a workaround due to the lack of imperative connect API in rainbowkit. I'll try to implement it and raise a PR in rainbowkit. https://github.com/rainbow-me/rainbowkit/discussions/386
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- try drop/claim and disconnect wallet (I did it by setting autoConnect false)


# Aside
we need to refactor some web3 hooks  https://linear.app/showtime/issue/SHOW2-917/clean-up-web3-action-hooks
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
