### PR TITLE
fix: mobile web hide feature is not accessible

### DIFF
--- a/packages/app/components/card/card.tsx
+++ b/packages/app/components/card/card.tsx
@@ -1,6 +1,8 @@
 import { Suspense, useMemo, useCallback } from "react";
 import { Platform, useWindowDimensions } from "react-native";
 
+import { Link } from "solito/link";
+
 import { useColorScheme } from "@showtime-xyz/universal.color-scheme";
 import { PressableScale } from "@showtime-xyz/universal.pressable-scale";
 import { Skeleton } from "@showtime-xyz/universal.skeleton";
@@ -17,7 +19,6 @@ import { withMemoAndColorScheme } from "app/components/memo-with-theme";
 import { NFTDropdown } from "app/components/nft-dropdown";
 import { LikeContextProvider } from "app/context/like-context";
 import { useContentWidth } from "app/hooks/use-content-width";
-import { Link } from "app/navigation/link";
 import { NFT } from "app/types";
 
 import { CARD_DARK_SHADOW } from "design-system/theme";
@@ -28,10 +29,10 @@ type Props = {
   onPress: () => void;
   tw?: string;
   variant?: "nft" | "activity" | "market";
-  hrefProps?: string;
+  href?: string;
 };
 
-function Card({ nft, numColumns, tw, onPress, hrefProps = "" }: Props) {
+function Card({ nft, numColumns, tw, onPress, href = "" }: Props) {
   const { width } = useWindowDimensions();
   const { colorScheme } = useColorScheme();
   const contentWidth = useContentWidth();
@@ -64,7 +65,7 @@ function Card({ nft, numColumns, tw, onPress, hrefProps = "" }: Props) {
 
   if (width < 768) {
     return (
-      <RouteComponent href={hrefProps} onPress={handleOnPress}>
+      <RouteComponent href={href} onPress={handleOnPress}>
         <Media item={nft} numColumns={numColumns} />
       </RouteComponent>
     );
@@ -106,13 +107,13 @@ function Card({ nft, numColumns, tw, onPress, hrefProps = "" }: Props) {
             </ErrorBoundary>
           </View>
 
-          <RouteComponent href={hrefProps!} onPress={handleOnPress}>
+          <RouteComponent href={href!} onPress={handleOnPress}>
             <Media item={nft} numColumns={numColumns} />
           </RouteComponent>
           <RouteComponent
             // @ts-ignore
             dataSet={{ testId: "nft-card-title-link" }}
-            href={hrefProps!}
+            href={href!}
             onPress={handleOnPress}
           >
             <Title nft={nft} cardMaxWidth={cardMaxWidth} />

--- a/packages/app/components/feed/feed.md.tsx
+++ b/packages/app/components/feed/feed.md.tsx
@@ -181,9 +181,7 @@ const NFTScrollList = ({ data, isLoading, fetchMore }: NFTScrollListProps) => {
     return (
       <View tw="p-2">
         <Card
-          hrefProps={{
-            pathname: `/nft/${item.chain_name}/${item.contract_address}/${item.token_id}`,
-          }}
+          href={`/nft/${item.chain_name}/${item.contract_address}/${item.token_id}`}
           nft={item}
           tw={`w-[${CARD_WIDTH}px] mb-4`}
         />

--- a/packages/app/components/profile/profile-tab-list.tsx
+++ b/packages/app/components/profile/profile-tab-list.tsx
@@ -119,7 +119,7 @@ export const ProfileTabList = forwardRef<ProfileTabListRef, TabListProps>(
           />
         );
       },
-      [onItemPress]
+      [onItemPress, list.type]
     );
     if (isBlocked) {
       return (

--- a/packages/app/components/profile/profile-tab-list.tsx
+++ b/packages/app/components/profile/profile-tab-list.tsx
@@ -115,9 +115,7 @@ export const ProfileTabList = forwardRef<ProfileTabListRef, TabListProps>(
             nft={item}
             numColumns={3}
             onPress={() => onItemPress(item.nft_id)}
-            hrefProps={{
-              pathname: `/nft/${item.chain_name}/${item.contract_address}/${item.token_id}`,
-            }}
+            href={`/nft/${item.chain_name}/${item.contract_address}/${item.token_id}?tabType=${list.type}`}
           />
         );
       },

--- a/packages/app/components/trending/nfts-list.tsx
+++ b/packages/app/components/trending/nfts-list.tsx
@@ -52,9 +52,7 @@ export const NFTSList = forwardRef<TrendingTabListRef, TrendingTabListProps>(
                 `/list?initialScrollIndex=${index}&days=${days}&type=trendingNFTs`
               )
             }
-            hrefProps={{
-              pathname: `/nft/${item.chain_name}/${item.contract_address}/${item.token_id}`,
-            }}
+            href={`/nft/${item.chain_name}/${item.contract_address}/${item.token_id}`}
           />
         );
       },

--- a/packages/app/components/trending/trending-nfts-list.md.tsx
+++ b/packages/app/components/trending/trending-nfts-list.md.tsx
@@ -29,9 +29,7 @@ export function TrendingNFTSList({ days }: TrendingMDListProps) {
       return (
         <View tw="my-4 flex-1 px-2">
           <Card
-            hrefProps={{
-              pathname: `/nft/${item.chain_name}/${item.contract_address}/${item.token_id}`,
-            }}
+            href={`/nft/${item.chain_name}/${item.contract_address}/${item.token_id}`}
             key={`nft-list-card-${index}`}
             nft={item}
             tw={`w-full h-[${cardHeight}px] bg-white dark:bg-black`}

--- a/packages/app/hooks/use-hide-nft.ts
+++ b/packages/app/hooks/use-hide-nft.ts
@@ -25,6 +25,10 @@ export const useHideNFT = () => {
           if (router.pathname.includes("list") && Platform.OS !== "web") {
             router.pop();
           }
+
+          if (router.pathname.includes("/nft/") && Platform.OS === "web") {
+            router.pop();
+          }
           return true;
         } catch (error) {
           return false;
@@ -50,6 +54,9 @@ export const useHideNFT = () => {
             router.pop();
           }
 
+          if (router.pathname.includes("/nft/") && Platform.OS === "web") {
+            router.pop();
+          }
           return true;
         } catch (error) {
           return false;

--- a/packages/app/screens/nft.tsx
+++ b/packages/app/screens/nft.tsx
@@ -18,6 +18,7 @@ import {
   ViewabilityItemsContext,
 } from "app/components/viewability-tracker-flatlist";
 import { MOBILE_WEB_BOTTOM_NAV_HEIGHT } from "app/constants/layout";
+import { ProfileTabsNFTProvider } from "app/context/profile-tabs-nft-context";
 import { useNFTListings } from "app/hooks/api/use-nft-listings";
 import { useNFTDetailByTokenId } from "app/hooks/use-nft-detail-by-token-id";
 import { useUser } from "app/hooks/use-user";
@@ -32,11 +33,11 @@ type Query = {
   tokenId: string;
   contractAddress: string;
   chainName: string;
+  tabType?: string;
 };
 
 const { useParam } = createParam<Query>();
 const { height: screenHeight, width: screenWidth } = Dimensions.get("screen");
-const BOTTOM_GAP = 128;
 
 function NftScreen() {
   useTrackPageViewed({ name: "NFT" });
@@ -89,6 +90,7 @@ const NFTDetail = () => {
   const [tokenId] = useParam("tokenId");
   const [contractAddress] = useParam("contractAddress");
   const [chainName] = useParam("chainName");
+  const [tabType] = useParam("tabType");
   const { data } = useNFTDetailByTokenId({
     chainName: chainName as string,
     tokenId: tokenId as string,
@@ -120,11 +122,13 @@ const NFTDetail = () => {
 
   if (nft) {
     return (
-      <FeedItem
-        itemHeight={itemHeight}
-        bottomPadding={safeAreaBottom}
-        nft={nftWithListing as NFT}
-      />
+      <ProfileTabsNFTProvider tabType={tabType}>
+        <FeedItem
+          itemHeight={itemHeight}
+          bottomPadding={safeAreaBottom}
+          nft={nftWithListing as NFT}
+        />
+      </ProfileTabsNFTProvider>
     );
   }
 


### PR DESCRIPTION
# Why
Hide is not accessible on mobile web browser as we redirect to NFT detail screen to show the dropdown
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- use query parameter to pass the tab info to next screen
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
Hide/Unhide should be accessible on mobile web
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
