### PR TITLE
fix: report NFT

### DIFF
--- a/packages/app/components/nft-dropdown.tsx
+++ b/packages/app/components/nft-dropdown.tsx
@@ -254,7 +254,7 @@ function NFTDropdown({
         {!hasOwnership && (
           <DropdownMenuItem
             onSelect={async () => {
-              await report({ nftId: nft?.token_id });
+              await report({ nftId: nft?.nft_id });
               router.pop();
             }}
             key="report"

--- a/packages/app/hooks/use-report.ts
+++ b/packages/app/hooks/use-report.ts
@@ -8,7 +8,7 @@ import { axios } from "app/lib/axios";
 
 type Report = {
   userId?: number;
-  nftId?: string;
+  nftId?: number;
   activityId?: number;
   description?: string;
 };


### PR DESCRIPTION
# Why

report the NFT should be use `nft.nft_id` not `nft.token_id`

# How

use `nft.nft_id` replace with  `nft.token_id`

# Test Plan

check if the report NFT works. 