### PR TITLE
fix: improve reconnect wallet flow

### DIFF
--- a/packages/app/components/claim/claim-form.tsx
+++ b/packages/app/components/claim/claim-form.tsx
@@ -35,7 +35,9 @@ import {
 } from "app/utilities";
 
 export const ClaimForm = ({ edition }: { edition: CreatorEditionResponse }) => {
-  const { state, claimNFT } = useClaimNFT(edition?.creator_airdrop_edition);
+  const { state, claimNFT, onReconnectWallet } = useClaimNFT(
+    edition?.creator_airdrop_edition
+  );
   const share = useShare();
   const router = useRouter();
   const { userAddress } = useCurrentUserAddress();
@@ -256,18 +258,19 @@ export const ClaimForm = ({ edition }: { edition: CreatorEditionResponse }) => {
             </View>
           </View>
 
-          {state.signaturePrompt && !isMagic ? (
-            <MissingSignatureMessage
-              onMount={() => {
-                scrollViewRef.current?.scrollToEnd();
-              }}
-            />
-          ) : null}
-
           {state.error ? (
             <View tw="mt-4">
               <Text tw="text-red-500">{state.error}</Text>
             </View>
+          ) : null}
+
+          {state.signaturePrompt && !isMagic ? (
+            <MissingSignatureMessage
+              onReconnectWallet={onReconnectWallet}
+              onMount={() => {
+                scrollViewRef.current?.scrollToEnd();
+              }}
+            />
           ) : null}
         </View>
       </View>

--- a/packages/app/components/drop/drop-form.tsx
+++ b/packages/app/components/drop/drop-form.tsx
@@ -105,6 +105,7 @@ export const DropForm = () => {
     shouldShowSignMessage,
     signMessageData,
     signTransaction,
+    onReconnectWallet,
   } = useDropNFT();
   const user = useUser();
   const { isAuthenticated } = useUser();
@@ -537,18 +538,19 @@ export const DropForm = () => {
               </View>
             ) : null}
 
-            {state.signaturePrompt && !isMagic ? (
-              <MissingSignatureMessage
-                onMount={() => {
-                  scrollViewRef.current?.scrollToEnd();
-                }}
-              />
-            ) : null}
-
             {state.error ? (
               <View tw="mt-4">
                 <Text tw="text-red-500">{state.error}</Text>
               </View>
+            ) : null}
+
+            {state.signaturePrompt && !isMagic ? (
+              <MissingSignatureMessage
+                onReconnectWallet={onReconnectWallet}
+                onMount={() => {
+                  scrollViewRef.current?.scrollToEnd();
+                }}
+              />
             ) : null}
           </View>
 

--- a/packages/app/hooks/auth/use-wallet.ts
+++ b/packages/app/hooks/auth/use-wallet.ts
@@ -17,7 +17,8 @@ export type UseWalletReturnType = {
 };
 
 const useWallet = (): UseWalletReturnType => {
-  const { connected, killSession, session, connect } = useWalletConnect();
+  const connector = useWalletConnect();
+  const { connected, session } = connector;
   const { web3, isMagic } = useWeb3();
   const [address, setAddress] = useState<string | undefined>();
 
@@ -36,8 +37,8 @@ const useWallet = (): UseWalletReturnType => {
 
   return {
     address,
-    connect,
-    disconnect: killSession,
+    connect: connector.connect,
+    disconnect: connector.killSession,
     connected: connected || isMagic,
     networkChanged: undefined,
     signMessageAsync: async (args: {

--- a/packages/app/hooks/use-claim-nft.ts
+++ b/packages/app/hooks/use-claim-nft.ts
@@ -1,4 +1,4 @@
-import { useReducer, useEffect, useRef } from "react";
+import { useReducer, useEffect, useRef, useCallback } from "react";
 
 import { ethers } from "ethers";
 
@@ -82,6 +82,7 @@ const reducer = (state: State, action: Action): State => {
         signaturePrompt: true,
       };
     }
+
     case "signatureSuccess": {
       return {
         ...state,
@@ -228,8 +229,16 @@ export const useClaimNFT = (edition?: IEdition) => {
     }
   };
 
+  const onReconnectWallet = useCallback(() => {
+    dispatch({
+      type: "error",
+      error: "Please retry claiming the drop",
+    });
+  }, []);
+
   return {
     state,
     claimNFT,
+    onReconnectWallet,
   };
 };

--- a/packages/app/hooks/use-drop-nft.ts
+++ b/packages/app/hooks/use-drop-nft.ts
@@ -1,4 +1,4 @@
-import { useReducer, useState } from "react";
+import { useReducer, useState, useCallback } from "react";
 
 import type {
   TypedDataDomain,
@@ -310,6 +310,13 @@ export const useDropNFT = () => {
     }
   };
 
+  const onReconnectWallet = useCallback(() => {
+    dispatch({
+      type: "error",
+      error: "Please retry creating a drop",
+    });
+  }, []);
+
   return {
     dropNFT,
     state,
@@ -317,5 +324,6 @@ export const useDropNFT = () => {
     shouldShowSignMessage,
     signMessageData,
     signTransaction,
+    onReconnectWallet,
   };
 };


### PR DESCRIPTION
# Why
- Improves reconnect flow, fixes some quirks on disconnect and reconnecting on wallet connect and rainbowkit
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- show the user a message to retry claiming after reconnecting, ideally it should auto start reclaiming, but I think this is good for now, will do that after testing this for a while.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Testing is a bit tricky on this one as we don't know when the session ends, but you can try something like the below on web. Native has a similar flow.

https://user-images.githubusercontent.com/23293248/183385144-11a2cadd-2aae-4af5-9954-4e3abe1badfe.mov


<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
