### PR TITLE
feat: resize profile img on native

### DIFF
--- a/packages/app/components/edit-profile.tsx
+++ b/packages/app/components/edit-profile.tsx
@@ -284,7 +284,13 @@ export const EditProfile = () => {
                   render={({ field: { onChange, value } }) => (
                     <Pressable
                       onPress={async () => {
-                        const file = await pickFile({ mediaTypes: "image" });
+                        const file = await pickFile({
+                          mediaTypes: "image",
+                          option: Platform.select({
+                            android: { allowsEditing: true, aspect: [3, 1] },
+                            default: {},
+                          }),
+                        });
                         const uri = getLocalFileURI(file.file);
 
                         setSelectedImg(uri);
@@ -321,6 +327,7 @@ export const EditProfile = () => {
                           onPress={async () => {
                             const file = await pickFile({
                               mediaTypes: "image",
+                              option: { allowsEditing: true, aspect: [1, 1] },
                             });
 
                             setSelectedImg(getLocalFileURI(file.file));

--- a/packages/app/components/edit-profile.tsx
+++ b/packages/app/components/edit-profile.tsx
@@ -287,6 +287,7 @@ export const EditProfile = () => {
                         const file = await pickFile({
                           mediaTypes: "image",
                           option: Platform.select({
+                            // aspect option only support android.
                             android: { allowsEditing: true, aspect: [3, 1] },
                             default: {},
                           }),

--- a/packages/design-system/file-picker/index.ts
+++ b/packages/design-system/file-picker/index.ts
@@ -5,6 +5,7 @@ import * as ImagePicker from "expo-image-picker";
 
 type Props = {
   mediaTypes?: "image" | "video" | "all";
+  option?: ImagePicker.ImagePickerOptions;
 };
 
 export type FilePickerResolveValue = {
@@ -23,7 +24,7 @@ export const useFilePicker = () => {
     };
   }, []);
 
-  const pickFile = ({ mediaTypes = "all" }: Props) => {
+  const pickFile = ({ mediaTypes = "all", option = {} }: Props) => {
     // eslint-disable-next-line no-async-promise-executor
     return new Promise<FilePickerResolveValue>(async (resolve, reject) => {
       if (Platform.OS === "web") {
@@ -72,6 +73,7 @@ export const useFilePicker = () => {
                 : ImagePicker.MediaTypeOptions.All,
             allowsMultipleSelection: false,
             quality: 1,
+            ...option,
           });
 
           if (result.cancelled) return;


### PR DESCRIPTION
# Why

last week I noticed that expo has the `allowsEditing` option, it supports crop images on native.

https://docs.expo.dev/versions/latest/sdk/imagepicker/#imagepickeroptions

# How

- on iOS, it uses [UIImagePickerController](https://developer.apple.com/documentation/uikit/uiimagepickercontroller), so currently, custom cropping aspect areas don't support it. maybe we can add 3rd lib later if it is necessary.
- on Android, it uses [Android-Image-Cropper](https://github.com/ArthurHub/Android-Image-Cropper).

# Test Plan

check if the cropper looks good on native!
