### PR TITLE
fix: hide drop option in profile

### DIFF
--- a/packages/app/components/card/card.tsx
+++ b/packages/app/components/card/card.tsx
@@ -93,9 +93,7 @@ function Card({ listId, nft, numColumns, tw, onPress, hrefProps = {} }: Props) {
           <View tw="flex-row items-center justify-between px-4">
             <Creator nft={nft} shouldShowDateCreated={false} />
             <Suspense fallback={<Skeleton width={24} height={24} />}>
-              {!isCreatorDrop ? (
-                <NFTDropdown nftId={nft.nft_id} listId={listId} />
-              ) : null}
+              <NFTDropdown nft={nft} listId={listId} />
             </Suspense>
           </View>
 

--- a/packages/app/components/swipe-list.tsx
+++ b/packages/app/components/swipe-list.tsx
@@ -353,9 +353,7 @@ export const FeedItem = memo(
                   {nft.token_name}
                 </Text>
                 <Suspense fallback={<Skeleton width={24} height={24} />}>
-                  {!isCreatorDrop ? (
-                    <NFTDropdown nftId={nft.nft_id} listId={listId} />
-                  ) : null}
+                  <NFTDropdown nft={nft} listId={listId} />
                 </Suspense>
               </View>
               <Description nft={nft} />
@@ -522,7 +520,7 @@ const NFTDetails = ({
             ) : null}
             <Suspense fallback={<Skeleton width={24} height={24} />}>
               <NFTDropdown
-                nftId={nft?.nft_id}
+                nft={nft}
                 shouldEnableSharing={false}
                 listId={listId}
               />

--- a/packages/app/hooks/use-nft-detail-by-token-id.ts
+++ b/packages/app/hooks/use-nft-detail-by-token-id.ts
@@ -6,8 +6,8 @@ import type { NFT } from "app/types";
 
 type UseNFTDetailByTokenIdParams = {
   contractAddress?: string;
-  tokenId: string;
-  chainName: string;
+  tokenId?: string;
+  chainName?: string;
 };
 
 type Data = {


### PR DESCRIPTION
# Why
user should be able to hide a drop after creation

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
Enable `hide` option in NFT dropdown and `hide` all other options for drop nfts 😛  
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
Go to profile and tap dropdown in NFT drop card. Hide option should be visible  
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
