### PR TITLE
fix: remove flashlist from web mobile feed

### DIFF
--- a/packages/app/components/swipe-list.web.tsx
+++ b/packages/app/components/swipe-list.web.tsx
@@ -1,0 +1,226 @@
+import { useCallback, useMemo, useRef } from "react";
+import {
+  Dimensions,
+  FlatList,
+  Platform,
+  RefreshControl,
+  useWindowDimensions,
+} from "react-native";
+
+import {
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated";
+
+import { useSafeAreaFrame } from "@showtime-xyz/universal.safe-area";
+import { tw } from "@showtime-xyz/universal.tailwind";
+
+import { FeedItem } from "app/components/feed-item";
+import { MAX_HEADER_WIDTH } from "app/constants/layout";
+import { VideoConfigContext } from "app/context/video-config-context";
+import { useIsMobileWeb } from "app/hooks/use-is-mobile-web";
+import { useUser } from "app/hooks/use-user";
+import { useHeaderHeight } from "app/lib/react-navigation/elements";
+import { useNavigation, useScrollToTop } from "app/lib/react-navigation/native";
+import { DataProvider, LayoutProvider } from "app/lib/recyclerlistview";
+import type { NFT } from "app/types";
+
+import { ViewabilityTrackerRecyclerList } from "./viewability-tracker-swipe-list";
+
+const { height: screenHeight, width: screenWidth } = Dimensions.get("screen");
+const SCROLL_BAR_WIDTH = 15;
+const MOBILE_WEB_TABS_HEIGHT = 50;
+const MOBILE_WEB_BOTTOM_NAV_HEIGHT = 64;
+
+type Props = {
+  data: NFT[];
+  fetchMore?: () => void;
+  isRefreshing?: boolean;
+  refresh?: () => void;
+  initialScrollIndex?: number;
+  bottomPadding?: number;
+  listId?: number;
+};
+
+export const SwipeList = ({
+  data,
+  fetchMore,
+  isRefreshing = false,
+  refresh,
+  initialScrollIndex = 0,
+  bottomPadding = 0,
+  listId,
+}: Props) => {
+  const { isAuthenticated } = useUser();
+  const listRef = useRef<FlatList>(null);
+  const headerHeight = useHeaderHeight();
+  useScrollToTop(listRef);
+  const navigation = useNavigation();
+  const { isMobileWeb } = useIsMobileWeb();
+  const { height: safeAreaFrameHeight } = useSafeAreaFrame();
+  const { height: windowHeight, width: windowWidth } = useWindowDimensions();
+
+  const itemHeight =
+    Platform.OS === "web"
+      ? windowHeight -
+        headerHeight -
+        (isAuthenticated
+          ? MOBILE_WEB_BOTTOM_NAV_HEIGHT + MOBILE_WEB_TABS_HEIGHT
+          : 0)
+      : Platform.OS === "android"
+      ? safeAreaFrameHeight - headerHeight
+      : screenHeight;
+
+  let dataProvider = useMemo(
+    () =>
+      new DataProvider((r1, r2) => {
+        return r1.nft_id !== r2.nft_id;
+      }).cloneWithRows(data),
+    [data]
+  );
+
+  const _layoutProvider = useMemo(
+    () =>
+      new LayoutProvider(
+        () => {
+          return "item";
+        },
+        (_type, dim) => {
+          dim.width = screenWidth;
+          dim.height = itemHeight;
+        }
+      ),
+    [itemHeight]
+  );
+
+  const opacity = useSharedValue(1);
+
+  const detailStyle = useAnimatedStyle(() => {
+    return {
+      opacity: opacity.value,
+    };
+  }, []);
+
+  const hideHeader = useCallback(() => {
+    if (Platform.OS === "ios") {
+      navigation.setOptions({
+        headerShown: false,
+      });
+      opacity.value = withTiming(0);
+    }
+  }, [navigation, opacity]);
+
+  const showHeader = useCallback(() => {
+    if (Platform.OS === "ios") {
+      navigation.setOptions({
+        headerShown: true,
+      });
+      opacity.value = withTiming(1);
+    }
+  }, [navigation, opacity]);
+
+  const toggleHeader = useCallback(() => {
+    if (opacity.value === 1) {
+      hideHeader();
+    } else {
+      showHeader();
+    }
+  }, [hideHeader, showHeader, opacity]);
+
+  const _rowRenderer = useCallback(
+    (_type: any, item: any) => {
+      return (
+        <FeedItem
+          nft={item}
+          {...{
+            itemHeight,
+            bottomPadding,
+            detailStyle,
+            toggleHeader,
+            hideHeader,
+            showHeader,
+            listId,
+          }}
+        />
+      );
+    },
+    [
+      itemHeight,
+      bottomPadding,
+      hideHeader,
+      showHeader,
+      toggleHeader,
+      detailStyle,
+      listId,
+    ]
+  );
+
+  const contentWidth = useMemo(() => {
+    const scorllBarWidth = isMobileWeb ? 0 : SCROLL_BAR_WIDTH;
+    return windowWidth < MAX_HEADER_WIDTH
+      ? windowWidth - scorllBarWidth
+      : MAX_HEADER_WIDTH;
+  }, [windowWidth, isMobileWeb]);
+
+  const layoutSize = useMemo(
+    () => ({
+      width: contentWidth,
+      height: windowHeight,
+    }),
+    [contentWidth, windowHeight]
+  );
+  // const ListFooterComponent = useCallback(() => {
+  //   const colorMode = useColorScheme();
+  //   return isLoadingMore ? (
+  //     <View tw="w-full">
+  //       <Skeleton height={100} width={screenWidth} colorMode={colorMode} />
+  //     </View>
+  //   ) : null;
+  // }, [isLoadingMore, bottomBarHeight, screenWidth]);
+
+  const scrollViewProps = useMemo(
+    () => ({
+      pagingEnabled: true,
+      showsVerticalScrollIndicator: false,
+      onMomentumScrollEnd: showHeader,
+      refreshControl: (
+        <RefreshControl refreshing={isRefreshing} onRefresh={refresh} />
+      ),
+    }),
+    [isRefreshing, refresh, showHeader]
+  );
+
+  const videoConfig = useMemo(
+    () => ({
+      isMuted: true,
+      useNativeControls: false,
+      previewOnly: false,
+    }),
+    []
+  );
+
+  const extendedState = useMemo(() => ({ bottomPadding }), [bottomPadding]);
+
+  if (data.length === 0) return null;
+
+  return (
+    <VideoConfigContext.Provider value={videoConfig}>
+      <ViewabilityTrackerRecyclerList
+        layoutProvider={_layoutProvider}
+        dataProvider={dataProvider}
+        rowRenderer={_rowRenderer}
+        disableRecycling={Platform.OS === "android"}
+        ref={listRef}
+        initialRenderIndex={initialScrollIndex}
+        style={tw.style("flex-1 dark:bg-gray-900 bg-gray-100")}
+        renderAheadOffset={itemHeight}
+        onEndReached={fetchMore}
+        onEndReachedThreshold={itemHeight}
+        scrollViewProps={scrollViewProps}
+        extendedState={extendedState}
+        layoutSize={layoutSize}
+      />
+    </VideoConfigContext.Provider>
+  );
+};


### PR DESCRIPTION
# Why
- reverts FlashList from web mobile.
- It's not working well after initial scroll, needs more testing

https://user-images.githubusercontent.com/23293248/182410249-72dcc87f-74e0-46f1-b7be-0d79a68688b9.MP4


<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- add the previous swipe list for web
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
test feed on web mobile
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
cc - @alantoa we can move to virtuoso for web mobile feed. Adding recyclerlistview for now 😓 