### PR TITLE
fix: profile blocked text

### DIFF
--- a/apps/next-react-native/src/pages/_app.tsx
+++ b/apps/next-react-native/src/pages/_app.tsx
@@ -90,7 +90,11 @@ export default function App({ Component, pageProps, router }: AppProps) {
               router.pathname.split("/").length - 1 >= 2
             }
           />
-          <View tw="min-h-screen items-center overflow-x-hidden">
+          <View
+            tw="min-h-screen items-center"
+            // @ts-ignore currently overflow-x-hidden doesn't support web
+            style={{ overflowX: "hidden" }}
+          >
             <Component {...pageProps} />
           </View>
           <Footer />

--- a/packages/app/components/profile/index.tsx
+++ b/packages/app/components/profile/index.tsx
@@ -208,27 +208,21 @@ const Profile = ({ address }: { address: string | null }) => {
           animationHeaderPosition={animationHeaderPosition}
           animationHeaderHeight={animationHeaderHeight}
           insertStickyTabBarElement={
-            Platform.OS === "web" ? (
-              <View
-                tw="absolute left-0 top-0 h-full w-screen bg-white dark:bg-black"
-                style={{
-                  left: headerBgLeft,
-                  // @ts-ignore
-                  boxShadow: headerShadow,
-                }}
-              />
-            ) : null
+            <View
+              tw="absolute left-0 top-0 h-full w-screen bg-white dark:bg-black"
+              style={{
+                left: headerBgLeft,
+                // @ts-ignore
+                boxShadow: headerShadow,
+              }}
+            />
           }
           insertTabBarElement={
-            Platform.OS === "web" ? (
-              <>
-                <View tw="absolute -bottom-11 w-full justify-between md:bottom-1.5 md:right-10 md:w-auto">
-                  <ProfileListFilter
-                    collections={data?.tabs[index]?.collections || []}
-                  />
-                </View>
-              </>
-            ) : null
+            <View tw="relative my-2 w-full justify-between md:absolute md:bottom-1.5 md:right-10 md:my-0 md:w-auto">
+              <ProfileListFilter
+                collections={data?.tabs[index]?.collections || []}
+              />
+            </View>
           }
         />
       </View>

--- a/packages/app/components/profile/profile-tab-list.tsx
+++ b/packages/app/components/profile/profile-tab-list.tsx
@@ -10,7 +10,6 @@ import { useWindowDimensions } from "react-native";
 
 import { tw } from "@showtime-xyz/universal.tailwind";
 import { Text } from "@showtime-xyz/universal.text";
-import { View } from "@showtime-xyz/universal.view";
 
 import { Card } from "app/components/card";
 import { getLocalFileURI } from "app/components/preview";
@@ -23,14 +22,12 @@ import { DataProvider } from "app/lib/recyclerlistview";
 import { useRouter } from "app/navigation/use-router";
 import { MutateProvider } from "app/providers/mutate-provider";
 
-import { Hidden } from "design-system/hidden";
 import { TabRecyclerList, TabScrollView } from "design-system/tab-view";
 import { TabSpinner } from "design-system/tab-view/tab-spinner";
 
 import { EmptyPlaceholder } from "../empty-placeholder";
 import { FilterContext } from "./fillter-context";
 import { ProfileFooter } from "./footer";
-import { ProfileListFilter } from "./profile-tab-filter";
 
 type TabListProps = {
   username?: string;
@@ -91,19 +88,8 @@ export const ProfileTabList = forwardRef<ProfileTabListRef, TabListProps>(
       [isLoadingMore]
     );
 
-    const ListHeaderComponent = useCallback(
-      () => (
-        <View tw="p-4">
-          <Hidden platform="web">
-            <ProfileListFilter collections={list.collections} />
-          </Hidden>
-        </View>
-      ),
-      [list.collections]
-    );
-
     const newData = useMemo(() => {
-      let newData: any = ["header"];
+      let newData: any = [];
       if (isBlocked) return newData;
       if (
         mintingState.loading &&
@@ -135,13 +121,9 @@ export const ProfileTabList = forwardRef<ProfileTabListRef, TabListProps>(
       user?.data.profile.profile_id,
     ]);
 
-    const headerHeight = useMemo(
-      () => (isBlocked ? 80 : width < 768 ? 80 : 32),
-      [width, isBlocked]
-    );
     const _layoutProvider = useNFTCardsListLayoutProvider({
       newData,
-      headerHeight,
+      headerHeight: 0,
     });
 
     const dataProvider = useMemo(
@@ -164,17 +146,12 @@ export const ProfileTabList = forwardRef<ProfileTabListRef, TabListProps>(
     );
     const _rowRenderer = useCallback(
       (_type: any, item: any) => {
-        if (_type === "header") {
-          return <ListHeaderComponent />;
-        }
-
         // currently minting nft
         if (item.loading) {
           return <Card nft={item} numColumns={3} />;
         }
 
         return (
-          // index - 1 because header takes the initial index!
           <Card
             nft={item}
             numColumns={3}
@@ -186,15 +163,23 @@ export const ProfileTabList = forwardRef<ProfileTabListRef, TabListProps>(
           />
         );
       },
-      [list.type, ListHeaderComponent, onItemPress]
+      [list.type, onItemPress]
     );
     if (isBlocked) {
       return (
-        <View tw="mt-8 items-center justify-center">
-          <Text tw="text-gray-900 dark:text-white">
-            <Text tw="font-bold">@{username}</Text> is blocked
-          </Text>
-        </View>
+        <TabScrollView
+          contentContainerStyle={tw.style("mt-12 items-center")}
+          index={index}
+        >
+          <EmptyPlaceholder
+            title={
+              <Text tw="text-gray-900 dark:text-white">
+                <Text tw="font-bold">@{username}</Text> is blocked
+              </Text>
+            }
+            hideLoginBtn
+          />
+        </TabScrollView>
       );
     }
 

--- a/packages/design-system/tab-view/index.tsx
+++ b/packages/design-system/tab-view/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, isValidElement } from "react";
 import { Platform, StatusBar, View } from "react-native";
 
 import {
@@ -24,6 +24,7 @@ export * from "react-native-tab-view-next";
 
 type TabBarProps<T extends Route> = HeaderTabViewProps<T> & {
   autoWidthTabBar?: boolean;
+  insertTabBarElement?: JSX.Element;
 };
 const StatusBarHeight = StatusBar.currentHeight ?? 0;
 
@@ -31,6 +32,7 @@ export function HeaderTabView<T extends Route>({
   autoWidthTabBar,
   renderScene,
   navigationState,
+  insertTabBarElement,
   ...props
 }: TabBarProps<T>) {
   const insets = useSafeAreaInsets();
@@ -40,13 +42,17 @@ export function HeaderTabView<T extends Route>({
       props: SceneRendererProps & {
         navigationState: NavigationState<Route>;
       }
-    ) =>
-      autoWidthTabBar ? (
-        <ScollableAutoWidthTabBar {...props} />
-      ) : (
-        <ScollableTabBar {...props} />
-      ),
-    [autoWidthTabBar]
+    ) => (
+      <>
+        {autoWidthTabBar ? (
+          <ScollableAutoWidthTabBar {...props} />
+        ) : (
+          <ScollableTabBar {...props} />
+        )}
+        {isValidElement(insertTabBarElement) && insertTabBarElement}
+      </>
+    ),
+    [autoWidthTabBar, insertTabBarElement]
   );
   const onPullEnough = useCallback(() => {
     Haptics.impactAsync();

--- a/packages/design-system/tab-view/src/create-header-tabs.tsx
+++ b/packages/design-system/tab-view/src/create-header-tabs.tsx
@@ -90,7 +90,9 @@ function CollapsibleHeaderTabView<T extends Route>({
             navigationState: NavigationState<T>;
           }
         ) => e.renderTabBarContainer(_renderTabBar(tabbarProps))}
-        renderScene={(props: any) => e.renderSceneHeader(renderScene(props))}
+        renderScene={(props: any) =>
+          e.renderSceneHeader(renderScene(props), props)
+        }
       />
     );
   };

--- a/packages/design-system/tab-view/src/gesture-container.tsx
+++ b/packages/design-system/tab-view/src/gesture-container.tsx
@@ -26,6 +26,7 @@ import Animated, {
   withDecay,
   withTiming,
 } from "react-native-reanimated";
+import type { SceneRendererProps } from "react-native-tab-view-next/src";
 
 import { HeaderTabContext } from "./context";
 import { useRefreshDerivedValue } from "./hooks/use-refresh-value";
@@ -587,7 +588,10 @@ export const GestureContainer = React.forwardRef<
       </Animated.View>
     );
   };
-  const _renderSceneHeader = (children: React.ReactElement) => {
+  const _renderSceneHeader = (
+    children: React.ReactElement,
+    props: SceneRendererProps & { route: Route }
+  ) => {
     return (
       <View style={{ flex: 1 }}>
         {children}
@@ -607,7 +611,7 @@ export const GestureContainer = React.forwardRef<
             headerStyle,
           ]}
         >
-          {renderSceneHeader?.(children.props as Route)}
+          {renderSceneHeader?.(props.route)}
         </Animated.View>
       </View>
     );

--- a/packages/design-system/tab-view/src/index.web.tsx
+++ b/packages/design-system/tab-view/src/index.web.tsx
@@ -40,7 +40,6 @@ function CollapsibleHeaderTabView<T extends Route>(
     renderScrollHeader,
     initTabbarHeight = 44,
     minHeaderHeight = 0,
-    insertTabBarElement,
     navigationState,
     insertStickyTabBarElement,
     emptyBodyComponent,
@@ -103,7 +102,9 @@ function CollapsibleHeaderTabView<T extends Route>(
             navigationState: NavigationState<T>;
           }
         ) => e.renderTabBarContainer(_renderTabBar(tabbarProps))}
-        renderScene={(props: any) => e.renderSceneHeader(renderScene(props))}
+        renderScene={(props: any) =>
+          e.renderSceneHeader(renderScene(props), props)
+        }
       />
     );
   };
@@ -124,8 +125,6 @@ function CollapsibleHeaderTabView<T extends Route>(
             stickyState === Sticky.STATUS_FIXED &&
             insertStickyTabBarElement}
           <View onLayout={tabbarOnLayout}>{children}</View>
-
-          {React.isValidElement(insertTabBarElement) && insertTabBarElement}
         </Sticky>
       </View>
     );

--- a/packages/design-system/tab-view/src/types.tsx
+++ b/packages/design-system/tab-view/src/types.tsx
@@ -44,10 +44,6 @@ export type CollapsibleHeaderProps<T extends Route> = {
   refreshControlTop?: number;
   emptyBodyComponent?: JSX.Element | null;
   /**
-   * WEB_ONLY: Insert element into tabbar.
-   */
-  insertTabBarElement?: JSX.Element | null;
-  /**
    * WEB_ONLY: Insert element into tabbar on Sticky.
    */
   insertStickyTabBarElement?: JSX.Element | null;
@@ -56,7 +52,7 @@ export type CollapsibleHeaderProps<T extends Route> = {
 
 export type TabViewCustomRenders = {
   renderTabBarContainer: (children: any) => JSX.Element;
-  renderSceneHeader: (children: any) => JSX.Element;
+  renderSceneHeader: (children: any, props: any) => JSX.Element;
 };
 
 export type GestureContainerProps<T extends Route> = Pick<


### PR DESCRIPTION
# Why

- profile blocked text is obscured.
- on native, `ProfileListFilter` is inserted in the list now, the code is not pure.


# How

- use`TabScrollView` to display the blocked text.
- native and web use the same props as we build new a `TabView`, we don't need hacks.


# Test Plan

- check the profile page if it works.
