### PR TITLE
fix: magic test login

### DIFF
--- a/packages/app/types/environment.d.ts
+++ b/packages/app/types/environment.d.ts
@@ -1,0 +1,9 @@
+export {};
+
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv {
+      NEXT_PUBLIC_MAGIC_PUB_KEY: string;
+    }
+  }
+}

--- a/packages/app/utilities.ts
+++ b/packages/app/utilities.ts
@@ -107,13 +107,10 @@ export const overrideMagicInstance = (email: string) => {
       customNodeOptions.chainId = 80001;
     }
 
-    const testMagic = new Magic(
-      (process.env as any).NEXT_PUBLIC_MAGIC_PUB_KEY,
-      {
-        network: customNodeOptions,
-        testMode: true,
-      }
-    );
+    const testMagic = new Magic(process.env.NEXT_PUBLIC_MAGIC_PUB_KEY, {
+      network: customNodeOptions,
+      testMode: true,
+    });
     return testMagic;
   }
 

--- a/packages/app/utilities.ts
+++ b/packages/app/utilities.ts
@@ -107,6 +107,7 @@ export const overrideMagicInstance = (email: string) => {
       customNodeOptions.chainId = 80001;
     }
 
+    //@ts-ignore
     const testMagic = new Magic(process.env.NEXT_PUBLIC_MAGIC_PUB_KEY, {
       network: customNodeOptions,
       testMode: true,

--- a/packages/app/utilities.ts
+++ b/packages/app/utilities.ts
@@ -107,7 +107,6 @@ export const overrideMagicInstance = (email: string) => {
       customNodeOptions.chainId = 80001;
     }
 
-    //@ts-ignore
     const testMagic = new Magic(process.env.NEXT_PUBLIC_MAGIC_PUB_KEY, {
       network: customNodeOptions,
       testMode: true,


### PR DESCRIPTION
# Why
appstore approval. Reviewer not able to test with magic login
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
Looks like babel env plugin is not able to parse `process.env as any` and convert to the value . Also it has to do with the order of typescript transpile and babel plugin. 
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Test sign in with test email works
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
