### PR TITLE
feat: profile default tab

### DIFF
--- a/packages/app/components/profile/index.tsx
+++ b/packages/app/components/profile/index.tsx
@@ -65,16 +65,16 @@ const Profile = ({ address }: { address: string | null }) => {
     if ((router.query as any)?.tab) return (router.query as any)?.tab;
     const createdIndex =
       data?.tabs.findIndex((item) => item.type === "created") ?? 0;
-    const onwedIndex =
+    const ownedIndex =
       data?.tabs.findIndex((item) => item.type === "owned") ?? 0;
-    if (onwedIndex === createdIndex || createdIndex === -1 || onwedIndex === -1)
+    if (ownedIndex === createdIndex || createdIndex === -1 || ownedIndex === -1)
       return 0;
     const createdCount = data?.tabs[createdIndex].displayed_count ?? 0;
-    const ownedCount = data?.tabs[onwedIndex].displayed_count ?? 0;
+    const ownedCount = data?.tabs[ownedIndex].displayed_count ?? 0;
     return createdCount > 0
       ? createdIndex
       : ownedCount > 0
-      ? onwedIndex
+      ? ownedIndex
       : createdIndex;
   }, [data?.tabs, router]);
 

--- a/packages/app/components/profile/index.tsx
+++ b/packages/app/components/profile/index.tsx
@@ -58,7 +58,7 @@ const Profile = ({ address }: { address: string | null }) => {
     profileId: profileData?.data?.profile.profile_id,
   });
   /**
-   * defalut tab index.
+   * default tab index.
    * if Created list = 0, it should go to the Owned section directly.
    * */
   const defaultIndex = useMemo(() => {

--- a/packages/app/hooks/use-tab-state.tsx
+++ b/packages/app/hooks/use-tab-state.tsx
@@ -6,14 +6,24 @@ import { Route } from "design-system/tab-view/src/types";
 
 const { useParam } = createParam();
 
+type TabState = {
+  params?: string;
+  defaultIndex?: number;
+};
 export function useTabState<PageRef, T = Route>(
   routesProps: T[],
-  params = "tab"
+  props?: TabState
 ) {
+  const defaultIndex = props?.defaultIndex ?? 0;
+  const defaultParam = props?.params ?? "tab";
   const [isRefreshing, setIsRefreshing] = useState(false);
-  const [index, setIndex] = useParam(params, {
-    parse: (v) => Number(v ?? 0),
-    initial: 0,
+  const [index, setIndex] = useParam(defaultParam, {
+    parse: (v) => {
+      // handling when params index is an illegal character, e.g.tab = 11,1a,abc
+      const value = Number(v ?? defaultIndex) ? Number(v ?? defaultIndex) : 0;
+      return value > routesProps.length || value < 0 ? 0 : value;
+    },
+    initial: defaultIndex,
   });
   const [routes, setRoute] = useState(routesProps);
   const tabRefs = useRef<PageRef[]>([]);


### PR DESCRIPTION
# Why

- If Created list counts = 0, it should go to the Owned tab directly. 
- If the parmas of the current tab exceeds the range, will get an empty list. 

# How

- do some judgment handing the default tab.
- when the params don't match, enter the default tab.


# Test Plan

check if the Profile tab load works.