### PR TITLE
Bring back backdrop filter to the dropdowns on web

### DIFF
--- a/apps/next/src/styles/styles.css
+++ b/apps/next/src/styles/styles.css
@@ -15,6 +15,7 @@
   a {
     @apply text-inherit no-underline;
   }
+
   button:focus {
     @apply outline-none;
   }
@@ -40,22 +41,22 @@
   }
 
   [role="menuitem"]:hover,
-  [role="menuitem"]:focus {
-    @apply cursor-pointer rounded-lg bg-gray-900 bg-opacity-5;
+  [role="menuitem"]:focus-within {
+    @apply outline-none cursor-pointer rounded-lg bg-gray-900 bg-opacity-5;
   }
 
   [data-color-scheme="dark"] [role="menuitem"]:hover,
-  [data-color-scheme="dark"] [role="menuitem"]:focus {
+  [data-color-scheme="dark"] [role="menuitem"]:focus-within {
     @apply bg-gray-100 bg-opacity-5;
   }
 
   [role="menuitem"].danger:hover,
-  [role="menuitem"].danger:focus {
+  [role="menuitem"].danger:focus-within {
     @apply bg-red-500 bg-opacity-20;
   }
 
   [data-color-scheme="dark"] [role="menuitem"].danger:hover,
-  [data-color-scheme="dark"] [role="menuitem"].danger:focus {
+  [data-color-scheme="dark"] [role="menuitem"].danger:focus-within {
     @apply bg-red-500 bg-opacity-20;
   }
 
@@ -69,8 +70,8 @@
 
   [role="menuitem"].danger:hover > div > div:nth-child(3),
   [role="menuitem"].danger:hover svg > *,
-  [role="menuitem"].danger:focus > div > div:nth-child(3),
-  [role="menuitem"].danger:focus svg > * {
+  [role="menuitem"].danger:focus-within > div > div:nth-child(3),
+  [role="menuitem"].danger:focus-within svg > * {
     @apply text-red-500;
   }
 }

--- a/apps/next/src/styles/styles.css
+++ b/apps/next/src/styles/styles.css
@@ -19,8 +19,12 @@
     @apply outline-none;
   }
 
+  [data-radix-popper-content-wrapper] {
+    @apply rounded-2xl backdrop-filter backdrop-blur-md backdrop-saturate-150;
+  }
+
   [role="menu"] > div:nth-child(1) {
-    @apply w-60 rounded-2xl bg-white bg-opacity-80 p-2 shadow backdrop-blur-md backdrop-saturate-150;
+    @apply w-60 rounded-2xl bg-white bg-opacity-80 p-2 shadow;
   }
 
   [data-color-scheme="dark"] [role="menu"] > div:nth-child(1) {


### PR DESCRIPTION
# Why

We lost the backdrop filter on web

# How

The backdrop css styles were there but they were added to the wrong container, instead we should have added it to the [role="menu"] container (the dropdown menu main wrapper)

# Test Plan

Light | Dark
-- | -- 
<img width="394" alt="image" src="https://user-images.githubusercontent.com/2805320/178720214-d9cdbb8f-324b-4e37-9ae6-50a8366815b3.png"> | <img width="411" alt="image" src="https://user-images.githubusercontent.com/2805320/178720249-fdf73e04-d069-4072-bc15-8698af63995c.png">

