### PR TITLE
Send `nsfw` query param to `poll-edition` endpoint

### DIFF
--- a/packages/app/hooks/use-sign-typed-data.ts
+++ b/packages/app/hooks/use-sign-typed-data.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   TypedDataDomain,
   TypedDataField,
 } from "@ethersproject/abstract-signer";
@@ -18,7 +18,7 @@ export const useSignTypedData = () => {
   const signTypedData = async (
     domain: TypedDataDomain,
     types: Record<string, Array<TypedDataField>>,
-    value: Record<string, any>
+    value: Record<string, string | number>
   ) => {
     // magic or web
     try {


### PR DESCRIPTION
# Why

We want to flag NSFW drops in our backend directly

# How

- Sent `nsfw` query param to `poll-edition` endpoint
- Improved types

# Test Plan

Flag a drop as NSFW while creating it and check if the backend is flagging it correctly