### PR TITLE
fix: notificaions nfts display name

### DIFF
--- a/packages/app/components/notifications/nfts-display-name.tsx
+++ b/packages/app/components/notifications/nfts-display-name.tsx
@@ -29,86 +29,20 @@ export const NFTSDisolayName = ({ nfts }: NotificationDescriptionProps) => {
       </Text>
     );
   }
-  if (nfts.length === 2) {
-    const nft = nfts[0];
-    const nft_1 = nfts[1];
 
-    return (
-      <>
-        <Text
-          onPress={() => {
-            router.push(getNFTLink(nft));
-          }}
-          key={nft.id}
-          tw="text-13 font-bold text-black dark:text-white"
-        >
-          {nft.display_name}
-        </Text>
-        {` and `}
-        <Text
-          onPress={() => {
-            router.push(getNFTLink(nft_1));
-          }}
-          key={nft_1.id}
-          tw="text-13 font-bold text-black dark:text-white"
-        >
-          {nft_1.display_name}
-        </Text>
-      </>
-    );
-  }
-  if (nfts.length === 3) {
-    const nft = nfts[0];
-    const nft_1 = nfts[1];
-    const nft_2 = nfts[2];
-
-    return (
-      <>
-        <Text
-          onPress={() => {
-            router.push(getNFTLink(nft));
-          }}
-          tw="text-13 font-bold text-black dark:text-white"
-        >
-          {nft.display_name}
-        </Text>
-        {`, `}
-        <Text
-          onPress={() => {
-            router.push(getNFTLink(nft_1));
-          }}
-          tw="text-13 font-bold text-black dark:text-white"
-        >
-          {nft_1.display_name}
-        </Text>
-        <Text
-          onPress={() => {
-            router.push(getNFTLink(nft_2));
-          }}
-          tw="text-13 font-bold text-black dark:text-white"
-        >
-          {nft_2.display_name}
-        </Text>
-      </>
-    );
-  }
+  const nft = nfts[0];
   return (
     <>
-      {nfts?.map((nft) => (
-        <Text
-          onPress={() => {
-            router.push(
-              `/nft/${findTokenChainName(nft?.chain_identifier)}/${
-                nft?.contract_address
-              }/${nft?.token_identifier}`
-            );
-          }}
-          key={nft.id}
-          tw="text-13 font-bold text-black dark:text-white"
-        >
-          {`${nft.display_name}, `}
-        </Text>
-      ))}
+      <Text
+        onPress={() => {
+          router.push(getNFTLink(nft));
+        }}
+        key={nft.id}
+        tw="text-13 font-bold text-black dark:text-white"
+      >
+        {nft.display_name}
+      </Text>
+      {` and more`}
     </>
   );
 };


### PR DESCRIPTION
# Why

![image](https://user-images.githubusercontent.com/37520667/182332968-b408803d-9149-4c78-8497-3b501e3876b8.png) 
notifications nfts display names too long!

# How

- only show 1 NFT + `and more` text.

# Test Plan

check if the new notification description looks good!