### PR TITLE
Force a major version bump

### DIFF
--- a/.github/workflows/expo-production.yml
+++ b/.github/workflows/expo-production.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      versionType:
+        description: "Force a major version bump"
+        required: false
 
 concurrency:
   group: expo-production-${{ github.event_name }}-${{ github.ref }}
@@ -60,7 +64,7 @@ jobs:
       - name: Bump the version
         id: version
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: yarn bump-application-version
+        run: yarn bump-application-version ${{ github.event.inputs.versionType }}
 
       - name: Set up Expo
         uses: expo/expo-github-action@v7

--- a/apps/expo/scripts/bump-version.mjs
+++ b/apps/expo/scripts/bump-version.mjs
@@ -2,8 +2,6 @@
 import "zx/globals";
 const applicationPackage = require('../../../package.json')
 
-// TODO: Implement flags to force a patch, minor or major
-
 const hasPlatform = (fileDiffList, reactNativeConfig, configuration) => {
   const checkIos = configuration.ios
   const checkAndroid = configuration.android
@@ -57,6 +55,9 @@ const bumpVersion = async (versionType) => {
 
 try {
   $.verbose = false
+
+  // Retrieve the first arg when running `yarn bump-application-version major`
+  const versionType = process.argv[3] ?? "patch"
   const rootPath = "./apps/expo"
   const monorepoRootPath = "../.."
   const dirtyPath = "apps/expo/package.json";
@@ -79,8 +80,8 @@ try {
 
   const sameCommit = lastReleaseCommitId === currentCommitHeadId
 
-  console.log(`Current Commit ID: ${chalk.blue(currentCommitHeadId)}`)
-  console.log(`Last Release Commit ID: ${chalk.blue(lastReleaseCommitId)}`)
+  console.log(`Current Commit ID: ${chalk.blue(currentCommitHeadId)}\n`)
+  console.log(`Last Release Commit ID: ${chalk.blue(lastReleaseCommitId)}\n`)
 
   if (sameCommit) {
     console.log("No new commits since the last release, no action needed")
@@ -88,55 +89,61 @@ try {
     await $`exit 1`
   }
 
-  /**
-   * If file at path "apps/expo/package.json" has been modified within the commit range then it's possible
-   * a native module has been added. If file path was not modified then a safe assumption to bump as patch can be made. 
-   * 
-   * Has native changes -> Increment major version
-   * No native changes -> Increment patch version
-   * 
-   */
-  // Commit order matters for diff, previous then latest commit id
-  const fileNameDiffResponse = await $`git diff ${lastReleaseCommitId} ${currentCommitHeadId} --name-only`
-  const fileNameDiff = fileNameDiffResponse.stdout.split("\n");
-  const hasPossiblePackageChanges = Boolean(fileNameDiff.find((fileName) => fileName === dirtyPath))
+  // Force a major version bump
+  if (versionType === "major") {
+    console.log(`The application will update as a ${chalk.green("major")} from version ${chalk.green(currentApplicationVersion)}`)
+    await bumpVersion("major")
+  } else {
+    /**
+     * If file at path "apps/expo/package.json" has been modified within the commit range then it's possible
+     * a native module has been added. If file path was not modified then a safe assumption to bump as patch can be made. 
+     * 
+     * Has native changes -> Increment major version
+     * No native changes -> Increment patch version
+     * 
+     */
+    // Commit order matters for diff, previous then latest commit id
+    const fileNameDiffResponse = await $`git diff ${lastReleaseCommitId} ${currentCommitHeadId} --name-only`
+    const fileNameDiff = fileNameDiffResponse.stdout.split("\n");
+    const hasPossiblePackageChanges = Boolean(fileNameDiff.find((fileName) => fileName === dirtyPath))
 
-  if (hasPossiblePackageChanges) {
-    console.log(`Since last release there have ${chalk.green("been")} changes to ${chalk.green(dirtyPath)}`)
-    
-    // Returns the string diff of the package.json with just the lines added and removed 
-    const fileDiffResponse = await $`git diff ${lastReleaseCommitId} ${currentCommitHeadId} --unified=0 ${dirtyPath} | grep '^[+|-][^+|-]'`
-    // Sanitizes the diff string into an array of strings that are the "keys" for just added lines
-    const fileDiffSanitized = fileDiffResponse.stdout
-      .split('\n')
-      .filter((diff) => diff.charAt(0) === "+")
-      .map((diff) => diff.substring(diff.indexOf('"') + 1))
-      .map((diff) => diff.substring(0, diff.indexOf('"')))
+    if (hasPossiblePackageChanges) {
+      console.log(`Since last release there have ${chalk.green("been")} changes to ${chalk.green(dirtyPath)}`)
+      
+      // Returns the string diff of the package.json with just the lines added and removed 
+      const fileDiffResponse = await $`git diff ${lastReleaseCommitId} ${currentCommitHeadId} --unified=0 ${dirtyPath} | grep '^[+|-][^+|-]'`
+      // Sanitizes the diff string into an array of strings that are the "keys" for just added lines
+      const fileDiffSanitized = fileDiffResponse.stdout
+        .split('\n')
+        .filter((diff) => diff.charAt(0) === "+")
+        .map((diff) => diff.substring(diff.indexOf('"') + 1))
+        .map((diff) => diff.substring(0, diff.indexOf('"')))
 
-    console.log(`Keys added in ${dirtyPath} since last release are: \n${chalk.green(fileDiffSanitized.join('\n'))}`)
+      console.log(`Keys added in ${dirtyPath} since last release are: \n${chalk.green(fileDiffSanitized.join('\n'))}`)
 
-    // React Native config has to be invoked within the expo directory
-    cd(rootPath)
+      // React Native config has to be invoked within the expo directory
+      cd(rootPath)
 
-    const reactNativeConfigResponse = await $`${reactNativeConfigPath} config`
-    const reactNativeConfig = JSON.parse(reactNativeConfigResponse.stdout)
+      const reactNativeConfigResponse = await $`${reactNativeConfigPath} config`
+      const reactNativeConfig = JSON.parse(reactNativeConfigResponse.stdout)
 
-    const hasIos = hasPlatform(fileDiffSanitized, reactNativeConfig, { ios: true })  
-    const hasAndroid = hasPlatform(fileDiffSanitized, reactNativeConfig, { android: true })
+      const hasIos = hasPlatform(fileDiffSanitized, reactNativeConfig, { ios: true })  
+      const hasAndroid = hasPlatform(fileDiffSanitized, reactNativeConfig, { android: true })
 
-    cd(monorepoRootPath)
+      cd(monorepoRootPath)
 
-    if (hasIos || hasAndroid) {
-      console.log(`The application will update as a major from version ${chalk.green(currentApplicationVersion)}`)
-      await bumpVersion("major")
+      if (hasIos || hasAndroid) {
+        console.log(`The application will update as a ${chalk.green("major")} from version ${chalk.green(currentApplicationVersion)}`)
+        await bumpVersion("major")
+      } else {
+        console.log(`The application will update as a ${chalk.green("patch")} from version ${chalk.green(currentApplicationVersion)}`)
+        await bumpVersion("patch")
+      }
     } else {
-      console.log(`The application will update as a patch from version ${chalk.green(currentApplicationVersion)}`)
+      console.log(`The last release had no changes to ${dirtyPath}`)
+      console.log(`The application will update as a ${chalk.green("patch")} from version ${chalk.green(currentApplicationVersion)}`)
       await bumpVersion("patch")
     }
-  } else {
-    console.log(`The last release had no changes to ${dirtyPath}`)
-    console.log(`The application will update as a patch from version ${chalk.green(currentApplicationVersion)}`)
-    await bumpVersion("patch")
   }
 } catch (error) {
   console.error(`Error: ${error.stderr}`);


### PR DESCRIPTION
# Why

We want to be able to run `/promote frontend major` to force a major version bump that triggers a new build and submit to the app stores
