### PR TITLE
fix: trending nft tap leads to open previous nft

### DIFF
--- a/packages/app/components/trending/nfts-list.tsx
+++ b/packages/app/components/trending/nfts-list.tsx
@@ -53,10 +53,7 @@ export const NFTSList = forwardRef<TrendingTabListRef, TrendingTabListProps>(
             numColumns={numColumns}
             onPress={() =>
               router.push(
-                `/list?initialScrollIndex=${
-                  // index - 1 because header takes the initial index!
-                  index - 1
-                }&days=${days}&type=trendingNFTs`
+                `/list?initialScrollIndex=${index}&days=${days}&type=trendingNFTs`
               )
             }
           />


### PR DESCRIPTION
# Why
 trending nft tap leads to open previous nft
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
correction in calculating index
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
tap an NFT from trending NFTs
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
