### PR TITLE
Use `--yes` to skip `npx` and `bumpp` confirmation

### DIFF
--- a/apps/expo/scripts/bump-version.mjs
+++ b/apps/expo/scripts/bump-version.mjs
@@ -43,7 +43,7 @@ const bumpVersion = async (versionType) => {
   const inCI = process.env.CI;
   if (inCI) {
     // --tag
-    const versionUpdateResponse = await $`npx bumpp ${versionType} --all --commit "release v" --push`
+    const versionUpdateResponse = await $`npx --yes bumpp ${versionType} --all --commit "release v" --push --yes`
     console.log(versionUpdateResponse)
     const newVersion = versionUpdateResponse.stdout.split("✔")[1].replace('Updated package.json to ', '').trim()
     console.log(`${chalk.green(newVersion)}`)

--- a/apps/expo/scripts/bump-version.mjs
+++ b/apps/expo/scripts/bump-version.mjs
@@ -42,8 +42,7 @@ const hasPlatform = (fileDiffList, reactNativeConfig, configuration) => {
 const bumpVersion = async (versionType) => {
   const inCI = process.env.CI;
   if (inCI) {
-    // --tag
-    const versionUpdateResponse = await $`npx --yes bumpp ${versionType} --all --commit "release v" --push --yes`
+    const versionUpdateResponse = await $`npx --yes bumpp ${versionType} --all --commit "release v" --tag "v" --push --yes`
     console.log(versionUpdateResponse)
     const newVersion = versionUpdateResponse.stdout.split("✔")[1].replace('Updated package.json to ', '').trim()
     console.log(`${chalk.green(newVersion)}`)


### PR DESCRIPTION
# Why

`bumpp` recently added a prompt which broke the script execution when running in a GitHub Action: https://github.com/antfu/bumpp/commit/75b62fe357430571f589ca3a8049d772b68d91da#diff-268436fa43c4021c68862c3a15870211137b411b24fee0849f0a16c1a030e517

They also enabled `--tag` by default so I decided to add it back