### PR TITLE
refactor: cannot burn nft on web

### DIFF
--- a/packages/app/components/delete.tsx
+++ b/packages/app/components/delete.tsx
@@ -7,6 +7,7 @@ import { formatDistanceToNowStrict } from "date-fns";
 import { Controller, useForm } from "react-hook-form";
 import useSWR from "swr";
 
+import { useAlert } from "@showtime-xyz/universal.alert";
 import { Button } from "@showtime-xyz/universal.button";
 import { Fieldset } from "@showtime-xyz/universal.fieldset";
 import { PolygonScan } from "@showtime-xyz/universal.icon";
@@ -18,6 +19,7 @@ import { View } from "@showtime-xyz/universal.view";
 import { Owner } from "app/components/card";
 import { Media } from "app/components/media";
 import { UseBurnNFT, useBurnNFT } from "app/hooks/use-burn-nft";
+import { useCurrentUserAddress } from "app/hooks/use-current-user-address";
 import { useUser } from "app/hooks/use-user";
 import { axios } from "app/lib/axios";
 import { yup } from "app/lib/yup";
@@ -32,6 +34,8 @@ const defaultValues = {
 function Delete({ nft }: { nft: NFT }) {
   const { user } = useUser();
   const { startBurning, state } = useBurnNFT();
+  const { userAddress } = useCurrentUserAddress();
+  const { alert } = useAlert();
 
   const handleSubmitForm = (values: Omit<UseBurnNFT, "filePath">) => {
     startBurning({ ...values, tokenId: nft.token_id });
@@ -125,16 +129,27 @@ function Delete({ nft }: { nft: NFT }) {
     );
   }
 
+  const handleBurnNFT = () => {
+    if (nft?.creator_address !== userAddress) {
+      alert(
+        "Switch Wallet",
+        "Please log in with the wallet that created this NFT."
+      );
+    } else {
+      handleSubmit(handleSubmitForm);
+    }
+  };
+
   return (
     <View tw="flex-1">
       <CreateScrollView>
         <View tw="flex-1 px-3 py-4">
-          <View tw="mb-4">
+          <View tw="mb-4 px-2">
             <Text tw="text-xl font-bold text-black dark:text-white">
               Are you sure you want to delete this NFT?
             </Text>
             <View tw="h-4" />
-            <Text tw="text-sm text-black dark:text-white">
+            <Text tw="text-sm text-gray-600 dark:text-gray-400">
               This can't be undone and it will be sent to a burn address.
             </Text>
           </View>
@@ -146,7 +161,7 @@ function Delete({ nft }: { nft: NFT }) {
               <Text tw="font-space-bold mb-2 text-lg font-medium text-black dark:text-white">
                 {nft?.token_name}
               </Text>
-              <View tw="flex-row items-center">
+              <View tw="mt-2 flex-row items-center">
                 <PolygonScan
                   width={16}
                   height={16}
@@ -200,7 +215,7 @@ function Delete({ nft }: { nft: NFT }) {
       </CreateScrollView>
       <View tw="w-full p-4">
         <Button
-          onPress={handleSubmit(handleSubmitForm)}
+          onPress={handleBurnNFT}
           tw="h-12 rounded-full"
           disabled={!enable}
         >

--- a/packages/app/components/profile/profile-top.tsx
+++ b/packages/app/components/profile/profile-top.tsx
@@ -140,7 +140,8 @@ export const ProfileTop = ({
         Platform.select({
           native: `/profile/followers?profileId=${profileId}`,
           web: router.asPath,
-        })
+        }),
+        { scroll: false }
       ),
     [profileId, router]
   );
@@ -161,7 +162,10 @@ export const ProfileTop = ({
         Platform.select({
           native: `/profile/following?profileId=${profileId}`,
           web: router.asPath,
-        })
+        }),
+        {
+          scroll: false,
+        }
       ),
     [profileId, router]
   );


### PR DESCRIPTION
# Why

When we merge the accounts, we see the NFTs which created with the wallet we added. Then when trying to delete these NFTs, we got an error due to wrong ownership. Added an alert to make users log in with the wallet the NFT is created with.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Compared the nft creator address with the current user address and called alert if needed.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- Login
- Add wallet to account in settings
- Try to remove (burn) the NFT from secondary wallet.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
