### PR TITLE
refactor: scroll to top issues

### DIFF
--- a/apps/next-react-native/src/styles/styles.css
+++ b/apps/next-react-native/src/styles/styles.css
@@ -53,10 +53,6 @@
     @apply bg-red-500 bg-opacity-20;
   }
 
-  [data-color-scheme="dark"] [role="menuitem"].danger:focus {
-    @apply outline-red-800;
-  }
-
   [role="menuitem"] > div > div:nth-child(1) {
     @apply flex-1 font-semibold text-gray-700;
   }

--- a/apps/next-react-native/src/styles/styles.css
+++ b/apps/next-react-native/src/styles/styles.css
@@ -38,6 +38,11 @@
 
   [data-color-scheme="dark"] [role="menuitem"]:hover {
     @apply bg-gray-100 bg-opacity-5;
+    outline: none;
+  }
+
+  [data-color-scheme="dark"] [role="menuitem"]:focus {
+    outline: initial;
   }
 
   [role="menuitem"].danger:hover {
@@ -46,6 +51,10 @@
 
   [data-color-scheme="dark"] [role="menuitem"].danger:hover {
     @apply bg-red-500 bg-opacity-20;
+  }
+
+  [data-color-scheme="dark"] [role="menuitem"].danger:focus {
+    @apply outline-red-800;
   }
 
   [role="menuitem"] > div > div:nth-child(1) {

--- a/packages/app/components/nft-dropdown.tsx
+++ b/packages/app/components/nft-dropdown.tsx
@@ -118,6 +118,10 @@ function NFTDropdown({ nftId, listId, shouldEnableSharing = true }: Props) {
       Platform.select({
         native: as,
         web: router.asPath.startsWith("/nft/") ? as : router.asPath,
+      }),
+      Platform.select({
+        native: {},
+        web: { scroll: false },
       })
     );
   };

--- a/packages/app/pages/profile/index.web.tsx
+++ b/packages/app/pages/profile/index.web.tsx
@@ -16,6 +16,7 @@ function ProfileRouter() {
       const as = router.asPath.replace("/", "/@");
       router.replace(href, as, {
         shallow: true,
+        scroll: false,
       });
     }
 

--- a/packages/app/pages/profile/index.web.tsx
+++ b/packages/app/pages/profile/index.web.tsx
@@ -28,6 +28,7 @@ function ProfileRouter() {
       const as = router.asPath.replace("/profile/", "/");
       router.replace(href, as, {
         shallow: true,
+        scroll: false,
       });
     }
   }, [router]);

--- a/packages/design-system/router/use-router.web.ts
+++ b/packages/design-system/router/use-router.web.ts
@@ -1,5 +1,12 @@
 import { useRouter as useNextRouter } from "next/router";
+import type { NextRouter } from "next/router";
 import { useRouter as useSolitoRouter } from "solito/router";
+
+interface TransitionOptions {
+  shallow?: boolean;
+  locale?: string | false;
+  scroll?: boolean;
+}
 
 export function useRouter() {
   const { replace, back, pathname, query, asPath } = useNextRouter();
@@ -10,6 +17,15 @@ export function useRouter() {
 
   return {
     ...solitoRouter,
+    push: (
+      url: Parameters<NextRouter["push"]>[0],
+      as?: Parameters<NextRouter["push"]>[1],
+      options?: TransitionOptions | undefined
+    ) =>
+      solitoRouter.push(url, as, {
+        ...options,
+        scroll: false,
+      }),
     pop: () => {
       if (modal) {
         // Sometimes we open a modal and we also update the URL to match the
@@ -21,7 +37,7 @@ export function useRouter() {
           ? asPath.split("/").slice(0, -1).join("/")
           : asPath;
 
-        replace(as, as, { shallow: true });
+        replace(as, as, { shallow: true, scroll: false });
       } else {
         back();
       }


### PR DESCRIPTION
# Why

Due to some default configurations of current router methods, we were scrolling the page to the top on page loads or URL changes. This was causing a bad experience. During this task I was able to disable scrolling for the following cases:

- Opening NFT dropdown modals (activity, details, etc)
- Opening comments modal
- Tabs (profile, feed)

> **Note**
> Still couldn't figure out why it's scrolling top when navigating the with browser's native buttons.
> Also header buttons are scrolling top but disabling these causes bad UX too, like the following case: if I scroll the page, then go to the profile, it starts from the scrolled position. **It shouldn't**, because I'm opening that page for the first time...
> I'll continue to investigate this.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Overrided. the router methods that inherited from Solito router and set the scroll to false. Needed to update some more methods too.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Testing modals and page navigations on web. 


<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
