### PR TITLE
Use latest image for EAS Build

### DIFF
--- a/apps/expo/eas.json
+++ b/apps/expo/eas.json
@@ -3,6 +3,9 @@
     "production": {
       "channel": "production",
       "distribution": "store",
+      "ios": {
+        "image": "latest"
+      },
       "android": {
         "buildType": "app-bundle",
         "image": "latest"
@@ -20,6 +23,9 @@
     "preview": {
       "channel": "staging",
       "distribution": "internal",
+      "ios": {
+        "image": "latest"
+      },
       "android": {
         "buildType": "apk",
         "image": "latest"
@@ -37,6 +43,9 @@
     "development": {
       "developmentClient": true,
       "distribution": "internal",
+      "ios": {
+        "image": "latest"
+      },
       "android": {
         "image": "latest"
       },
@@ -51,7 +60,11 @@
     },
     "simulator": {
       "ios": {
-        "simulator": true
+        "simulator": true,
+        "image": "latest"
+      },
+      "android": {
+        "image": "latest"
       },
       "env": {
         "STAGE": "staging"

--- a/apps/storybook-react-native/eas.json
+++ b/apps/storybook-react-native/eas.json
@@ -3,6 +3,12 @@
     "development": {
       "developmentClient": true,
       "distribution": "internal",
+      "ios": {
+        "image": "latest"
+      },
+      "android": {
+        "image": "latest"
+      },
       "env": {
         "STAGE": "development"
       },


### PR DESCRIPTION
# Why

We are experiencing weird issues with App Store returning an "Invalid Binary" error from time to time. Let's try to upgrade to Xcode 13.4 https://docs.expo.dev/build-reference/infrastructure/#image--macos-monterey-124-xcode-134--alias--latest

# How

Used `latest` image in `eas.json`
