### PR TITLE
fix: audio stays muted even after pressing unmute

### DIFF
--- a/apps/expo/App.tsx
+++ b/apps/expo/App.tsx
@@ -3,6 +3,7 @@ import { LogBox } from "react-native";
 
 import LogRocket from "@logrocket/react-native";
 import rudderClient from "@rudderstack/rudder-sdk-react-native";
+import { Audio } from "expo-av";
 import * as Notifications from "expo-notifications";
 import { StatusBar } from "expo-status-bar";
 import { enableScreens } from "react-native-screens";
@@ -111,6 +112,10 @@ function App() {
       });
 
     return () => Notifications.removeNotificationSubscription(responseListener);
+  }, []);
+
+  useEffect(() => {
+    Audio.setAudioModeAsync({ playsInSilentModeIOS: true });
   }, []);
 
   return (


### PR DESCRIPTION
# Why
This can happen if physical silent button on iOS is turned on
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
set `playsInSilentModeIOS` to `true` in expo-av Audio
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
Audio plays in video on unmute if physical silent button is turned on
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
