### PR TITLE
Feature/show2 999 trending list is obscured by bottomtab

### DIFF
--- a/packages/app/components/footer/list-footer.tsx
+++ b/packages/app/components/footer/list-footer.tsx
@@ -3,7 +3,7 @@ import { memo } from "react";
 import { Spinner } from "@showtime-xyz/universal.spinner";
 import { View } from "@showtime-xyz/universal.view";
 
-import { useBottomTabBarHeight } from "app/lib/react-navigation/bottom-tabs";
+import { usePlatformBottomHeight } from "app/hooks/use-platform-bottom-height";
 
 const LIST_FOOTER_HEIGHT = 80;
 type ListFooterProps = {
@@ -14,7 +14,7 @@ export const ListFooter = memo<ListFooterProps>(function ListFooter({
   isLoading,
   height = LIST_FOOTER_HEIGHT,
 }) {
-  const tabBarHeight = useBottomTabBarHeight();
+  const tabBarHeight = usePlatformBottomHeight();
 
   if (isLoading) {
     return (

--- a/packages/app/navigation/tab-bar-icons.tsx
+++ b/packages/app/navigation/tab-bar-icons.tsx
@@ -194,7 +194,7 @@ export const NotificationsTabBarIcon = ({
       ) : (
         <Bell style={tw.style("z-1")} width={24} height={24} color={color} />
       )}
-      <ErrorBoundary>
+      <ErrorBoundary renderFallback={() => <></>}>
         <Suspense fallback={null}>
           <UnreadNotificationIndicator />
         </Suspense>


### PR DESCRIPTION
# Why

- Trending list is obscured by BottomTab 
- notification bug affects icons


# How

- use `useBottomTabBarHeight`

# Test Plan

