### PR TITLE
feat: claim misc

### DIFF
--- a/packages/app/components/card/card.tsx
+++ b/packages/app/components/card/card.tsx
@@ -13,12 +13,14 @@ import { Creator } from "app/components/card/rows/elements/creator";
 import { Owner } from "app/components/card/rows/owner";
 import { Title } from "app/components/card/rows/title";
 import { Social } from "app/components/card/social";
+import { ClaimButton } from "app/components/claim/claim-button";
 import { ErrorBoundary } from "app/components/error-boundary";
 import { Media } from "app/components/media";
 import { withMemoAndColorScheme } from "app/components/memo-with-theme";
 import { NFTDropdown } from "app/components/nft-dropdown";
 import { LikeContextProvider } from "app/context/like-context";
 import { useContentWidth } from "app/hooks/use-content-width";
+import { useCreatorCollectionDetail } from "app/hooks/use-creator-collection-detail";
 import { NFT } from "app/types";
 
 import { CARD_DARK_SHADOW } from "design-system/theme";
@@ -30,15 +32,25 @@ type Props = {
   tw?: string;
   variant?: "nft" | "activity" | "market";
   href?: string;
+  showClaimButton?: Boolean;
 };
 
-function Card({ nft, numColumns, tw, onPress, href = "" }: Props) {
+function Card({
+  nft,
+  numColumns,
+  tw,
+  onPress,
+  href = "",
+  showClaimButton = false,
+}: Props) {
   const { width } = useWindowDimensions();
   const { colorScheme } = useColorScheme();
   const contentWidth = useContentWidth();
   const isWeb = Platform.OS === "web";
   const RouteComponent = isWeb ? Link : PressableScale;
-
+  const { data: edition } = useCreatorCollectionDetail(
+    nft.creator_airdrop_edition_address
+  );
   const size = tw
     ? tw
     : numColumns === 3
@@ -118,8 +130,14 @@ function Card({ nft, numColumns, tw, onPress, href = "" }: Props) {
           >
             <Title nft={nft} cardMaxWidth={cardMaxWidth} />
           </RouteComponent>
-
-          <Social nft={nft} />
+          <View tw="flex-row justify-between px-4 pt-4">
+            <Social nft={nft} />
+            {showClaimButton &&
+            !!nft.creator_airdrop_edition_address &&
+            edition ? (
+              <ClaimButton edition={edition} />
+            ) : null}
+          </View>
 
           <Owner nft={nft} price={false} />
         </View>

--- a/packages/app/components/card/rows/description.tsx
+++ b/packages/app/components/card/rows/description.tsx
@@ -1,126 +1,25 @@
-import {
-  useState,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useLayoutEffect,
-} from "react";
-import { LayoutAnimation, UIManager, Platform } from "react-native";
-
-import { PressableScale } from "@showtime-xyz/universal.pressable-scale";
-import { Text } from "@showtime-xyz/universal.text";
 import { View } from "@showtime-xyz/universal.view";
 
-import type { NFT } from "app/types";
-import { removeTags } from "app/utilities";
+import { MultiClampText } from "design-system/multi-clamp-text";
 
 type Props = {
-  nft?: NFT;
+  descriptionText?: string;
+  tw?: string;
+  maxLines?: number;
 };
 
-const animation = LayoutAnimation.create(
-  300,
-  LayoutAnimation.Types.easeOut,
-  LayoutAnimation.Properties.opacity
-);
-
-function Description({ nft }: Props) {
-  const textRef = useRef<Element | Text>(null);
-  const [isExpanded, setIsExpanded] = useState(false);
-  const [showMore, setShowMore] = useState(false);
-  const [showLess, setShowLess] = useState(false);
-  const [numberOfLines, setNumberOfLines] = useState<number | undefined>(
-    undefined
-  );
-
-  useEffect(() => {
-    if (Platform.OS === "android") {
-      if (UIManager.setLayoutAnimationEnabledExperimental) {
-        UIManager.setLayoutAnimationEnabledExperimental(true);
-      }
-
-      return () => {
-        if (UIManager.setLayoutAnimationEnabledExperimental) {
-          UIManager.setLayoutAnimationEnabledExperimental(false);
-        }
-      };
-    }
-  }, []);
-
-  const countLines = useCallback((ele: Element | null) => {
-    if (!ele) return 0;
-    const styles = window.getComputedStyle(ele, null);
-    const lh = parseInt(styles.lineHeight, 10);
-    const h = parseInt(styles.height, 10);
-    const lc = Math.round(h / lh);
-    return lc;
-  }, []);
-
-  const onTextLayout = useCallback(
-    (lines: number) => {
-      if (lines > 3 && !isExpanded) {
-        setShowMore(true);
-        setNumberOfLines(3);
-      }
-    },
-    [isExpanded]
-  );
-
-  useLayoutEffect(() => {
-    onTextLayout(countLines(textRef.current as Element));
-  }, [countLines, isExpanded, onTextLayout]);
-
-  const description = useMemo(
-    () =>
-      nft && nft.token_description
-        ? removeTags(nft.token_description)
-        : undefined,
-    [nft]
-  );
-
-  const onShowMore = useCallback(() => {
-    LayoutAnimation.configureNext(animation);
-    setShowMore(false);
-    setShowLess(true);
-    setIsExpanded(true);
-    setNumberOfLines(0);
-  }, []);
-
-  const onShowLess = useCallback(() => {
-    LayoutAnimation.configureNext(animation);
-    setShowLess(false);
-    setShowMore(true);
-    setIsExpanded(false);
-    setNumberOfLines(3);
-  }, []);
-
-  if (!nft || !nft.token_description || nft.token_description === "") {
+function Description({ descriptionText = "", tw, maxLines = 3 }: Props) {
+  if (!descriptionText || descriptionText === "") {
     return null;
   }
 
   return (
-    <View tw="bg-white px-4 pb-4 dark:bg-black">
-      <Text
+    <View tw={tw}>
+      <MultiClampText
         tw="text-sm text-gray-600 dark:text-gray-400"
-        numberOfLines={numberOfLines}
-        ref={textRef as any}
-        // onTextLayout only support native
-        onTextLayout={(e) => onTextLayout(e.nativeEvent.lines.length)}
-      >
-        {description}
-      </Text>
-
-      {(showMore || showLess) && (
-        <>
-          <View tw="h-1" />
-          <PressableScale onPress={showMore ? onShowMore : onShowLess}>
-            <Text tw="text-sm font-bold text-gray-600 dark:text-gray-400">
-              {showMore ? "More" : "Less"}
-            </Text>
-          </PressableScale>
-        </>
-      )}
+        numberOfLines={maxLines}
+        text={descriptionText}
+      />
     </View>
   );
 }

--- a/packages/app/components/card/social/index.tsx
+++ b/packages/app/components/card/social/index.tsx
@@ -9,7 +9,7 @@ function Social({ nft }: { nft?: NFT }) {
   if (!nft) return null;
 
   return (
-    <View tw="flex-row justify-between bg-white px-4 pt-4 dark:bg-black">
+    <View tw="flex-row justify-between bg-white  dark:bg-black">
       <View tw="flex-row items-center">
         <Like nft={nft} />
         <View tw="w-4" />

--- a/packages/app/components/claim/claim-button.tsx
+++ b/packages/app/components/claim/claim-button.tsx
@@ -1,6 +1,7 @@
 import { Platform } from "react-native";
 
 import { Button } from "@showtime-xyz/universal.button";
+import { ButtonProps } from "@showtime-xyz/universal.button/types";
 import { Check } from "@showtime-xyz/universal.icon";
 import { useRouter } from "@showtime-xyz/universal.router";
 import { Text } from "@showtime-xyz/universal.text";
@@ -10,11 +11,11 @@ import { CreatorEditionResponse } from "app/hooks/use-creator-collection-detail"
 
 import { ClaimStatus, getClaimStatus } from ".";
 
-export const ClaimButton = ({
-  edition,
-}: {
+type ClaimButtonProps = {
   edition: CreatorEditionResponse;
-}) => {
+  size?: ButtonProps["size"];
+};
+export const ClaimButton = ({ edition, size = "small" }: ClaimButtonProps) => {
   const router = useRouter();
 
   const onClaimPress = () => {
@@ -60,6 +61,7 @@ export const ClaimButton = ({
       onPress={onClaimPress}
       disabled={disabled}
       style={bgIsGreen ? { backgroundColor: "#0CB504" } : undefined}
+      size={size}
       tw={isExpired && !bgIsGreen ? "opacity-50" : ""}
     >
       {status === ClaimStatus.Claimed ? (

--- a/packages/app/components/claim/gift-button.tsx
+++ b/packages/app/components/claim/gift-button.tsx
@@ -9,7 +9,7 @@ import { useCreatorCollectionDetail } from "app/hooks/use-creator-collection-det
 import { useSocialColor } from "app/hooks/use-social-color";
 import { NFT } from "app/types";
 
-import { getClaimStatus, ClaimStatus, formatClaimNumber } from ".";
+import { getClaimStatus, formatClaimNumber } from ".";
 
 export function GiftButton({ nft }: { nft: NFT }) {
   const router = useRouter();
@@ -56,11 +56,9 @@ export function GiftButton({ nft }: { nft: NFT }) {
       accentColor={textColors}
     >
       <GiftIcon height={24} width={24} color={iconColor} />
-      {status === ClaimStatus.Soldout
-        ? ` ${formatClaimNumber(edition.total_claimed_count)}`
-        : ` ${formatClaimNumber(edition.total_claimed_count)}/${
-            edition.creator_airdrop_edition.edition_size
-          }`}
+      {` ${formatClaimNumber(edition.total_claimed_count)}/${
+        edition.creator_airdrop_edition.edition_size
+      }`}
     </Button>
   );
 }

--- a/packages/app/components/feed-item/details.tsx
+++ b/packages/app/components/feed-item/details.tsx
@@ -42,7 +42,7 @@ export const NFTDetails = ({ nft, edition }: NFTDetailsProps) => {
       />
       <View tw="h-4" />
 
-      <View tw="flex-row justify-between">
+      <View tw="mb-1 flex-row justify-between">
         <View tw="flex-row">
           <Like nft={nft} />
           <View tw="w-6" />
@@ -61,7 +61,6 @@ export const NFTDetails = ({ nft, edition }: NFTDetailsProps) => {
             />
           </Pressable>
           <View tw="w-8" />
-
           <Suspense fallback={<Skeleton width={24} height={24} />}>
             <NFTDropdown nft={nft} />
           </Suspense>

--- a/packages/app/components/feed-item/details.tsx
+++ b/packages/app/components/feed-item/details.tsx
@@ -7,6 +7,7 @@ import { tw } from "@showtime-xyz/universal.tailwind";
 import { Text } from "@showtime-xyz/universal.text";
 import { View } from "@showtime-xyz/universal.view";
 
+import { Description } from "app/components/card/rows/description";
 import { Creator } from "app/components/card/rows/elements/creator";
 import { ClaimButton } from "app/components/claim/claim-button";
 import { GiftButton } from "app/components/claim/gift-button";
@@ -26,47 +27,49 @@ export const NFTDetails = ({ nft, edition }: NFTDetailsProps) => {
   const isCreatorDrop = !!nft.creator_airdrop_edition_address;
 
   return (
-    <View>
-      <View tw="flex-row items-center justify-between px-4">
+    <View tw="px-4">
+      <View tw="flex-row items-center justify-between ">
         <Creator nft={nft} shouldShowCreatorIndicator={false} />
-        {isCreatorDrop && edition ? <ClaimButton edition={edition} /> : null}
         {/* {!isCreatorDrop ? <BuyButton nft={nft} /> : null} */}
       </View>
+      <Text tw="font-space-bold text-lg dark:text-white" numberOfLines={3}>
+        {nft.token_name}
+      </Text>
+      <Description
+        descriptionText={nft?.token_description}
+        tw="pt-2"
+        maxLines={2}
+      />
+      <View tw="h-4" />
 
-      <View tw="px-4">
-        <Text tw="font-space-bold text-lg dark:text-white" numberOfLines={3}>
-          {nft.token_name}
-        </Text>
+      <View tw="flex-row justify-between">
+        <View tw="flex-row">
+          <Like nft={nft} />
+          <View tw="w-6" />
+          <CommentButton nft={nft} />
+          <View tw="w-6" />
+          <GiftButton nft={nft} />
+        </View>
 
-        <View tw="h-4" />
+        <View tw="flex-row">
+          <Pressable onPress={() => shareNFT(nft)}>
+            <Share
+              height={32}
+              width={22}
+              // @ts-ignore
+              color={tw.style("bg-gray-900 dark:bg-white").backgroundColor}
+            />
+          </Pressable>
+          <View tw="w-8" />
 
-        <View tw="flex-row justify-between">
-          <View tw="flex-row">
-            <Like nft={nft} />
-            <View tw="w-6" />
-            <CommentButton nft={nft} />
-            <View tw="w-6" />
-            <GiftButton nft={nft} />
-          </View>
-
-          <View tw="flex-row">
-            <Pressable onPress={() => shareNFT(nft)}>
-              <Share
-                height={32}
-                width={22}
-                // @ts-ignore
-                color={tw.style("bg-gray-900 dark:bg-white").backgroundColor}
-              />
-            </Pressable>
-            <View tw="w-8" />
-
-            <Suspense fallback={<Skeleton width={24} height={24} />}>
-              <NFTDropdown nft={nft} />
-            </Suspense>
-          </View>
+          <Suspense fallback={<Skeleton width={24} height={24} />}>
+            <NFTDropdown nft={nft} />
+          </Suspense>
         </View>
       </View>
-
+      {isCreatorDrop && edition ? (
+        <ClaimButton edition={edition} size="regular" />
+      ) : null}
       <View tw="h-4" />
     </View>
   );

--- a/packages/app/components/feed-item/feed-item.md.tsx
+++ b/packages/app/components/feed-item/feed-item.md.tsx
@@ -186,14 +186,19 @@ export const FeedItemMD = memo<FeedItemProps>(function FeedItemMD({
             },
           ]}
         >
-          <Social nft={nft} />
+          <View tw="px-4 pt-4">
+            <Social nft={nft} />
+          </View>
           <LikedBy nft={nft} />
           <View tw="my-4 mr-4 flex-row justify-between px-4">
             <Text tw="font-space-bold text-lg text-black dark:text-white md:text-2xl">
               {nft.token_name}
             </Text>
           </View>
-          <Description nft={nft} />
+          <Description
+            descriptionText={nft?.token_description}
+            tw="px-4 pb-4"
+          />
           <View tw="flex-row items-center justify-between px-4">
             <Creator nft={nft} />
             <Owner nft={nft} price={false} />

--- a/packages/app/components/feed/feed.md.tsx
+++ b/packages/app/components/feed/feed.md.tsx
@@ -186,6 +186,7 @@ const NFTScrollList = ({ data, isLoading, fetchMore }: NFTScrollListProps) => {
           href={`/nft/${item.chain_name}/${item.contract_address}/${item.token_id}`}
           nft={item}
           tw={`w-[${CARD_WIDTH}px] mb-4`}
+          showClaimButton
         />
       </View>
     );

--- a/packages/design-system/multi-clamp-text/index.tsx
+++ b/packages/design-system/multi-clamp-text/index.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useRef, useMemo } from "react";
+import { UIManager, Platform } from "react-native";
+
+import { Text, Props as TextProps } from "@showtime-xyz/universal.text";
+
+import { removeTags } from "app/utilities";
+
+import { useClampText } from "./use-clamp-text";
+
+type Props = {
+  text?: string;
+} & TextProps;
+
+export const MultiClampText = ({ text = "", tw, numberOfLines = 3 }: Props) => {
+  const textRef = useRef<Element | Text>(null);
+  const description = useMemo(() => (text ? removeTags(text) : ""), [text]);
+  useEffect(() => {
+    if (Platform.OS === "android") {
+      if (UIManager.setLayoutAnimationEnabledExperimental) {
+        UIManager.setLayoutAnimationEnabledExperimental(true);
+      }
+
+      return () => {
+        if (UIManager.setLayoutAnimationEnabledExperimental) {
+          UIManager.setLayoutAnimationEnabledExperimental(false);
+        }
+      };
+    }
+  }, []);
+
+  const {
+    showMore,
+    onShowLess,
+    onShowMore,
+    showLess,
+    innerText,
+    onTextLayout,
+  } = useClampText({
+    element: textRef.current as Element,
+    rows: numberOfLines,
+    text: description,
+  });
+
+  if (!text || text === "") {
+    return null;
+  }
+
+  return (
+    <Text
+      tw={tw}
+      ref={textRef as any}
+      // onTextLayout only support native
+      onTextLayout={onTextLayout}
+    >
+      {innerText}
+      {(showMore || showLess) && (
+        <Text
+          onPress={showMore ? onShowMore : onShowLess}
+          tw="text-sm font-bold text-gray-900 dark:text-white"
+        >
+          {showMore ? "More" : "Less"}
+        </Text>
+      )}
+    </Text>
+  );
+};

--- a/packages/design-system/multi-clamp-text/index.tsx
+++ b/packages/design-system/multi-clamp-text/index.tsx
@@ -58,7 +58,7 @@ export const MultiClampText = ({ text = "", tw, numberOfLines = 3 }: Props) => {
           onPress={showMore ? onShowMore : onShowLess}
           tw="text-sm font-bold text-gray-900 dark:text-white"
         >
-          {showMore ? "More" : "Less"}
+          {showMore ? " More" : " Less"}
         </Text>
       )}
     </Text>

--- a/packages/design-system/multi-clamp-text/use-clamp-text.tsx
+++ b/packages/design-system/multi-clamp-text/use-clamp-text.tsx
@@ -1,0 +1,71 @@
+import { useState, useRef, useCallback } from "react";
+import {
+  NativeSyntheticEvent,
+  TextLayoutEventData,
+  LayoutAnimation,
+} from "react-native";
+
+const animation = LayoutAnimation.create(
+  300,
+  LayoutAnimation.Types.easeOut,
+  LayoutAnimation.Properties.opacity
+);
+export type ClampTextProps = {
+  element?: Element;
+  text: string;
+  rows?: number;
+  ellipsis?: string;
+  expandButtonWidth?: number;
+};
+export const useClampText = ({
+  text = "",
+  rows = 3,
+  ellipsis = "...",
+  expandButtonWidth = 6,
+}: ClampTextProps) => {
+  const [innerText, setInnerText] = useState(text);
+  const [showMore, setShowMore] = useState(false);
+  const [showLess, setShowLess] = useState(false);
+  const collapseText = useRef("");
+  const isLayouted = useRef(false);
+
+  const onTextLayout = (e: NativeSyntheticEvent<TextLayoutEventData>) => {
+    if (e.nativeEvent.lines.length <= rows || isLayouted.current) return;
+
+    const finalText = e.nativeEvent.lines
+      .slice(0, rows)
+      .map((item) => item.text)
+      .join("");
+
+    const text = `${finalText.slice(
+      0,
+      finalText.length - expandButtonWidth
+    )}${ellipsis}`;
+
+    collapseText.current = text;
+    setInnerText(text);
+    setShowMore(true);
+    isLayouted.current = true;
+  };
+  const onShowMore = useCallback(() => {
+    LayoutAnimation.configureNext(animation);
+    setShowMore(false);
+    setShowLess(true);
+    setInnerText(text);
+  }, [text]);
+
+  const onShowLess = useCallback(() => {
+    LayoutAnimation.configureNext(animation);
+    setShowLess(false);
+    setShowMore(true);
+    setInnerText(collapseText.current);
+  }, []);
+  return {
+    showMore,
+    showLess,
+    onShowLess,
+    onShowMore,
+    innerText,
+    onTextLayout,
+  };
+};

--- a/packages/design-system/multi-clamp-text/use-clamp-text.web.tsx
+++ b/packages/design-system/multi-clamp-text/use-clamp-text.web.tsx
@@ -1,0 +1,113 @@
+import { useLayoutEffect, useState, useRef, useCallback } from "react";
+import { Platform } from "react-native";
+
+import type { ClampTextProps } from "./use-clamp-text";
+
+const int = (v: string) => parseFloat(v);
+const countRows = (h: number, l: number) => Math.round(h / l);
+const binarySearch = (text: string | any[], cb: (arg0: number) => any) => {
+  let min = 0,
+    max = text.length - 1;
+  while (min <= max) {
+    const mid = (max + min) / 2;
+    const result = cb(mid);
+    max = result > 0 ? mid - 1 : max;
+    min = result < 0 ? mid + 1 : min;
+    if (result === 0) return mid;
+  }
+};
+const getStyle = (attr: keyof CSSStyleDeclaration, ele: any) =>
+  window.getComputedStyle
+    ? window.getComputedStyle(ele, null)[attr]
+    : ele.currentStyle[attr];
+
+const countLines = (element: Element | null) => {
+  if (!element) return 0;
+  const styles = window.getComputedStyle(element, null);
+
+  const lh = parseInt(styles.lineHeight, 10);
+  const h = parseInt(styles.height, 10);
+  const lc = Math.round(h / lh);
+  return lc;
+};
+
+export const useClampText = ({
+  element,
+  text = "",
+  rows = 3,
+  ellipsis = "...",
+  expandButtonWidth = 6,
+}: ClampTextProps) => {
+  const [innerText, setInnerText] = useState(text);
+  const [showMore, setShowMore] = useState(false);
+  const [showLess, setShowLess] = useState(false);
+  const defaultText = useRef(text);
+  const collapseText = useRef("");
+
+  useLayoutEffect(() => {
+    if (Platform.OS !== "web" || !element) return;
+    const initRows = countLines(element);
+    if (initRows <= rows) return;
+    const sliceText = (pos: number) => `${text.slice(0, pos)}${ellipsis}`;
+    const fillText = (text: any) => {
+      element.innerHTML = text;
+    };
+    const contentHeight = () => {
+      if (!element) return 0;
+      const height = (element as any).offsetHeight;
+      const attrs = [
+        "borderTop",
+        "borderBottom",
+        "paddingTop",
+        "paddingBottom",
+      ];
+      return (
+        height -
+        attrs.reduce(
+          (total, cur) =>
+            total + int(getStyle(cur as keyof CSSStyleDeclaration, element)),
+          0
+        )
+      );
+    };
+    const singleLineHeight = int(getStyle("lineHeight", element));
+
+    const textRows = (text: string) => {
+      fillText(text);
+      return countRows(contentHeight(), singleLineHeight);
+    };
+
+    const lastStrPosition = binarySearch(text, (cur) => {
+      const curRows = textRows(sliceText(cur));
+      if (curRows !== rows) return curRows - rows;
+      return textRows(sliceText(cur + 1)) - rows - 1;
+    });
+    if (typeof lastStrPosition !== "number") return;
+    collapseText.current = sliceText(lastStrPosition - expandButtonWidth);
+    fillText(collapseText.current);
+    setShowMore(true);
+  }, [element, ellipsis, expandButtonWidth, rows, text]);
+
+  const onShowLess = useCallback(() => {
+    setShowLess(false);
+    setShowMore(true);
+    if (!element) return;
+    element.childNodes[0].nodeValue = collapseText.current;
+  }, [element]);
+
+  const onShowMore = useCallback(() => {
+    setShowMore(false);
+    setShowLess(true);
+    if (!element) return;
+    element.childNodes[0].nodeValue = defaultText.current;
+  }, [element]);
+  const onTextLayout = () => {};
+  return {
+    showMore,
+    showLess,
+    onShowLess,
+    onShowMore,
+    innerText,
+    onTextLayout,
+  };
+};


### PR DESCRIPTION
# Why
fixed & done: 
- [SHOW2-1108](https://linear.app/showtime/issue/SHOW2-1103/make-claim-button-full-width-above-nav-bar-like-swm-design)
- [SHOW2-1103](https://linear.app/showtime/issue/SHOW2-1103/make-claim-button-full-width-above-nav-bar-like-swm-design)
- [SHOW2-1102](https://linear.app/showtime/issue/SHOW2-1102/show-description-in-nft-card-instead-of-details-dropdown)
- [SHOW2-1183](https://linear.app/showtime/issue/SHOW2-1083/add-claim-button-to-nft-card)

due we need to move description to feed bottom, will look very bad if the `More` text button is alone in the third row, so we need to move `More` to the end of the second line。


# How

- just adjust some style and layout.
- implement a `MultiClampText` component to support clamping the text:
 on the native, use `onTextLayout` props to calculate the last line.
 on the web, use `binarySearch` to find the last word if in the specified line and do some logic.

this component will be released with List and Tabs in the next PR. 

# Test Plan

check if the Feed/Card UI looks good.
