### PR TITLE
fix: TabView init error

### DIFF
--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -179,7 +179,7 @@
     "react-native-localhost": "^1.0.0",
     "react-native-mmkv": "2.3.3",
     "react-native-os": "^1.0.1",
-    "react-native-pager-view": "^5.4.24",
+    "react-native-pager-view": "^5.4.25",
     "react-native-popper": "^0.3.2",
     "react-native-quick-base64": "^2.0.2",
     "react-native-random-values-jsi-helper": "^1.0.3",

--- a/apps/storybook-react-native/package.json
+++ b/apps/storybook-react-native/package.json
@@ -67,7 +67,7 @@
     "react-native-gesture-handler": "2.5.0",
     "react-native-ios-context-menu": "1.3.0",
     "react-native-mmkv": "^2.3.3",
-    "react-native-pager-view": "^5.4.24",
+    "react-native-pager-view": "^5.4.25",
     "react-native-quick-base64": "^2.0.2",
     "react-native-random-values-jsi-helper": "^1.0.3",
     "react-native-randombytes": "^3.6.1",

--- a/packages/app/hooks/use-tab-state.tsx
+++ b/packages/app/hooks/use-tab-state.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef } from "react";
+import { Platform } from "react-native";
 
 import { createParam } from "app/navigation/use-param";
 
@@ -15,16 +16,25 @@ export function useTabState<PageRef, T = Route>(
   props?: TabState
 ) {
   const defaultIndex = props?.defaultIndex ?? 0;
+
   const defaultParam = props?.params ?? "tab";
   const [isRefreshing, setIsRefreshing] = useState(false);
-  const [index, setIndex] = useParam(defaultParam, {
-    parse: (v) => {
-      // handling when params index is an illegal character, e.g.tab = 11,1a,abc
-      const value = Number(v ?? defaultIndex) ? Number(v ?? defaultIndex) : 0;
-      return value > routesProps.length || value < 0 ? 0 : value;
-    },
-    initial: defaultIndex,
-  });
+  // Todo: Native use useParam hooks.
+  const [index, setIndex] =
+    Platform.OS === "web"
+      ? // eslint-disable-next-line react-hooks/rules-of-hooks
+        useParam(defaultParam, {
+          parse: (v) => {
+            // handling when params index is an illegal character, e.g.tab = 11,1a,abc
+            const value = Number(v ?? defaultIndex)
+              ? Number(v ?? defaultIndex)
+              : 0;
+            return value > routesProps.length || value < 0 ? 0 : value;
+          },
+          initial: defaultIndex,
+        })
+      : // eslint-disable-next-line react-hooks/rules-of-hooks
+        useState(defaultIndex);
   const [routes, setRoute] = useState(routesProps);
   const tabRefs = useRef<PageRef[]>([]);
   const setTabRefs = (ref: PageRef) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7815,7 +7815,7 @@ __metadata:
     react-native-localhost: ^1.0.0
     react-native-mmkv: 2.3.3
     react-native-os: ^1.0.1
-    react-native-pager-view: ^5.4.24
+    react-native-pager-view: ^5.4.25
     react-native-popper: ^0.3.2
     react-native-quick-base64: ^2.0.2
     react-native-random-values-jsi-helper: ^1.0.3
@@ -7971,7 +7971,7 @@ __metadata:
     react-native-gesture-handler: 2.5.0
     react-native-ios-context-menu: 1.3.0
     react-native-mmkv: ^2.3.3
-    react-native-pager-view: ^5.4.24
+    react-native-pager-view: ^5.4.25
     react-native-quick-base64: ^2.0.2
     react-native-random-values-jsi-helper: ^1.0.3
     react-native-randombytes: ^3.6.1
@@ -29800,13 +29800,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-pager-view@npm:^5.4.24":
-  version: 5.4.24
-  resolution: "react-native-pager-view@npm:5.4.24"
+"react-native-pager-view@npm:^5.4.25":
+  version: 5.4.25
+  resolution: "react-native-pager-view@npm:5.4.25"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 5f296492ce7f386e5d4fabac4e85e0bc1cea39fe9ac070d1879cc0444f174014e1add708356b6c53a58b2b9bed9b1c1dff1799a8a3ba10b49b2efc2e1fdbda8a
+  checksum: 2b5c8667b40897001d30ff2b19545cac34637c9dfa1ff54cad8e8ddedc3b3437a45af951b19f8e3c6a114cb6fdcff68f4ce18cf46752ed5fefde42d4e0461578
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Why

TabView init error, just quickly fix patch, not sure useParam get `undefined` on Native, will dig it later.
# How

use `useState` replace to `useParam` which will be fixed later.


# Test Plan

check  Profile/Trending/Setting is working.
