### PR TITLE
fix: mobile web login redirection

### DIFF
--- a/packages/app/components/login/index.web.tsx
+++ b/packages/app/components/login/index.web.tsx
@@ -87,7 +87,7 @@ export function Login({ onLogin }: LoginProps) {
             cost any gas.
           </Text>
           <Button tw="mt-8" onPress={verifySignature}>
-            Sign a message
+            Sign the message
           </Button>
         </View>
       ) : (

--- a/packages/app/components/login/index.web.tsx
+++ b/packages/app/components/login/index.web.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from "react";
 import { StyleSheet } from "react-native";
 
+import { Button } from "@showtime-xyz/universal.button";
 import { Text } from "@showtime-xyz/universal.text";
 import { View } from "@showtime-xyz/universal.view";
 
@@ -26,6 +27,8 @@ export function Login({ onLogin }: LoginProps) {
     handleSubmitWallet,
     handleSubmitEmail,
     handleSubmitPhoneNumber,
+    showSignMessage,
+    verifySignature,
   } = useLogin(onLogin);
   //#endregion
 
@@ -76,6 +79,16 @@ export function Login({ onLogin }: LoginProps) {
               ? `Pushed a request to ${walletName}... Please check your wallet.`
               : `Pushed a request to your wallet...`}
           </Text>
+        </View>
+      ) : showSignMessage ? (
+        <View tw="py-20 px-10">
+          <Text tw="text-center text-lg dark:text-gray-400">
+            We need a signature in order to verify your identity. This won't
+            cost any gas.
+          </Text>
+          <Button tw="mt-8" onPress={verifySignature}>
+            Sign a message
+          </Button>
         </View>
       ) : (
         <>

--- a/packages/app/components/login/use-login.ts
+++ b/packages/app/components/login/use-login.ts
@@ -21,6 +21,10 @@ export const useLogin = (onLogin?: () => void) => {
     name: walletName,
     status: walletStatus,
     error: walletError,
+    //@ts-ignore web only
+    showSignMessage,
+    //@ts-ignore web only
+    verifySignature,
   } = useWalletLogin();
   const { loginWithEmail, loginWithPhoneNumber } = useMagicLogin();
   const isWeb = Platform.OS === "web";
@@ -131,5 +135,7 @@ export const useLogin = (onLogin?: () => void) => {
     handleSubmitWallet,
     handleSubmitEmail,
     handleSubmitPhoneNumber,
+    showSignMessage,
+    verifySignature,
   };
 };

--- a/packages/app/hooks/auth/use-wallet-login.web.ts
+++ b/packages/app/hooks/auth/use-wallet-login.web.ts
@@ -1,6 +1,8 @@
-import { useMemo, useEffect } from "react";
+import { useMemo, useEffect, useState } from "react";
 
-import { useAccessToken } from "../../lib/access-token";
+import { useAccessToken } from "app/lib/access-token";
+import { isMobile } from "app/utilities";
+
 import { useUser } from "../use-user";
 import { useWeb3 } from "../use-web3";
 import { useAuth } from "./use-auth";
@@ -19,6 +21,7 @@ export function useWalletLogin() {
   const { setWeb3 } = useWeb3();
   const { getNonce, rotateNonce } = useNonce();
   const { login: _login } = useAuth();
+  const [showSignMessage, setShowSignMessage] = useState(false);
   const {
     address: walletAddress,
     connected,
@@ -101,7 +104,13 @@ export function useWalletLogin() {
     ) {
       handleSetWeb3();
     } else if (connected && !authenticated && loggedIn) {
-      handleLogin();
+      // TODO: refactor after getting a better alternative
+      // https://github.com/rainbow-me/rainbowkit/discussions/536
+      if (isMobile()) {
+        setShowSignMessage(true);
+      } else {
+        handleLogin();
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loggedIn, accessToken, connected, authenticated, networkChanged]);
@@ -113,5 +122,12 @@ export function useWalletLogin() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [signed]);
 
-  return { status, name, error, loginWithWallet: handleLogin };
+  return {
+    status,
+    name,
+    error,
+    loginWithWallet: handleLogin,
+    showSignMessage,
+    verifySignature: handleLogin,
+  };
 }

--- a/packages/app/utilities.ts
+++ b/packages/app/utilities.ts
@@ -687,5 +687,5 @@ export function isIOS(): boolean {
 }
 
 export function isMobile(): boolean {
-  return isAndroid() || isSmallIOS();
+  return isAndroid() || isIOS();
 }

--- a/packages/app/utilities.ts
+++ b/packages/app/utilities.ts
@@ -665,3 +665,27 @@ export const getTwitterIntent = ({
     url
   )}&text=${encodeURIComponent(message)}`;
 };
+
+export function isAndroid(): boolean {
+  return (
+    typeof navigator !== "undefined" && /android/i.test(navigator.userAgent)
+  );
+}
+
+export function isSmallIOS(): boolean {
+  return (
+    typeof navigator !== "undefined" && /iPhone|iPod/.test(navigator.userAgent)
+  );
+}
+
+export function isLargeIOS(): boolean {
+  return typeof navigator !== "undefined" && /iPad/.test(navigator.userAgent);
+}
+
+export function isIOS(): boolean {
+  return isSmallIOS() || isLargeIOS();
+}
+
+export function isMobile(): boolean {
+  return isAndroid() || isSmallIOS();
+}

--- a/patches/@rainbow-me+rainbowkit+0.3.3.patch
+++ b/patches/@rainbow-me+rainbowkit+0.3.3.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@rainbow-me/rainbowkit/dist/chunk-S7EOD33A.js b/node_modules/@rainbow-me/rainbowkit/dist/chunk-S7EOD33A.js
+index 9dc7933..5d2b3ba 100644
+--- a/node_modules/@rainbow-me/rainbowkit/dist/chunk-S7EOD33A.js
++++ b/node_modules/@rainbow-me/rainbowkit/dist/chunk-S7EOD33A.js
+@@ -3083,7 +3083,7 @@ function WalletButton({ wallet }) {
+           const mobileUri = await getMobileUri();
+           setWalletConnectDeepLink({ mobileUri, name });
+           if (mobileUri.startsWith("http")) {
+-            window.open(mobileUri, "_blank", "noreferrer,noopener");
++            window.location.href = mobileUri;
+           } else {
+             window.location.href = mobileUri;
+           }


### PR DESCRIPTION
# Why

Sign-in flow in iOS browser acts weird because it involves a signature request to the wallet and includes redirection to wallet app but is not user-generated action so safari ends up opening it in the browser instead of the app.

Discussed here in more detail - https://github.com/rainbow-me/rainbowkit/discussions/536
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- Patch package in rainbowkit to fix twitter in-app browser blank. https://github.com/rainbow-me/rainbowkit/issues/524#issuecomment-1164795047
- Show signature button after the connection is established. Discussed here in possible solutions. https://github.com/rainbow-me/rainbowkit/discussions/536


https://user-images.githubusercontent.com/23293248/175610794-d93b4203-77ba-4707-9b16-df77450e2865.mp4



<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
Test sign-in on iOS/Android browser

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
