### PR TITLE
Handle errors when reaching OZ quota

### DIFF
--- a/packages/app/hooks/use-claim-nft.ts
+++ b/packages/app/hooks/use-claim-nft.ts
@@ -2,6 +2,8 @@ import { useReducer, useEffect, useRef, useCallback } from "react";
 
 import { ethers } from "ethers";
 
+import { useAlert } from "@showtime-xyz/universal.alert";
+
 import { PROFILE_NFTS_QUERY_KEY } from "app/hooks/api-hooks";
 import { useWallet } from "app/hooks/auth/use-wallet";
 import { useCreatorCollectionDetail } from "app/hooks/use-creator-collection-detail";
@@ -105,6 +107,7 @@ export const useClaimNFT = (edition?: IEdition) => {
   const signTypedData = useSignTypedData();
   const [state, dispatch] = useReducer(reducer, initialState);
   const mutate = useMatchMutate();
+  const Alert = useAlert();
   const { mutate: mutateEdition } = useCreatorCollectionDetail(
     edition?.contract_address
   );
@@ -225,6 +228,14 @@ export const useClaimNFT = (edition?: IEdition) => {
       dispatch({ type: "error", error: e?.message });
       forwarderRequestCached.current = null;
       Logger.error("nft drop claim failed", e);
+
+      if (e?.response?.status === 500) {
+        Alert.alert(
+          "Oops. An error occured.",
+          "We are currently experiencing a lot of usage. Please try again in one hour!"
+        );
+      }
+
       captureException(e);
     }
   };

--- a/packages/app/hooks/use-drop-nft.ts
+++ b/packages/app/hooks/use-drop-nft.ts
@@ -300,12 +300,21 @@ export const useDropNFT = () => {
     } catch (e: any) {
       dispatch({ type: "error", error: e?.message });
       Logger.error("nft drop failed", e);
+
       if (e?.response?.status === 420) {
         Alert.alert(
-          "Drop creation failed",
+          "Oops. An error occured.",
           "Only one drop per day is allowed. Please try again tomorrow!"
         );
       }
+
+      if (e?.response?.status === 500) {
+        Alert.alert(
+          "Oops. An error occured.",
+          "We are currently experiencing a lot of usage. Please try again in one hour!"
+        );
+      }
+
       captureException(e);
     }
   };


### PR DESCRIPTION
# Why

We need to handle errors when we reach our OZ quota

# How

- Updated copy for error 420
- Added an `Alert` on error 500 when drop or claim failed

# Test Plan

Wasn't able to test this change, we need to simulate getting an error 500 from the backend