### PR TITLE
fix: update edition cache after claiming and notification error 

### DIFF
--- a/packages/app/components/card/card.tsx
+++ b/packages/app/components/card/card.tsx
@@ -71,8 +71,6 @@ function Card({ listId, nft, numColumns, tw, onPress, hrefProps = {} }: Props) {
     );
   }
 
-  const isCreatorDrop = !!nft.creator_airdrop_edition_address;
-
   return (
     <LikeContextProvider nft={nft} key={nft.nft_id}>
       <View

--- a/packages/app/components/claim/claim-form.tsx
+++ b/packages/app/components/claim/claim-form.tsx
@@ -33,7 +33,7 @@ import {
 } from "app/utilities";
 
 export const ClaimForm = ({ edition }: { edition: CreatorEditionResponse }) => {
-  const { state, claimNFT } = useClaimNFT();
+  const { state, claimNFT } = useClaimNFT(edition?.creator_airdrop_edition);
   const share = useShare();
   const router = useRouter();
   const { userAddress } = useCurrentUserAddress();

--- a/packages/app/components/header.tsx
+++ b/packages/app/components/header.tsx
@@ -190,7 +190,9 @@ const NotificationsInHeader = () => {
           <ErrorBoundary
             fallback={
               <View tw="p-4">
-                <Text>Something went wrong</Text>
+                <Text tw="text-black dark:text-white">
+                  Something went wrong
+                </Text>
               </View>
             }
           >

--- a/packages/app/components/notifications.tsx
+++ b/packages/app/components/notifications.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { FlatList } from "react-native";
 
-// import { formatDistanceToNowStrict } from "date-fns";
+import { Link } from "solito/link";
+
 import { Avatar } from "@showtime-xyz/universal.avatar";
 import { useColorScheme } from "@showtime-xyz/universal.color-scheme";
 import {
@@ -27,7 +28,7 @@ import { axios } from "app/lib/axios";
 import { CHAIN_IDENTIFIERS } from "app/lib/constants";
 import { useBottomTabBarHeight } from "app/lib/react-navigation/bottom-tabs";
 import { useScrollToTop } from "app/lib/react-navigation/native";
-import { Link, TextLink } from "app/navigation/link";
+import { TextLink } from "app/navigation/link";
 import { formatAddressShort } from "app/utilities";
 
 type NotificationCardProp = { notification: NotificationType; setUsers: any };
@@ -57,7 +58,7 @@ export const Notifications = () => {
         width="100%"
       />
     ) : (
-      <View tw={`h-${bottomBarHeight}px`} />
+      <View tw={`h-${bottomBarHeight ?? 0}px`} />
     );
   }, [isLoadingMore, bottomBarHeight, colorScheme]);
 
@@ -208,12 +209,11 @@ const NotificationDescription = ({
           {notification.type_name === "NFT_SALE" ? "bought " : null}
 
           {notification.nft_display_name ? (
-            <TextLink
-              tw="text-13 font-bold text-black dark:text-white"
-              href={notificationInfo.href}
-            >
-              {notification.nft_display_name}
-            </TextLink>
+            <Link href={notificationInfo.href}>
+              <Text tw="text-13 font-bold text-black dark:text-white">
+                {notification.nft_display_name}
+              </Text>
+            </Link>
           ) : null}
         </Text>
         <View tw="h-1" />


### PR DESCRIPTION
# Why
- Claim button is not disabled after successful claiming.
- Notification crash had one more issue apart from API failure. The `View cannot have Text RNW error` was being caught in `ErrorBoundary` leading to show `Something went wrong`. This error was happening due to the usage of `TextLink` as it uses `View` on web and mounting Text in it was causing error.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- Update swr cache
- Notification crash fix - Use Link from solito to pass href and a Text node for styling. 

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Test notifications and claim on web
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
