### PR TITLE
Feature/show2 951 hide follow button when the account is

### DIFF
--- a/packages/app/components/follow-button.tsx
+++ b/packages/app/components/follow-button.tsx
@@ -14,7 +14,8 @@ type ToggleFollowParams = Pick<ButtonProps, "size"> & {
 
 export const FollowButton = memo<ToggleFollowParams>(
   ({ isFollowing, profileId, name, ...rest }) => {
-    const { unfollow, follow } = useMyInfo();
+    const { unfollow, follow, data } = useMyInfo();
+
     const Alert = useAlert();
 
     const toggleFollow = useCallback(() => {
@@ -36,7 +37,7 @@ export const FollowButton = memo<ToggleFollowParams>(
         follow(profileId);
       }
     }, [Alert, follow, unfollow, isFollowing, profileId, name]);
-
+    if (data?.data?.profile?.profile_id === profileId) return null;
     return (
       <Button
         variant={isFollowing ? "tertiary" : "primary"}

--- a/packages/design-system/tab-view/src/index.web.tsx
+++ b/packages/design-system/tab-view/src/index.web.tsx
@@ -129,10 +129,13 @@ function CollapsibleHeaderTabView<T extends Route>(
       </View>
     );
   };
-  const _renderSceneHeader = (children: React.ReactElement) => {
+  const _renderSceneHeader = (
+    children: React.ReactElement,
+    props: SceneRendererProps & { route: T }
+  ) => {
     return (
-      <View style={{ flex: 1 }}>
-        {renderSceneHeader?.(children.props as T)}
+      <View style={styles.full}>
+        {renderSceneHeader?.(props.route)}
         {children}
       </View>
     );
@@ -159,7 +162,7 @@ function CollapsibleHeaderTabView<T extends Route>(
         scrollStickyHeaderHeight: 0,
       }}
     >
-      <View ref={containeRef} style={styles.container}>
+      <View ref={containeRef} style={styles.full}>
         {renderScrollHeader && renderScrollHeader()}
 
         {navigationState.routes.length === 0 && emptyBodyComponent ? (
@@ -176,7 +179,7 @@ function CollapsibleHeaderTabView<T extends Route>(
 }
 
 const styles = StyleSheet.create({
-  container: {
+  full: {
     flex: 1,
   },
   tabbarStyle: {


### PR DESCRIPTION
# Why

- `Follow` button always show even if your current account is yourself.
- `SegmentedControl` default index incorrect on mobile web.

# How

- hide `Follow` button when the account is yourself.
- fixed `TabView` 's renderSceneHeader props.

# Test Plan

check if displayed normally when  `Follow` button is removed.
