### PR TITLE
Feature/show2 944 nft card sizing

### DIFF
--- a/packages/app/components/feed/feed.md.tsx
+++ b/packages/app/components/feed/feed.md.tsx
@@ -1,6 +1,8 @@
 import React, { Suspense, useCallback, useMemo } from "react";
 import { Platform, useWindowDimensions } from "react-native";
 
+import Sticky from "react-stickynode";
+
 import { useColorScheme } from "@showtime-xyz/universal.color-scheme";
 import { useIsDarkMode } from "@showtime-xyz/universal.hooks";
 import { SegmentedControl } from "@showtime-xyz/universal.segmented-control";
@@ -82,7 +84,9 @@ export const FeedList = () => {
             marginRight: LEFT_SLIDE_MARGIN,
           }}
         >
-          <SuggestedUsers />
+          <Sticky enabled>
+            <SuggestedUsers />
+          </Sticky>
         </View>
       </Hidden>
 
@@ -90,7 +94,7 @@ export const FeedList = () => {
         {isAuthenticated ? (
           <>
             <View
-              tw="mr-2 mb-2 w-[375px] self-end rounded-lg bg-white p-4 shadow-lg dark:bg-black"
+              tw="mr-2 mb-6 w-[375px] self-end rounded-lg bg-white p-4 shadow-lg dark:bg-black"
               style={{
                 // @ts-ignore
                 boxShadow: isDark ? CARD_DARK_SHADOW : undefined,
@@ -265,15 +269,15 @@ const SuggestedUsers = () => {
 
   return (
     <>
-      <Text tw="font-space-bold p-4 text-2xl text-black dark:text-white">
-        Home
-      </Text>
+      <View tw="h-16 justify-center">
+        <Text tw="font-space-bold text-2xl text-black dark:text-white">
+          Home
+        </Text>
+      </View>
       <View
         tw="mt-8 rounded-2xl bg-white dark:bg-black"
-        // @ts-ignore
         style={{
-          position: Platform.OS === "web" ? "sticky" : null,
-          top: 100,
+          // @ts-ignore
           boxShadow: isDark ? CARD_DARK_SHADOW : undefined,
         }}
       >

--- a/packages/app/screens/trending.md.tsx
+++ b/packages/app/screens/trending.md.tsx
@@ -113,7 +113,7 @@ const TrendingTabs = ({ selectedTab }: { selectedTab: "nft" | "creator" }) => {
         </Tabs.Trigger>
       </Tabs.List>
       <Tabs.Pager>
-        <View tw="flex-1" nativeID="12132323">
+        <View tw="flex-1">
           <Suspense fallback={null}>
             <List days={days} selectedTab={selectedTab} />
           </Suspense>
@@ -223,7 +223,7 @@ const NFTList = ({ days }: { days: any }) => {
                   key={`nft-list-card-${index}`}
                   nft={item}
                   tw={`w-[${containerWidth / numColumns - 30}px] h-[${
-                    containerWidth / numColumns + 205
+                    containerWidth / numColumns + 167
                   }px] mb-8`}
                 />
               );


### PR DESCRIPTION
# Why

- we removed the <Collection /> component, so the Trending NFT Card height is incorrect.
- `Suggested` sticky now is not working on the web.

# How
- minus the height of the `Collection` component.
- use `react-stickynode` lib to fix sticky.


# Test Plan

- check if the height of the Trending Card height is correct.
- check home `Suggested` sticky if it works.
