### PR TITLE
fix: handle disconnected wallet

### DIFF
--- a/packages/app/hooks/use-current-user-address.ts
+++ b/packages/app/hooks/use-current-user-address.ts
@@ -1,26 +1,25 @@
-import { useEffect, useCallback, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { useWallet } from "app/hooks/auth/use-wallet";
-import { useUser } from "app/hooks/use-user";
+import { useWeb3 } from "app/hooks/use-web3";
 
 function useCurrentUserAddress() {
-  const { user } = useUser();
   const [userAddress, setUserAddress] = useState("");
   const { address } = useWallet();
-
-  const getCurrentUserAddress = useCallback(async () => {
-    if (address) {
-      setUserAddress(address);
-    } else if (user?.data && user?.data.profile.wallet_addresses_v2[0]) {
-      setUserAddress(user.data.profile.wallet_addresses_v2[0].address);
-    } else {
-      setUserAddress("");
-    }
-  }, [user, address]);
+  const { web3 } = useWeb3();
 
   useEffect(() => {
-    getCurrentUserAddress();
-  }, [getCurrentUserAddress]);
+    (async function fetchUserAddress() {
+      if (address) {
+        setUserAddress(address);
+      } else if (web3) {
+        const userAddress = await web3.getSigner().getAddress();
+        setUserAddress(userAddress);
+      } else {
+        setUserAddress("");
+      }
+    })();
+  }, [web3, address]);
 
   return { userAddress };
 }


### PR DESCRIPTION
# Why
Sometimes if a wallet is disconnected but user is logged in, it still won't show it's disconnected during claim/drop.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
Use connected wallet address instead from our API.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
Test drop/claim

# Aside
Need to prioritise cleaning up web3 hooks. Right now it has some files for different platforms and it's making it hard to debug.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
