### PR TITLE
Show `Hidden` tab on profile + Unhide NFT

### DIFF
--- a/packages/app/components/card/card.tsx
+++ b/packages/app/components/card/card.tsx
@@ -28,7 +28,7 @@ type Props = {
   nft: NFT & { loading?: boolean };
   numColumns: number;
   onPress: () => void;
-  listId: number | undefined;
+  listId?: string;
   tw?: string;
   variant?: "nft" | "activity" | "market";
   hrefProps?: UrlObject;

--- a/packages/app/components/feed-item/details.tsx
+++ b/packages/app/components/feed-item/details.tsx
@@ -19,12 +19,10 @@ import type { NFT } from "app/types";
 
 export const NFTDetails = ({
   nft,
-  listId,
   edition,
 }: {
   nft: NFT;
   edition?: CreatorEditionResponse;
-  listId?: number;
 }) => {
   const { shareNFT } = useShareNFT();
   const isCreatorDrop = !!nft.creator_airdrop_edition_address;
@@ -65,7 +63,7 @@ export const NFTDetails = ({
             <View tw="w-8" />
 
             <Suspense fallback={<Skeleton width={24} height={24} />}>
-              <NFTDropdown nft={nft} listId={listId} />
+              <NFTDropdown nft={nft} />
             </Suspense>
           </View>
         </View>

--- a/packages/app/components/feed-item/feed-item.md.tsx
+++ b/packages/app/components/feed-item/feed-item.md.tsx
@@ -50,7 +50,6 @@ const { useParam } = createParam<Query>();
 export const FeedItemMD = memo<FeedItemProps>(function FeedItemMD({
   nft,
   itemHeight,
-  listId,
 }) {
   const router = useRouter();
   const isDark = useIsDarkMode();
@@ -160,7 +159,6 @@ export const FeedItemMD = memo<FeedItemProps>(function FeedItemMD({
                     size: "regular",
                   }}
                   nft={nft}
-                  listId={listId}
                 />
               </Suspense>
             </View>

--- a/packages/app/components/feed-item/index.tsx
+++ b/packages/app/components/feed-item/index.tsx
@@ -39,8 +39,8 @@ export type FeedItemProps = {
   bottomPadding?: number;
   bottomMargin?: number;
   itemHeight: number;
-  listId?: number;
 };
+
 export const FeedItem = memo<FeedItemProps>(function FeedItem({
   nft,
   bottomPadding = 0,

--- a/packages/app/components/nft-dropdown.tsx
+++ b/packages/app/components/nft-dropdown.tsx
@@ -59,22 +59,27 @@ const MenuItemIcon = ({ Icon, ...rest }: { Icon: ComponentType<SvgProps> }) => {
 
 type Props = {
   nft?: NFT;
-  listId?: number | undefined;
   shouldEnableSharing?: boolean;
   btnProps?: ButtonProps;
+  listId?: string;
 };
 
 function NFTDropdown({
   nft: propNFT,
-  listId,
   shouldEnableSharing = true,
   btnProps,
+  listId,
 }: Props) {
   //#region hooks
   const userId = useCurrentUserId();
   const { user, isAuthenticated } = useUser();
   const { report } = useReport();
-  const { unfollow, isFollowing, hide: hideNFT } = useMyInfo();
+  const {
+    unfollow,
+    isFollowing,
+    hide: hideNFT,
+    unhide: unhideNFT,
+  } = useMyInfo();
   const { getIsBlocked, toggleBlock } = useBlock();
   const router = useRouter();
   // const { refresh } = useFeed("");
@@ -168,15 +173,27 @@ function NFTDropdown({
       </DropdownMenuTrigger>
 
       <DropdownMenuContent loop>
-        {hasOwnership && listId ? (
+        {hasOwnership && listId !== "hidden" ? (
           <DropdownMenuItem
             onSelect={() => {
-              hideNFT(nft?.nft_id, listId);
+              hideNFT(nft?.nft_id);
             }}
             key="hide"
           >
             <MenuItemIcon Icon={EyeOff} />
             <DropdownMenuItemTitle>Hide</DropdownMenuItemTitle>
+          </DropdownMenuItem>
+        ) : null}
+
+        {hasOwnership && listId === "hidden" ? (
+          <DropdownMenuItem
+            onSelect={() => {
+              unhideNFT(nft?.nft_id);
+            }}
+            key="unhide"
+          >
+            <MenuItemIcon Icon={EyeOff} />
+            <DropdownMenuItemTitle>Unhide</DropdownMenuItemTitle>
           </DropdownMenuItem>
         ) : null}
 

--- a/packages/app/hooks/api-hooks.ts
+++ b/packages/app/hooks/api-hooks.ts
@@ -413,18 +413,46 @@ export const useMyInfo = () => {
   );
 
   const hide = useCallback(
-    async (nftId: number | undefined, listId: number | undefined) => {
+    async (nftId: number | undefined) => {
       if (!accessToken) {
         navigateToLogin();
         return false;
       }
 
-      if (data && nftId && listId) {
+      if (data && nftId) {
         try {
           await axios({
-            url: `/v1/hide_nft/${nftId}/${listId}`,
+            url: `/v2/profile-tabs/hide-nft`,
             method: "POST",
-            data: {},
+            data: {
+              nft_id: nftId,
+            },
+          });
+
+          return true;
+        } catch (error) {
+          return false;
+        }
+      }
+    },
+    [data, accessToken, navigateToLogin]
+  );
+
+  const unhide = useCallback(
+    async (nftId: number | undefined) => {
+      if (!accessToken) {
+        navigateToLogin();
+        return false;
+      }
+
+      if (data && nftId) {
+        try {
+          await axios({
+            url: `/v2/profile-tabs/unhide-nft`,
+            method: "POST",
+            data: {
+              nft_id: nftId,
+            },
           });
 
           return true;
@@ -491,5 +519,6 @@ export const useMyInfo = () => {
     isLiked,
     refetchMyInfo,
     hide,
+    unhide,
   };
 };

--- a/packages/app/hooks/api-hooks.ts
+++ b/packages/app/hooks/api-hooks.ts
@@ -422,11 +422,9 @@ export const useMyInfo = () => {
       if (data && nftId) {
         try {
           await axios({
-            url: `/v2/profile-tabs/hide-nft`,
+            url: `/v2/profile-tabs/hide-nft/${nftId}`,
             method: "POST",
-            data: {
-              nft_id: nftId,
-            },
+            data: {},
           });
 
           return true;
@@ -448,11 +446,9 @@ export const useMyInfo = () => {
       if (data && nftId) {
         try {
           await axios({
-            url: `/v2/profile-tabs/unhide-nft`,
+            url: `/v2/profile-tabs/unhide-nft/${nftId}`,
             method: "POST",
-            data: {
-              nft_id: nftId,
-            },
+            data: {},
           });
 
           return true;


### PR DESCRIPTION
# Why

We are now displaying a `Hidden` tab on your own profile. This PR enables users to `Unhide` their NFTs

# How

Displayed `Unhide` button in dropdown menu instead of `Hide` when displaying a NFT from the `Hidden` tab

# Test Plan

Run the app, go to your profile, hide some NFTs, go to the Hidden tab then unhide some NFTs