### PR TITLE
fix: ModalScreen when in BottomTab

### DIFF
--- a/packages/app/components/drop/drop-explanation.tsx
+++ b/packages/app/components/drop/drop-explanation.tsx
@@ -11,6 +11,8 @@ import { tw } from "@showtime-xyz/universal.tailwind";
 import { Text } from "@showtime-xyz/universal.text";
 import { View } from "@showtime-xyz/universal.view";
 
+import { useModalScreenViewStyle } from "app/hooks/use-modal-screen-view-style";
+
 import { CARD_DARK_SHADOW } from "design-system/theme";
 
 const values = [
@@ -52,9 +54,11 @@ export const DropExplanation = ({ onDone }: { onDone: () => void }) => {
   const previewWidth = previewHeight * previewAspectRatio;
 
   const isDark = useIsDarkMode();
+
+  const modalScreenViewStyle = useModalScreenViewStyle();
   return (
     <ScrollView>
-      <View tw="flex-1 p-8">
+      <View tw="px-8" style={modalScreenViewStyle}>
         <View tw="mb-10 items-center">
           <View
             tw="rounded-xl shadow-xl"

--- a/packages/app/components/drop/drop-form.tsx
+++ b/packages/app/components/drop/drop-form.tsx
@@ -23,6 +23,7 @@ import { PolygonScanButton } from "app/components/polygon-scan-button";
 import { Preview } from "app/components/preview";
 import { useMyInfo } from "app/hooks/api-hooks";
 import { UseDropNFT, useDropNFT } from "app/hooks/use-drop-nft";
+import { useModalScreenViewStyle } from "app/hooks/use-modal-screen-view-style";
 import { useShare } from "app/hooks/use-share";
 import { useUser } from "app/hooks/use-user";
 import { useWeb3 } from "app/hooks/use-web3";
@@ -136,6 +137,7 @@ export const DropForm = () => {
   const share = useShare();
   const router = useRouter();
   const insets = useSafeAreaInsets();
+  const modalScreenViewStyle = useModalScreenViewStyle({ mode: "margin" });
 
   // if (state.transactionHash) {
   //   return <View>
@@ -184,7 +186,7 @@ export const DropForm = () => {
     });
 
     return (
-      <View tw="items-center justify-center p-4">
+      <View tw="items-center justify-center p-4" style={modalScreenViewStyle}>
         <Text tw="text-8xl">🎉</Text>
         <View>
           <View tw="h-8" />

--- a/packages/app/components/drop/drop-form.tsx
+++ b/packages/app/components/drop/drop-form.tsx
@@ -186,7 +186,10 @@ export const DropForm = () => {
     });
 
     return (
-      <View tw="items-center justify-center p-4" style={modalScreenViewStyle}>
+      <View
+        tw="items-center justify-center px-4 pt-8"
+        style={modalScreenViewStyle}
+      >
         <Text tw="text-8xl">🎉</Text>
         <View>
           <View tw="h-8" />

--- a/packages/app/hooks/use-modal-screen-view-style.tsx
+++ b/packages/app/hooks/use-modal-screen-view-style.tsx
@@ -5,20 +5,23 @@ import { useRouter } from "@showtime-xyz/universal.router";
 import { useBottomTabBarHeight } from "app/lib/react-navigation/bottom-tabs";
 import { useHeaderHeight } from "app/lib/react-navigation/elements";
 
-type ViewOption = {
+type ViewStyleOption = {
   mode?: "padding" | "margin";
   offset?: number;
 };
-export const useModalScreenViewStyle = (options?: ViewOption): ViewStyle => {
-  const mode = options?.mode ?? "padding";
-  const offset = options?.offset ?? 0;
-
+export const useModalScreenViewStyle = (
+  options?: ViewStyleOption
+): ViewStyle => {
   const router = useRouter();
-  const isModalScreen = router.pathname !== "/";
   const headerHeight = useHeaderHeight();
   const bottomHeight = useBottomTabBarHeight();
+
+  const mode = options?.mode ?? "padding";
+  const offset = options?.offset ?? 0;
+  const isModalScreen = router.pathname !== "/";
   const top = isModalScreen ? 0 : headerHeight + 16 + offset;
   const bottom = isModalScreen ? 0 : bottomHeight + offset;
+
   if (mode === "margin") {
     return {
       marginTop: top,

--- a/packages/app/hooks/use-modal-screen-view-style.tsx
+++ b/packages/app/hooks/use-modal-screen-view-style.tsx
@@ -1,0 +1,32 @@
+import { ViewStyle } from "react-native";
+
+import { useRouter } from "@showtime-xyz/universal.router";
+
+import { useBottomTabBarHeight } from "app/lib/react-navigation/bottom-tabs";
+import { useHeaderHeight } from "app/lib/react-navigation/elements";
+
+type ViewOption = {
+  mode?: "padding" | "margin";
+  offset?: number;
+};
+export const useModalScreenViewStyle = (options?: ViewOption): ViewStyle => {
+  const mode = options?.mode ?? "padding";
+  const offset = options?.offset ?? 0;
+
+  const router = useRouter();
+  const isModalScreen = router.pathname !== "/";
+  const headerHeight = useHeaderHeight();
+  const bottomHeight = useBottomTabBarHeight();
+  const top = isModalScreen ? 0 : headerHeight + 16 + offset;
+  const bottom = isModalScreen ? 0 : bottomHeight + offset;
+  if (mode === "margin") {
+    return {
+      marginTop: top,
+      marginBottom: bottom,
+    };
+  }
+  return {
+    paddingTop: top,
+    paddingBottom: bottom,
+  };
+};


### PR DESCRIPTION
# Why

https://linear.app/showtime/issue/SHOW2-1086/congrats-screen

# How

- ModalScreen adds padding/margin when in BottomTabScreen via `useModalScreenViewStyle` hooks.

# Test Plan

- check if the screen is covered when the `ModalScreen` in `BottomTabScreen`.
