### PR TITLE
fix: cancel expo-update limit

### DIFF
--- a/packages/app/hooks/use-expo-update.tsx
+++ b/packages/app/hooks/use-expo-update.tsx
@@ -1,7 +1,5 @@
 import { useEffect } from "react";
-import { Platform } from "react-native";
 
-import { differenceInSeconds, differenceInDays } from "date-fns";
 import * as Updates from "expo-updates";
 import { MMKV } from "react-native-mmkv";
 
@@ -9,19 +7,20 @@ import { useSnackbar } from "@showtime-xyz/universal.snackbar";
 
 import { useIsForeground } from "app/hooks/use-is-foreground";
 import { usePlatformBottomHeight } from "app/hooks/use-platform-bottom-height";
+import { captureException } from "app/lib/sentry";
 
 /**
  * store key
  */
 const store = new MMKV();
-const BACKGROUND_START_TIME_KEY = "backgroundStartTime";
+// const BACKGROUND_START_TIME_KEY = "backgroundStartTime";
 const LAST_SHOW_UPDATE_KEY = "lastShowUpdateTime";
 
 /**
  * update constant
  */
-const CHECK_UPDATE_FREQUENCY = 1; // days
-const SWITCH_TO_FOREGROUND_INTERVAL = 300; // seconds
+// const CHECK_UPDATE_FREQUENCY = 1; // days
+// const SWITCH_TO_FOREGROUND_INTERVAL = 300; // seconds
 
 export function useExpoUpdate() {
   const bottom = usePlatformBottomHeight();
@@ -46,37 +45,40 @@ export function useExpoUpdate() {
           });
         }
       }
-    } catch (e) {
-      console.error(e);
+    } catch (error) {
+      captureException(error);
     }
   };
   useEffect(() => {
     const now = new Date();
-    if (isForeground) {
-      if (__DEV__) return;
-      if (Platform.OS !== "ios") return;
-      const lastUpdateTime = store.getString(LAST_SHOW_UPDATE_KEY);
-      const diffDays = lastUpdateTime
-        ? differenceInDays(now, Date.parse(lastUpdateTime))
-        : 0;
+    const currentHours = now.getHours();
 
-      // check update frequency, avoid prompting for updates multiple times a day.
-      if (diffDays < CHECK_UPDATE_FREQUENCY) return;
+    checkUpdate(currentHours > 3 && currentHours < 5);
+    // if (isForeground) {
+    //   if (__DEV__) return;
+    //   if (Platform.OS !== "ios") return;
+    //   const lastUpdateTime = store.getString(LAST_SHOW_UPDATE_KEY);
+    //   const diffDays = lastUpdateTime
+    //     ? differenceInDays(now, Date.parse(lastUpdateTime))
+    //     : 0;
 
-      const startTime = store.getString(BACKGROUND_START_TIME_KEY);
-      const diffSeconds = startTime
-        ? differenceInSeconds(now, Date.parse(startTime))
-        : 0;
+    //   // check update frequency, avoid prompting for updates multiple times a day.
+    //   if (diffDays < CHECK_UPDATE_FREQUENCY) return;
 
-      // only display update when after 5 minutes in background.
-      if (diffSeconds < SWITCH_TO_FOREGROUND_INTERVAL) return;
-      // if between 3am and 5am, will auto-update.
-      const currentHours = now.getHours();
+    //   const startTime = store.getString(BACKGROUND_START_TIME_KEY);
+    //   const diffSeconds = startTime
+    //     ? differenceInSeconds(now, Date.parse(startTime))
+    //     : 0;
 
-      checkUpdate(currentHours > 3 && currentHours < 5);
-    } else {
-      store.set(BACKGROUND_START_TIME_KEY, now.toISOString());
-    }
+    //   // only display update when after 5 minutes in background.
+    //   if (diffSeconds < SWITCH_TO_FOREGROUND_INTERVAL) return;
+    //   // if between 3am and 5am, will auto-update.
+    //   const currentHours = now.getHours();
+
+    //   checkUpdate(currentHours > 3 && currentHours < 5);
+    // } else {
+    //   store.set(BACKGROUND_START_TIME_KEY, now.toISOString());
+    // }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [bottom, isForeground]);
 }


### PR DESCRIPTION
# Why

just noticed that many App(Telegram), It's also updated multiple times a day, and we iterate fast, if now we limit the number of updates:

- some fixed issues unable to confirm.
- some urgent bugs could not be resolved in time, this will be more annoying than the update prompt.



# How

so I remove some `expo-update` logic and check updates every time, only auto-update when the local time is between 3 am and 5 am.


# Test Plan

check if the expo-update logic looks good.
