### PR TITLE
fix: turn autoConnect off till we identify signature requests bug

### DIFF
--- a/packages/app/components/edit-profile.tsx
+++ b/packages/app/components/edit-profile.tsx
@@ -7,7 +7,7 @@ import { Controller, useForm } from "react-hook-form";
 import { useSWRConfig } from "swr";
 
 import { Button } from "@showtime-xyz/universal.button";
-import { Fieldset } from "@showtime-xyz/universal.fieldset";
+import { ErrorText, Fieldset } from "@showtime-xyz/universal.fieldset";
 import { Upload } from "@showtime-xyz/universal.icon";
 import { useRouter } from "@showtime-xyz/universal.router";
 import { useSafeAreaInsets } from "@showtime-xyz/universal.safe-area";
@@ -31,9 +31,16 @@ import { useFilePicker } from "design-system/file-picker";
 import { SelectedTabIndicator, TabItem, Tabs } from "design-system/tabs";
 
 const editProfileValidationSchema = yup.object({
-  username: yup.string().min(2).nullable(),
-  bio: yup.string().max(300).nullable(),
+  username: yup
+    .string()
+    .min(2)
+    .required()
+    .typeError("Please enter a valid username"),
+  bio: yup.string().max(300).required().typeError("Please enter a valid bio"),
+  name: yup.string().max(40).required().typeError("Please enter a valid name"),
+  profilePicture: yup.mixed().required("Please add a profile picture"),
 });
+
 const tabs = ["Profile", "Links", "Page Settings"];
 
 const nftList = [
@@ -264,27 +271,36 @@ export const EditProfile = () => {
                   control={control}
                   name="profilePicture"
                   render={({ field: { onChange, value } }) => (
-                    <Pressable
-                      onPress={async () => {
-                        const file = await pickFile({ mediaTypes: "image" });
-                        onChange(file.file);
-                      }}
-                      style={tw.style(
-                        "w-24 h-24 rounded-full overflow-hidden border-2 border-gray-300 dark:border-gray-900 bg-white dark:bg-gray-800"
-                      )}
-                    >
-                      {value && (
-                        <Preview
-                          file={value}
-                          tw={"h-[94px] w-[94px] rounded-full"}
-                        />
-                      )}
-                      <View tw="absolute z-10 h-full w-full flex-1 items-center justify-center bg-black/10 dark:bg-black/60">
-                        <View tw="rounded-full bg-gray-800/70 p-2">
-                          <Upload height={20} width={20} color={colors.white} />
+                    <>
+                      <Pressable
+                        onPress={async () => {
+                          const file = await pickFile({ mediaTypes: "image" });
+                          onChange(file.file);
+                        }}
+                        style={tw.style(
+                          "w-24 h-24 rounded-full overflow-hidden border-2 border-gray-300 dark:border-gray-900 bg-white dark:bg-gray-800"
+                        )}
+                      >
+                        {value && (
+                          <Preview
+                            file={value}
+                            tw={"h-[94px] w-[94px] rounded-full"}
+                          />
+                        )}
+                        <View tw="absolute z-10 h-full w-full flex-1 items-center justify-center bg-black/10 dark:bg-black/60">
+                          <View tw="rounded-full bg-gray-800/70 p-2">
+                            <Upload
+                              height={20}
+                              width={20}
+                              color={colors.white}
+                            />
+                          </View>
                         </View>
-                      </View>
-                    </Pressable>
+                      </Pressable>
+                      {errors.profilePicture?.message ? (
+                        <ErrorText>{errors.profilePicture.message}</ErrorText>
+                      ) : null}
+                    </>
                   )}
                 />
 

--- a/packages/app/hooks/use-sign-typed-data.web.ts
+++ b/packages/app/hooks/use-sign-typed-data.web.ts
@@ -7,7 +7,6 @@ import {
   useNetwork,
   useSwitchNetwork,
 } from "wagmi";
-import { useSigner } from "wagmi";
 
 import { useAlert } from "@showtime-xyz/universal.alert";
 
@@ -25,7 +24,6 @@ export const useSignTypedData = () => {
   const { switchNetworkAsync } = useSwitchNetwork();
   const Alert = useAlert();
   const { signTypedDataAsync } = useWagmiSignTypedData();
-  const { data: signer } = useSigner();
 
   const signTypedData = async (
     domain: TypedDataDomain,
@@ -35,13 +33,7 @@ export const useSignTypedData = () => {
     // eslint-disable-next-line no-async-promise-executor
     return new Promise(async (resolve, reject) => {
       try {
-        if (signer) {
-          // https://docs.ethers.io/v5/api/signer/#Signer-signTypedData
-          //@ts-ignore
-          const result = await signer._signTypedData(domain, types, value);
-
-          resolve(result);
-        } else if (web3) {
+        if (web3) {
           const result = await web3
             .getSigner()
             ._signTypedData(domain, types, value);
@@ -75,11 +67,7 @@ export const useSignTypedData = () => {
                 onPress: async () => {
                   try {
                     await switchNetworkAsync?.(parseInt(EXPECTED_CHAIN_ID));
-                    const result = await signTypedDataAsync({
-                      domain,
-                      types,
-                      value,
-                    });
+                    const result = await signTypedData(domain, types, value);
                     resolve(result);
                   } catch (e) {
                     reject(

--- a/packages/app/providers/wallet-provider.web.tsx
+++ b/packages/app/providers/wallet-provider.web.tsx
@@ -16,7 +16,7 @@ const { connectors } = getDefaultWallets({
 });
 
 const wagmiClient = createClient({
-  autoConnect: true,
+  autoConnect: false,
   connectors,
   provider,
   webSocketProvider,


### PR DESCRIPTION
# Why
Wallets sometimes do not respond to signature requests even If it's in connected state. 
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
Set `autoConnect` to false, user will be shown connect button on trying to drop/claim. 
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
Login and test claim and drop, kill the app, try to claim and drop
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Aside

This issue seems to be related https://github.com/rainbow-me/rainbow/issues/3870, there are also some instances when the wallet is shown to be in a connected state but it doesn't respond to signature requests. 