### PR TITLE
fix: video bg-blur not working

### DIFF
--- a/packages/app/components/feed-item/index.tsx
+++ b/packages/app/components/feed-item/index.tsx
@@ -102,7 +102,13 @@ export const FeedItem = memo<FeedItemProps>(function FeedItem({
                 source={{
                   uri: getMediaUrl({ nft, stillPreview: true }),
                 }}
-              />
+              >
+                <BlurView
+                  tint={tint}
+                  intensity={100}
+                  style={tw.style("h-full w-full")}
+                />
+              </Image>
             )}
           </View>
         )}


### PR DESCRIPTION
# Why

video background blur not working on native because the video preview doesn't have the `blurhash` field.

# How

we use `BlurView` to replace it when `blurhash` is null.

# Test Plan

check if the feed video looks good!
