### PR TITLE
adds onViewabilityItemChanged to inifinite scroll list

### DIFF
--- a/packages/app/components/claim/claim-form.tsx
+++ b/packages/app/components/claim/claim-form.tsx
@@ -61,8 +61,12 @@ export const ClaimForm = ({ edition }: { edition: CreatorEditionResponse }) => {
     nft?.data.item.creator_airdrop_edition_address
   );
 
+  const { user } = useUser();
   const handleClaimNFT = async () => {
-    if (nft?.data.item.creator_id) {
+    if (
+      nft?.data.item.creator_id &&
+      user?.data?.profile.profile_id !== nft?.data.item.creator_id
+    ) {
       follow(nft?.data.item.creator_id);
     }
 

--- a/packages/app/lib/infinite-scroll-list/index.web.tsx
+++ b/packages/app/lib/infinite-scroll-list/index.web.tsx
@@ -44,13 +44,13 @@ const ViewabilityTracker = ({
   item,
   children,
   onViewableItemsChanged,
-  visibleItems,
+  viewableItems,
 }: {
   index: number;
   item: any;
   children: any;
   onViewableItemsChanged: FlatListProps<any>["onViewableItemsChanged"];
-  visibleItems: MutableRefObject<ViewToken[]>;
+  viewableItems: MutableRefObject<ViewToken[]>;
 }) => {
   const ref = useRef<any>(null);
 
@@ -58,21 +58,21 @@ const ViewabilityTracker = ({
     if (onViewableItemsChanged) {
       const observer = new IntersectionObserver(([entry]) => {
         if (entry.isIntersecting) {
-          if (!visibleItems.current.find((v) => v.index === index))
-            visibleItems.current.push({
+          if (!viewableItems.current.find((v) => v.index === index))
+            viewableItems.current.push({
               item,
               index,
               isViewable: true,
               key: index.toString(),
             });
         } else {
-          visibleItems.current = visibleItems.current.filter(
+          viewableItems.current = viewableItems.current.filter(
             (v) => v.index !== index
           );
         }
 
         onViewableItemsChanged?.({
-          viewableItems: visibleItems.current,
+          viewableItems: viewableItems.current,
 
           // TODO: implement changed
           changed: [],
@@ -84,7 +84,7 @@ const ViewabilityTracker = ({
         observer.disconnect();
       };
     }
-  }, [onViewableItemsChanged, visibleItems, index, item]);
+  }, [onViewableItemsChanged, viewableItems, index, item]);
 
   return <div ref={ref}>{children}</div>;
 };
@@ -106,7 +106,7 @@ export function VirtuosoList<T>(
   }: InfiniteScrollListWebProps<T>,
   ref: React.Ref<VirtuosoHandle> | React.Ref<VirtuosoGridHandle>
 ) {
-  const visibleItems = useRef<ViewToken[]>([]);
+  const viewableItems = useRef<ViewToken[]>([]);
 
   const renderItemContent = React.useCallback(
     (index: number) => {
@@ -124,7 +124,7 @@ export function VirtuosoList<T>(
           <ViewabilityTracker
             index={index}
             item={data[index]}
-            visibleItems={visibleItems}
+            viewableItems={viewableItems}
             onViewableItemsChanged={onViewableItemsChanged}
           >
             {element}

--- a/packages/app/lib/infinite-scroll-list/index.web.tsx
+++ b/packages/app/lib/infinite-scroll-list/index.web.tsx
@@ -39,7 +39,7 @@ const renderComponent = (Component: any) => {
   return <Component />;
 };
 
-const ViewablityTracker = ({
+const ViewabilityTracker = ({
   index,
   item,
   children,
@@ -121,7 +121,7 @@ export function VirtuosoList<T>(
           },
         });
         return (
-          <ViewablityTracker
+          <ViewabilityTracker
             index={index}
             item={data[index]}
             visibleItems={visibleItems}
@@ -133,7 +133,7 @@ export function VirtuosoList<T>(
               isReactComponent(ItemSeparatorComponent) && (
                 <ItemSeparatorComponent />
               )}
-          </ViewablityTracker>
+          </ViewabilityTracker>
         );
       }
 


### PR DESCRIPTION
# Why
- We need to add viewability tracking to list to support autoplay video, mute video improvements and backend viewed NFT API integration. 
- FlashList already supports this. This PR adds it to the Virtuoso list on web. API is kept same as FlashList/FlatList


<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- Use IntersectionObserver as Virtuoso doesn't natively support this as mentioned here https://github.com/petyosi/react-virtuoso/issues/118#issuecomment-642156138. 
- Currently, kept it simple i.e. 70% visible item is considered as visible. 
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Passing `onViewabilityItemsChanged` should trigger when items are visible
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
