### PR TITLE
fix: description multiline and quotes 

### DIFF
--- a/packages/app/components/drop/drop-form.tsx
+++ b/packages/app/components/drop/drop-form.tsx
@@ -341,6 +341,7 @@ export const DropForm = () => {
                         <Fieldset
                           tw="flex-1"
                           label="Description"
+                          multiline
                           placeholder="What is this NFT drop about?"
                           onBlur={onBlur}
                           helperText="You will not be able to edit this after the drop is created"

--- a/packages/app/hooks/use-drop-nft.ts
+++ b/packages/app/hooks/use-drop-nft.ts
@@ -183,12 +183,24 @@ export const useDropNFT = () => {
         dispatch({ type: "loading" });
 
         const ipfsHash = await uploadMedia(params.file);
-        Logger.log("ipfs hash ", ipfsHash, params);
+
+        const escapedTitle = JSON.stringify(params.title).slice(1, -1);
+        const escapedDescription = JSON.stringify(params.description).slice(
+          1,
+          -1
+        );
+
+        Logger.log("ipfs hash ", {
+          ipfsHash,
+          params,
+          escapedTitle,
+          escapedDescription,
+        });
 
         const callData = targetInterface.encodeFunctionData("createEdition", [
-          params.title,
+          escapedTitle,
           "SHOWTIME",
-          params.description,
+          escapedDescription,
           "", // animationUrl
           "0x0000000000000000000000000000000000000000000000000000000000000000", // animationHash
           "ipfs://" + ipfsHash, // imageUrl


### PR DESCRIPTION
# Why
if we have quotes or new line in description, collection doesn't appear on OpenSea. 
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- Hack - pass JSON escaped strings to contract. A clean fix would have to be done at the contract level.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- test creating collection with multiline description or quotes
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
