### PR TITLE
fix: edit-profile text align & validate username

### DIFF
--- a/packages/app/components/edit-profile.tsx
+++ b/packages/app/components/edit-profile.tsx
@@ -34,8 +34,11 @@ const editProfileValidationSchema = yup.object({
   username: yup
     .string()
     .min(2)
-    .required()
-    .typeError("Please enter a valid username"),
+    .max(30)
+    .matches(
+      /([0-9a-zA-Z_]{2,30})+$/,
+      "Invalid username. Can only contain letters, numbers, and underscores (_)."
+    ),
   bio: yup
     .string()
     .max(300)
@@ -126,6 +129,7 @@ export const EditProfile = () => {
   }, [reset, defaultValues]);
 
   const handleSubmitForm = async (values: typeof defaultValues) => {
+    if (!isValid) return;
     const links = Object.keys(values.links)
       .filter((key) => values.links[key]?.trim())
       .map((key) => {
@@ -447,6 +451,10 @@ export const EditProfile = () => {
                                   ios: 1,
                                   android: 4,
                                   default: 0,
+                                }),
+                                marginBottom: Platform.select({
+                                  default: 4,
+                                  web: 0,
                                 }),
                               }}
                             >


### PR DESCRIPTION
# Why

- edit-profile link text hasn't aligned.
- username hasn't validated the special character.

# How

- fixed the above issues.

# Test Plan

- check if the text of the edit-profile link looks good!