### PR TITLE
fix: notifications error boundary

### DIFF
--- a/packages/app/components/header.tsx
+++ b/packages/app/components/header.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, Suspense } from "react";
 import {
   FlatList,
   ListRenderItemInfo,
@@ -18,9 +18,12 @@ import { ArrowLeft, Close, Plus, Search } from "@showtime-xyz/universal.icon";
 import { Input } from "@showtime-xyz/universal.input";
 import { PressableScale } from "@showtime-xyz/universal.pressable-scale";
 import { useRouter } from "@showtime-xyz/universal.router";
+import { Spinner } from "@showtime-xyz/universal.spinner/index.web";
 import { tw } from "@showtime-xyz/universal.tailwind";
+import { Text } from "@showtime-xyz/universal.text";
 import { View } from "@showtime-xyz/universal.view";
 
+import { ErrorBoundary } from "app/components/error-boundary";
 // import { NetworkButton } from "app/components/connect-button";
 import { HeaderDropdown } from "app/components/header-dropdown";
 import { Notifications } from "app/components/notifications";
@@ -184,7 +187,23 @@ const NotificationsInHeader = () => {
             default: {},
           })}
         >
-          <Notifications />
+          <ErrorBoundary
+            fallback={
+              <View tw="p-4">
+                <Text>Something went wrong</Text>
+              </View>
+            }
+          >
+            <Suspense
+              fallback={
+                <View tw="p-4">
+                  <Spinner />
+                </View>
+              }
+            >
+              <Notifications />
+            </Suspense>
+          </ErrorBoundary>
         </View>
       </Popover.Content>
     </Popover.Root>


### PR DESCRIPTION
# Why
notification can crash on some profile. It's using suspense but lacked error boundary.
Fix has been pushed on BE https://showtime-rq88331.slack.com/archives/C02QD3J7DJM/p1656411292367589
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
add suspense and error boundary to Notifications
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- tapping on notification should not lead to crash
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
