### PR TITLE
profile and root url deeplinking (also fix a sentry error)

### DIFF
--- a/apps/next/src/pages/api/.well-known/apple-app-site-association.ts
+++ b/apps/next/src/pages/api/.well-known/apple-app-site-association.ts
@@ -9,7 +9,7 @@ const association = {
     details: [
       {
         appID: `${TEAM_ID}.${BUNDLE_ID}`,
-        paths: ["/nft/*", "/t/*"],
+        paths: ["/nft/*", "/t/*", "/@*", "/profile/*", "/"],
       },
     ],
   },

--- a/packages/app/components/profile/index.tsx
+++ b/packages/app/components/profile/index.tsx
@@ -121,8 +121,8 @@ const Profile = ({ username }: ProfileScreenProps) => {
           <Suspense fallback={<TabSpinner index={routeIndex} />}>
             {data?.tabs[routeIndex] && (
               <ProfileTabList
-                username={profileData?.data.profile.username}
-                profileId={profileData?.data.profile.profile_id}
+                username={profileData?.data?.profile.username}
+                profileId={profileData?.data?.profile.profile_id}
                 isBlocked={isBlocked}
                 list={data?.tabs[routeIndex]}
                 index={routeIndex}
@@ -137,8 +137,8 @@ const Profile = ({ username }: ProfileScreenProps) => {
       data?.tabs,
       index,
       isBlocked,
-      profileData?.data.profile.profile_id,
-      profileData?.data.profile.username,
+      profileData?.data?.profile.profile_id,
+      profileData?.data?.profile.username,
       tabRefs,
     ]
   );

--- a/packages/app/hooks/api-hooks.ts
+++ b/packages/app/hooks/api-hooks.ts
@@ -115,7 +115,7 @@ export const USER_PROFILE_KEY = "/v4/profile_server/";
 export const useUserProfile = ({ address }: { address?: string | null }) => {
   const queryKey = address ? USER_PROFILE_KEY + address : null;
   const { data, error, isLoading } = useSWR<{
-    data: UserProfile;
+    data?: UserProfile;
   }>(queryKey, fetcher);
   const { mutate } = useSWRConfig();
 


### PR DESCRIPTION
# Why
- tapping profile URLs should open in the app if app is installed. Also support opening root url in app.
- Getting this error of accessing profile of undefined object. Fix types in swr and add a null check https://sentry.io/organizations/showtime-l3/issues/3476062340/?project=5860034&query=is%3Aunresolved
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Tapping profile links should open in app if app is installed
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
