### PR TITLE
chore: update mobile check method usage

### DIFF
--- a/packages/app/components/claim/claim-form.tsx
+++ b/packages/app/components/claim/claim-form.tsx
@@ -29,7 +29,7 @@ import {
   formatAddressShort,
   getCreatorUsernameFromNFT,
   getTwitterIntent,
-  isMobile,
+  isMobileWeb,
 } from "app/utilities";
 
 export const ClaimForm = ({ edition }: { edition: CreatorEditionResponse }) => {
@@ -101,7 +101,7 @@ export const ClaimForm = ({ edition }: { edition: CreatorEditionResponse }) => {
 
     const isShareAPIAvailable = Platform.select({
       default: true,
-      web: typeof window !== "undefined" && !!navigator.share && isMobile(),
+      web: typeof window !== "undefined" && !!navigator.share && isMobileWeb(),
     });
 
     return (

--- a/packages/app/components/drop/drop-form.tsx
+++ b/packages/app/components/drop/drop-form.tsx
@@ -31,7 +31,7 @@ import { useNavigateToLogin } from "app/navigation/use-navigate-to";
 import {
   getTwitterIntent,
   getUserDisplayNameFromProfile,
-  isMobile,
+  isMobileWeb,
 } from "app/utilities";
 
 import { useFilePicker } from "design-system/file-picker";
@@ -161,7 +161,7 @@ export const DropForm = () => {
 
     const isShareAPIAvailable = Platform.select({
       default: true,
-      web: typeof window !== "undefined" && !!navigator.share && isMobile(),
+      web: typeof window !== "undefined" && !!navigator.share && isMobileWeb(),
     });
 
     return (


### PR DESCRIPTION
# Why

Drop and claim success modals are not showing because the mobile web checker methods were wrong.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
