### PR TITLE
fix: initial switch network prompt

### DIFF
--- a/packages/app/providers/wallet-provider.web.tsx
+++ b/packages/app/providers/wallet-provider.web.tsx
@@ -6,6 +6,7 @@ import { publicProvider } from "wagmi/providers/public";
 const { chains, provider, webSocketProvider } = configureChains(
   [chain.mainnet, chain.polygon, chain.polygonMumbai],
   [
+    //@ts-ignore
     alchemyProvider({ alchemyId: process.env.NEXT_PUBLIC_ALCHEMY_ID }),
     publicProvider(),
   ]
@@ -25,7 +26,16 @@ const wagmiClient = createClient({
 export const WalletProvider = ({ children }: { children: React.ReactNode }) => {
   return (
     <WagmiConfig client={wagmiClient}>
-      <RainbowKitProvider chains={chains}>{children}</RainbowKitProvider>
+      <RainbowKitProvider
+        initialChain={
+          process.env.NEXT_PUBLIC_CHAIN_ID === "polygon"
+            ? chain.polygon.id
+            : chain.polygonMumbai.id
+        }
+        chains={chains}
+      >
+        {children}
+      </RainbowKitProvider>
     </WagmiConfig>
   );
 };


### PR DESCRIPTION
# Why
Fixes the initial switch network prompt to mainnet. We'll try to switch to polygon, rainbowkit also handles adding the network if it's not added.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
There's a prop to specify `initialChain` in `RainbowKitProvider`
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
Try login in
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
