### PR TITLE
show reconnect wallet message on drop/claim

### DIFF
--- a/packages/app/components/claim/claim-form.tsx
+++ b/packages/app/components/claim/claim-form.tsx
@@ -9,11 +9,10 @@ import { tw } from "@showtime-xyz/universal.tailwind";
 import { Text } from "@showtime-xyz/universal.text";
 import { View } from "@showtime-xyz/universal.view";
 
-import { ConnectButton } from "app/components/connect-button";
 import { Media } from "app/components/media";
+import { MissingSignatureMessage } from "app/components/missing-signature-message";
 import { PolygonScanButton } from "app/components/polygon-scan-button";
 import { useMyInfo, useUserProfile } from "app/hooks/api-hooks";
-import { useWallet } from "app/hooks/auth/use-wallet";
 import { useClaimNFT } from "app/hooks/use-claim-nft";
 import {
   CreatorEditionResponse,
@@ -23,6 +22,7 @@ import { useCurrentUserAddress } from "app/hooks/use-current-user-address";
 import { useNFTDetailByTokenId } from "app/hooks/use-nft-detail-by-token-id";
 import { useShare } from "app/hooks/use-share";
 import { useUser } from "app/hooks/use-user";
+import { useWeb3 } from "app/hooks/use-web3";
 import { track } from "app/lib/analytics";
 import { useNavigateToLogin } from "app/navigation/use-navigate-to";
 import {
@@ -40,8 +40,8 @@ export const ClaimForm = ({ edition }: { edition: CreatorEditionResponse }) => {
   const router = useRouter();
   const { userAddress } = useCurrentUserAddress();
   const { isAuthenticated } = useUser();
-  const { connected } = useWallet();
   const navigateToLogin = useNavigateToLogin();
+  const { isMagic } = useWeb3();
   const { data: nft } = useNFTDetailByTokenId({
     //@ts-ignore
     chainName: process.env.NEXT_PUBLIC_CHAIN_ID,
@@ -106,17 +106,6 @@ export const ClaimForm = ({ edition }: { edition: CreatorEditionResponse }) => {
         <Button tw="my-4" onPress={() => router.push("/profile/edit")}>
           Complete your profile
         </Button>
-      </View>
-    );
-  }
-
-  // TODO: remove this after imperative login modal API in rainbowkit
-  if (!connected) {
-    return (
-      <View tw="p-4">
-        <ConnectButton
-          handleSubmitWallet={({ onOpenConnectModal }) => onOpenConnectModal()}
-        />
       </View>
     );
   }
@@ -265,6 +254,10 @@ export const ClaimForm = ({ edition }: { edition: CreatorEditionResponse }) => {
               <PolygonScanButton transactionHash={state.transactionHash} />
             </View>
           </View>
+
+          {state.signaturePrompt && !isMagic ? (
+            <MissingSignatureMessage />
+          ) : null}
 
           {state.error ? (
             <View tw="mt-4">

--- a/packages/app/components/drop/drop-form.tsx
+++ b/packages/app/components/drop/drop-form.tsx
@@ -18,14 +18,14 @@ import { tw } from "@showtime-xyz/universal.tailwind";
 import { Text } from "@showtime-xyz/universal.text";
 import { View } from "@showtime-xyz/universal.view";
 
-import { ConnectButton } from "app/components/connect-button";
+import { MissingSignatureMessage } from "app/components/missing-signature-message";
 import { PolygonScanButton } from "app/components/polygon-scan-button";
 import { Preview } from "app/components/preview";
 import { useMyInfo } from "app/hooks/api-hooks";
-import { useWallet } from "app/hooks/auth/use-wallet";
 import { UseDropNFT, useDropNFT } from "app/hooks/use-drop-nft";
 import { useShare } from "app/hooks/use-share";
 import { useUser } from "app/hooks/use-user";
+import { useWeb3 } from "app/hooks/use-web3";
 import { track } from "app/lib/analytics";
 import { useBottomTabBarHeight } from "app/lib/react-navigation/bottom-tabs";
 import { useHeaderHeight } from "app/lib/react-navigation/elements";
@@ -109,9 +109,9 @@ export const DropForm = () => {
   const user = useUser();
   const { isAuthenticated } = useUser();
   const navigateToLogin = useNavigateToLogin();
-  const { connected } = useWallet();
   const { data: userProfile } = useMyInfo();
   const headerHeight = useHeaderHeight();
+  const { isMagic } = useWeb3();
 
   const isSignRequested = signMessageData.status === "sign_requested";
 
@@ -168,17 +168,6 @@ export const DropForm = () => {
         <Button tw="my-4" onPress={() => router.push("/profile/edit")}>
           Complete your profile
         </Button>
-      </View>
-    );
-  }
-
-  // TODO: remove this after imperative login modal API in rainbowkit
-  if (!connected) {
-    return (
-      <View tw="p-4">
-        <ConnectButton
-          handleSubmitWallet={({ onOpenConnectModal }) => onOpenConnectModal()}
-        />
       </View>
     );
   }
@@ -544,6 +533,10 @@ export const DropForm = () => {
               <View tw="mt-4">
                 <PolygonScanButton transactionHash={state.transactionHash} />
               </View>
+            ) : null}
+
+            {state.signaturePrompt && !isMagic ? (
+              <MissingSignatureMessage />
             ) : null}
 
             {state.error ? (

--- a/packages/app/components/missing-signature-message.tsx
+++ b/packages/app/components/missing-signature-message.tsx
@@ -15,7 +15,7 @@ export const MissingSignatureMessage = () => {
   };
 
   return (
-    <View tw="mt-2 flex-row items-center">
+    <View tw="mt-2 flex-row items-center flex-wrap">
       <Text tw="py-4 pr-2 text-sm text-gray-900 dark:text-white">
         Haven't received a signature request yet?
       </Text>

--- a/packages/app/components/missing-signature-message.tsx
+++ b/packages/app/components/missing-signature-message.tsx
@@ -1,6 +1,7 @@
 import { Platform } from "react-native";
 
 import { Button } from "@showtime-xyz/universal.button";
+import { useRouter } from "@showtime-xyz/universal.router";
 import { Text } from "@showtime-xyz/universal.text";
 import { View } from "@showtime-xyz/universal.view";
 
@@ -8,14 +9,20 @@ import { useWallet } from "app/hooks/auth/use-wallet";
 
 export const MissingSignatureMessage = () => {
   const { disconnect, connect } = useWallet();
+  const router = useRouter();
   const handleReconnect = async () => {
-    await disconnect();
-    if (Platform.OS === "web") localStorage.removeItem("walletconnect");
-    connect?.();
+    disconnect();
+    if (Platform.OS === "web") {
+      localStorage.removeItem("walletconnect");
+      connect?.();
+    } else {
+      // TODO: wallet selection modal is only on login screen on native
+      router.push("/login");
+    }
   };
 
   return (
-    <View tw="mt-2 flex-row items-center flex-wrap">
+    <View tw="mt-2 flex-row flex-wrap items-center">
       <Text tw="py-4 pr-2 text-sm text-gray-900 dark:text-white">
         Haven't received a signature request yet?
       </Text>

--- a/packages/app/components/missing-signature-message.tsx
+++ b/packages/app/components/missing-signature-message.tsx
@@ -12,8 +12,8 @@ export const MissingSignatureMessage = () => {
   };
 
   return (
-    <View tw="flex-row items-center mt-2">
-      <Text tw="text-sm dark:text-white text-gray-900 py-4 pr-2">
+    <View tw="mt-2 flex-row items-center">
+      <Text tw="py-4 pr-2 text-sm text-gray-900 dark:text-white">
         Haven't received a signature request yet?
       </Text>
       <Button onPress={handleReconnect}>Reconnect your wallet</Button>

--- a/packages/app/components/missing-signature-message.tsx
+++ b/packages/app/components/missing-signature-message.tsx
@@ -1,0 +1,22 @@
+import { Button } from "@showtime-xyz/universal.button";
+import { Text } from "@showtime-xyz/universal.text";
+import { View } from "@showtime-xyz/universal.view";
+
+import { useWallet } from "app/hooks/auth/use-wallet";
+
+export const MissingSignatureMessage = () => {
+  const { disconnect, connect } = useWallet();
+  const handleReconnect = async () => {
+    await disconnect();
+    connect?.();
+  };
+
+  return (
+    <View tw="flex-row items-center mt-2">
+      <Text tw="text-sm dark:text-white text-gray-900 py-4 pr-2">
+        Haven't received a signature request yet?
+      </Text>
+      <Button onPress={handleReconnect}>Reconnect your wallet</Button>
+    </View>
+  );
+};

--- a/packages/app/components/missing-signature-message.tsx
+++ b/packages/app/components/missing-signature-message.tsx
@@ -1,3 +1,5 @@
+import { Platform } from "react-native";
+
 import { Button } from "@showtime-xyz/universal.button";
 import { Text } from "@showtime-xyz/universal.text";
 import { View } from "@showtime-xyz/universal.view";
@@ -8,6 +10,7 @@ export const MissingSignatureMessage = () => {
   const { disconnect, connect } = useWallet();
   const handleReconnect = async () => {
     await disconnect();
+    if (Platform.OS === "web") localStorage.removeItem("walletconnect");
     connect?.();
   };
 

--- a/packages/app/hooks/auth/use-wallet.ts
+++ b/packages/app/hooks/auth/use-wallet.ts
@@ -10,13 +10,14 @@ export type UseWalletReturnType = {
   disconnect: () => void;
   connected?: boolean;
   networkChanged?: boolean;
+  connect?: () => void;
   signMessageAsync: (args: {
     message: string | ethers.utils.Bytes;
   }) => Promise<string | undefined>;
 };
 
 const useWallet = (): UseWalletReturnType => {
-  const { connected, killSession, session } = useWalletConnect();
+  const { connected, killSession, session, connect } = useWalletConnect();
   const { web3, isMagic } = useWeb3();
   const [address, setAddress] = useState<string | undefined>();
 
@@ -35,6 +36,7 @@ const useWallet = (): UseWalletReturnType => {
 
   return {
     address,
+    connect,
     disconnect: killSession,
     connected: connected || isMagic,
     networkChanged: undefined,

--- a/packages/app/hooks/auth/use-wallet.web.ts
+++ b/packages/app/hooks/auth/use-wallet.web.ts
@@ -1,5 +1,6 @@
 import { useMemo, useState, useEffect } from "react";
 
+import { useConnectModal } from "@rainbow-me/rainbowkit";
 import {
   useAccount,
   useSignMessage,
@@ -17,6 +18,7 @@ const useWallet = (): UseWalletReturnType => {
   const { signMessageAsync } = useSignMessage();
   const { data: wagmiSigner } = useSigner();
   const { chain } = useNetwork();
+  const { openConnectModal } = useConnectModal();
   const { disconnect } = useDisconnect();
   const { web3, isMagic } = useWeb3();
 
@@ -41,6 +43,7 @@ const useWallet = (): UseWalletReturnType => {
 
   return {
     address,
+    connect: openConnectModal,
     connected,
     disconnect,
     networkChanged,

--- a/packages/app/hooks/use-claim-nft.ts
+++ b/packages/app/hooks/use-claim-nft.ts
@@ -2,9 +2,8 @@ import { useReducer, useEffect, useRef } from "react";
 
 import { ethers } from "ethers";
 
-import { useAlert } from "@showtime-xyz/universal.alert";
-
 import { PROFILE_NFTS_QUERY_KEY } from "app/hooks/api-hooks";
+import { useWallet } from "app/hooks/auth/use-wallet";
 import { useCreatorCollectionDetail } from "app/hooks/use-creator-collection-detail";
 import { useCurrentUserAddress } from "app/hooks/use-current-user-address";
 import { useMatchMutate } from "app/hooks/use-match-mutate";
@@ -47,6 +46,7 @@ type State = {
   error?: string;
   transactionHash?: string;
   mint?: any;
+  signaturePrompt?: boolean;
 };
 
 type Action = {
@@ -58,6 +58,7 @@ type Action = {
 
 const initialState: State = {
   status: "idle",
+  signaturePrompt: false,
 };
 
 const reducer = (state: State, action: Action): State => {
@@ -75,6 +76,12 @@ const reducer = (state: State, action: Action): State => {
         ...state,
         transactionHash: action.transactionHash,
       };
+    case "signaturePrompt": {
+      return {
+        ...state,
+        signaturePrompt: true,
+      };
+    }
     case "error":
       return { ...state, status: "error", error: action.error };
     default:
@@ -89,11 +96,13 @@ export const useClaimNFT = (edition?: IEdition) => {
   const { mutate: mutateEdition } = useCreatorCollectionDetail(
     edition?.contract_address
   );
+  const { connect } = useWallet();
   const { userAddress } = useCurrentUserAddress();
-  const Alert = useAlert();
 
   // @ts-ignore
   const signTransaction = async ({ forwardRequest }) => {
+    dispatch({ type: "signaturePrompt" });
+
     const signature = await signTypedData(
       forwardRequest.domain,
       forwardRequest.types,
@@ -176,27 +185,27 @@ export const useClaimNFT = (edition?: IEdition) => {
 
   const claimNFT = async () => {
     try {
-      if (userAddress && edition?.minter_address) {
-        dispatch({ type: "loading" });
+      if (userAddress) {
+        if (edition?.minter_address) {
+          dispatch({ type: "loading" });
 
-        let forwardRequest: any;
-        if (forwarderRequestCached.current) {
-          forwardRequest = forwarderRequestCached.current;
-        } else {
-          forwardRequest = await getForwarderRequest({
-            minterAddress: edition?.minter_address,
-            userAddress,
-          });
+          let forwardRequest: any;
+          if (forwarderRequestCached.current) {
+            forwardRequest = forwarderRequestCached.current;
+          } else {
+            forwardRequest = await getForwarderRequest({
+              minterAddress: edition?.minter_address,
+              userAddress,
+            });
+          }
+
+          Logger.log("Signing... ", forwardRequest);
+
+          await signTransaction({ forwardRequest });
         }
-
-        Logger.log("Signing... ", forwardRequest);
-
-        await signTransaction({ forwardRequest });
       } else {
-        Alert.alert(
-          "Wallet disconnected",
-          "Please logout and login again to complete the transaction"
-        );
+        // user is probably not connected to wallet
+        connect?.();
       }
     } catch (e: any) {
       dispatch({ type: "error", error: e?.message });

--- a/packages/app/hooks/use-claim-nft.ts
+++ b/packages/app/hooks/use-claim-nft.ts
@@ -82,8 +82,19 @@ const reducer = (state: State, action: Action): State => {
         signaturePrompt: true,
       };
     }
+    case "signatureSuccess": {
+      return {
+        ...state,
+        signaturePrompt: false,
+      };
+    }
     case "error":
-      return { ...state, status: "error", error: action.error };
+      return {
+        ...state,
+        status: "error",
+        signaturePrompt: false,
+        error: action.error,
+      };
     default:
       return state;
   }
@@ -108,6 +119,8 @@ export const useClaimNFT = (edition?: IEdition) => {
       forwardRequest.types,
       forwardRequest.value
     );
+
+    dispatch({ type: "signatureSuccess" });
 
     const newSignature = ledgerWalletHack(signature);
     Logger.log("Signature", { signature, newSignature });

--- a/packages/app/hooks/use-drop-nft.ts
+++ b/packages/app/hooks/use-drop-nft.ts
@@ -69,7 +69,12 @@ const reducer = (state: State, action: Action): State => {
     case "success":
       return { ...state, status: "success", edition: action.edition };
     case "error":
-      return { ...state, status: "error", error: action.error };
+      return {
+        ...state,
+        status: "error",
+        error: action.error,
+        signaturePrompt: false,
+      };
     case "transactionHash":
       return {
         ...state,
@@ -80,6 +85,12 @@ const reducer = (state: State, action: Action): State => {
       return {
         ...state,
         signaturePrompt: true,
+      };
+    }
+    case "signatureSuccess": {
+      return {
+        ...state,
+        signaturePrompt: false,
       };
     }
     default:
@@ -161,6 +172,8 @@ export const useDropNFT = () => {
       forwardRequest.types,
       forwardRequest.value
     );
+
+    dispatch({ type: "signatureSuccess" });
 
     const newSignature = ledgerWalletHack(signature);
     Logger.log("Signature", { signature, newSignature });

--- a/packages/app/providers/user-provider.tsx
+++ b/packages/app/providers/user-provider.tsx
@@ -1,11 +1,10 @@
-import { useEffect, useMemo, ReactNode, useRef } from "react";
+import { useEffect, useMemo, ReactNode } from "react";
 import { Platform } from "react-native";
 
 import useSWR from "swr";
 
 import { UserContext } from "app/context/user-context";
 import { useAuth } from "app/hooks/auth/use-auth";
-import { useWallet } from "app/hooks/auth/use-wallet";
 import { axios } from "app/lib/axios";
 import LogRocket from "app/lib/logrocket";
 import { mixpanel } from "app/lib/mixpanel";
@@ -26,7 +25,6 @@ export function UserProvider({ children }: UserProviderProps) {
     accessToken ? MY_INFO_ENDPOINT : null,
     (url) => axios({ url, method: "GET" })
   );
-  const { disconnect } = useWallet();
   //#endregion
 
   //#region variables
@@ -81,16 +79,6 @@ export function UserProvider({ children }: UserProviderProps) {
     identifyAndRegisterPushNotification();
   }, [data]);
   //#endregion
-
-  const isMounted = useRef(false);
-
-  // TODO: temp workaround - https://github.com/rainbow-me/rainbow/issues/3870
-  useEffect(() => {
-    if (!isMounted.current) {
-      disconnect?.();
-      isMounted.current = true;
-    }
-  }, [disconnect]);
 
   return (
     <UserContext.Provider value={userContextValue}>

--- a/packages/app/providers/wallet-provider.web.tsx
+++ b/packages/app/providers/wallet-provider.web.tsx
@@ -17,7 +17,7 @@ const { connectors } = getDefaultWallets({
 });
 
 const wagmiClient = createClient({
-  autoConnect: false,
+  autoConnect: true,
   connectors,
   provider,
   webSocketProvider,


### PR DESCRIPTION
# Why
- Added some findings regarding wallet connect missing signature bug here. https://github.com/rainbow-me/rainbow/issues/3870
- Until we find a better solution, we'll show a message to reconnect their wallet in case signature requests do not arrive in wallet app
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->


<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Try claim/drop
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
