### PR TITLE
fix: attempt to fix missing sign requests

### DIFF
--- a/apps/next/src/pages/wagmi-signature-test.tsx
+++ b/apps/next/src/pages/wagmi-signature-test.tsx
@@ -1,0 +1,37 @@
+import { ConnectButton } from "@rainbow-me/rainbowkit";
+import type { NextPage } from "next";
+import { useAccount, useDisconnect, useSignMessage } from "wagmi";
+
+const Home: NextPage = () => {
+  const { isConnected } = useAccount();
+  const { disconnect } = useDisconnect();
+  const { signMessageAsync } = useSignMessage();
+  console.log("is connected :: ", isConnected);
+  const signMessageAsyncTimeout = async () => {
+    await fetch("https://my-vercel-functions-six.vercel.app/api?delay=1000");
+    signMessageAsync({ message: "yo!" });
+  };
+
+  return (
+    <div>
+      <main>
+        {isConnected ? (
+          <button onClick={() => disconnect()}>Disconnect</button>
+        ) : (
+          <ConnectButton />
+        )}
+        <button
+          style={{ marginLeft: 10 }}
+          onClick={() => signMessageAsync({ message: "yo!" })}
+        >
+          Sign message
+        </button>
+        <button style={{ marginLeft: 10 }} onClick={signMessageAsyncTimeout}>
+          Sign message async
+        </button>
+      </main>
+    </div>
+  );
+};
+
+export default Home;

--- a/packages/app/hooks/use-sign-typed-data.web.ts
+++ b/packages/app/hooks/use-sign-typed-data.web.ts
@@ -19,7 +19,7 @@ const EXPECTED_CHAIN_ID =
   CHAIN_IDENTIFIERS[process.env.NEXT_PUBLIC_CHAIN_ID || "polygon"];
 
 export const useSignTypedData = () => {
-  let { web3 } = useWeb3();
+  let { web3, isMagic } = useWeb3();
   const { chain } = useNetwork();
   const { switchNetworkAsync } = useSwitchNetwork();
   const Alert = useAlert();
@@ -33,7 +33,7 @@ export const useSignTypedData = () => {
     // eslint-disable-next-line no-async-promise-executor
     return new Promise(async (resolve, reject) => {
       try {
-        if (web3) {
+        if (web3 && isMagic) {
           const result = await web3
             .getSigner()
             ._signTypedData(domain, types, value);


### PR DESCRIPTION
# Why
noticed we're using web3 object instead of wagmi's sign method. I am not sure if this will fix the issue, but worth the try.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
use web3 object for signing only when `isMagic` is true.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
test claim and drop is working with magic and normal wallet
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
