### PR TITLE
fix: drop/claim username in twitter intent

### DIFF
--- a/packages/app/components/claim/claim-form.tsx
+++ b/packages/app/components/claim/claim-form.tsx
@@ -12,7 +12,7 @@ import { View } from "@showtime-xyz/universal.view";
 import { ConnectButton } from "app/components/connect-button";
 import { Media } from "app/components/media";
 import { PolygonScanButton } from "app/components/polygon-scan-button";
-import { useMyInfo } from "app/hooks/api-hooks";
+import { useMyInfo, useUserProfile } from "app/hooks/api-hooks";
 import { useWallet } from "app/hooks/auth/use-wallet";
 import { useClaimNFT } from "app/hooks/use-claim-nft";
 import {
@@ -29,6 +29,7 @@ import {
   formatAddressShort,
   getCreatorUsernameFromNFT,
   getTwitterIntent,
+  getTwitterIntentUsername,
   isMobileWeb,
 } from "app/utilities";
 
@@ -46,6 +47,11 @@ export const ClaimForm = ({ edition }: { edition: CreatorEditionResponse }) => {
     tokenId: "0",
     contractAddress: edition.creator_airdrop_edition.contract_address,
   });
+
+  const { data: creatorProfile } = useUserProfile({
+    address: nft?.data.item.creator_address,
+  });
+
   const { follow } = useMyInfo();
   const { mutate } = useCreatorCollectionDetail(
     nft?.data.item.creator_airdrop_edition_address
@@ -125,8 +131,8 @@ export const ClaimForm = ({ edition }: { edition: CreatorEditionResponse }) => {
                   url: claimUrl,
                   message: `I just claimed a free NFT "${
                     nft?.data.item.token_name
-                  }" by ${getCreatorUsernameFromNFT(
-                    nft?.data.item
+                  }" by ${getTwitterIntentUsername(
+                    creatorProfile?.data?.profile
                   )} on @Showtime_xyz! 🎁🔗\n\nClaim yours for free here:`,
                 })
               );

--- a/packages/app/components/drop/drop-form.tsx
+++ b/packages/app/components/drop/drop-form.tsx
@@ -30,7 +30,7 @@ import { yup } from "app/lib/yup";
 import { useNavigateToLogin } from "app/navigation/use-navigate-to";
 import {
   getTwitterIntent,
-  getUserDisplayNameFromProfile,
+  getTwitterIntentUsername,
   isMobileWeb,
 } from "app/utilities";
 
@@ -186,8 +186,8 @@ export const DropForm = () => {
                   url: claimUrl,
                   message: `I just dropped a free NFT "${
                     state.edition?.name
-                  }" by ${getUserDisplayNameFromProfile(
-                    user.user
+                  }" by ${getTwitterIntentUsername(
+                    user?.user?.data?.profile
                   )} on @Showtime_xyz! 🎁🔗\n\nClaim yours for free here:`,
                 })
               );

--- a/packages/app/hooks/api-hooks.ts
+++ b/packages/app/hooks/api-hooks.ts
@@ -137,7 +137,11 @@ export const useTrendingNFTS = ({ days }: { days: number }) => {
 };
 
 export const USER_PROFILE_KEY = "/v4/profile_server/";
-export const useUserProfile = ({ address }: { address: string | null }) => {
+export const useUserProfile = ({
+  address,
+}: {
+  address: string | null | undefined;
+}) => {
   const { data, error, mutate, isLoading } = useSWR<{ data: UserProfile }>(
     address ? USER_PROFILE_KEY + address : null,
     fetcher

--- a/packages/app/utilities.ts
+++ b/packages/app/utilities.ts
@@ -11,13 +11,7 @@ import { axios as showtimeAPIAxios } from "app/lib/axios";
 import { BYPASS_EMAIL, LIST_CURRENCIES } from "app/lib/constants";
 import { magic, Magic } from "app/lib/magic";
 
-import {
-  NFT,
-  OwnersListOwner,
-  Profile,
-  UserType,
-  WalletAddressesV2,
-} from "./types";
+import { NFT, OwnersListOwner, Profile, WalletAddressesV2 } from "./types";
 
 export const formatAddressShort = (address?: string) => {
   if (!address) return null;
@@ -629,16 +623,22 @@ export const getCreatorUsernameFromNFT = (nft?: NFT) => {
     : formatAddressShort(nft.creator_address);
 };
 
-export const getUserDisplayNameFromProfile = (user?: UserType) => {
-  if (!user) return "";
+export const getTwitterIntentUsername = (profile?: Profile) => {
+  if (!profile) return "";
 
-  return user.data.profile.username
-    ? `@${user.data.profile.username}`
-    : user.data.profile.name
-    ? user.data.profile.name
-    : user.data.profile.wallet_addresses_v2?.[0]?.ens_domain
-    ? user.data.profile.wallet_addresses_v2[0].ens_domain
-    : formatAddressShort(user.data.profile.wallet_addresses_v2?.[0]?.address);
+  const twitterUsername = profile.links.find(
+    (l) => l.type__name.toLowerCase() === "twitter"
+  )?.user_input;
+
+  if (twitterUsername) {
+    return `@${twitterUsername}`;
+  }
+
+  return profile.name
+    ? profile.name
+    : profile.wallet_addresses_v2?.[0]?.ens_domain
+    ? profile.wallet_addresses_v2[0].ens_domain
+    : formatAddressShort(profile.wallet_addresses_v2?.[0]?.address);
 };
 
 export const getDomainName = (link?: string) => {

--- a/packages/app/utilities.ts
+++ b/packages/app/utilities.ts
@@ -634,7 +634,9 @@ export const getTwitterIntentUsername = (profile?: Profile) => {
     return `@${twitterUsername}`;
   }
 
-  return profile.name
+  return profile.username
+    ? profile.username
+    : profile.name
     ? profile.name
     : profile.wallet_addresses_v2?.[0]?.ens_domain
     ? profile.wallet_addresses_v2[0].ens_domain


### PR DESCRIPTION
# Why
twitter intent shows wrong username.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
prepend `@` only when twitter link is available.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
test sharing drop/claim on twitter
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
