### PR TITLE
allow 0 in royalty percentage

### DIFF
--- a/packages/app/components/drop/drop-form.tsx
+++ b/packages/app/components/drop/drop-form.tsx
@@ -68,7 +68,6 @@ const dropValidationSchema = yup.object({
   royalty: yup
     .number()
     .required()
-    .min(1)
     .typeError("Please enter a valid number")
     .max(69)
     .default(defaultValues.royalty),


### PR DESCRIPTION
# Why
https://linear.app/showtime/issue/SHOW2-1050/drop-screen-allow-royalties-to-be-0percent
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->


<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
Try putting 0 in royalty percentage while creating drop
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
