### PR TITLE
global mute state (native only)

### DIFF
--- a/packages/app/hooks/use-viewability-mount.ts
+++ b/packages/app/hooks/use-viewability-mount.ts
@@ -7,22 +7,22 @@ import {
   ItemKeyContext,
   ViewabilityItemsContext,
 } from "app/components/viewability-tracker-flatlist";
-import { useVideoConfig } from "app/context/video-config-context";
 
 import { useIsTabFocused } from "design-system/tabs/tablib";
 
 export const useViewabilityMount = ({
   videoRef,
   source,
+  isMuted,
 }: {
   videoRef: RefObject<Video>;
   source: any;
+  isMuted: boolean;
 }) => {
   const id = useContext(ItemKeyContext);
   const context = useContext(ViewabilityItemsContext);
   const isItemInList = typeof id !== "undefined";
   const loaded = useRef(false);
-  const videoConfig = useVideoConfig();
   let isListFocused = useIsTabFocused();
 
   const loadPlayOrPause = useCallback(
@@ -31,7 +31,7 @@ export const useViewabilityMount = ({
       if (!loaded.current) {
         await videoRef.current?.loadAsync(source, {
           isLooping: true,
-          isMuted: videoConfig?.isMuted,
+          isMuted,
         });
       }
 
@@ -43,7 +43,7 @@ export const useViewabilityMount = ({
 
       loaded.current = true;
     },
-    [source, videoRef, videoConfig?.isMuted]
+    [source, videoRef, isMuted]
   );
 
   const unload = useCallback(() => {

--- a/packages/app/providers/app-providers.tsx
+++ b/packages/app/providers/app-providers.tsx
@@ -18,6 +18,7 @@ import { UserProvider } from "app/providers/user-provider";
 import { WalletProvider } from "app/providers/wallet-provider";
 import { Web3Provider } from "app/providers/web3-provider";
 
+import { MuteProvider } from "./mute-provider";
 import { ThemeProvider } from "./theme-provider";
 
 // @
@@ -41,7 +42,7 @@ export const AppProviders = ({ children }: { children: React.ReactNode }) => {
                                 <GrowthBookProvider growthbook={growthbook}>
                                   <FeedProvider>
                                     <BiconomyProvider>
-                                      {children}
+                                      <MuteProvider>{children}</MuteProvider>
                                     </BiconomyProvider>
                                   </FeedProvider>
                                 </GrowthBookProvider>

--- a/packages/app/providers/mute-provider.tsx
+++ b/packages/app/providers/mute-provider.tsx
@@ -1,0 +1,21 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  Dispatch,
+  SetStateAction,
+} from "react";
+
+export const MuteContext = createContext(
+  null as [boolean, Dispatch<SetStateAction<boolean>>] | null
+);
+
+export const MuteProvider = ({ children }: { children: any }) => {
+  const values = useState(true);
+
+  return <MuteContext.Provider value={values}>{children}</MuteContext.Provider>;
+};
+
+export const useMuted = () => {
+  return useContext(MuteContext);
+};

--- a/packages/design-system/video/index.tsx
+++ b/packages/design-system/video/index.tsx
@@ -12,6 +12,7 @@ import { MuteButton } from "app/components/mute-button";
 import { useMuteButtonBottomOffset } from "app/components/mute-button/mute-button";
 import { useVideoConfig } from "app/context/video-config-context";
 import { useViewabilityMount } from "app/hooks/use-viewability-mount";
+import { useMuted } from "app/providers/mute-provider";
 
 type VideoProps = {
   tw?: TW;
@@ -29,10 +30,23 @@ function Video({
 }: VideoProps) {
   const videoRef = useRef<ExpoVideo>(null);
   const videoConfig = useVideoConfig();
+  const mutedContext = useMuted();
   const [muted, setMuted] = useState(true);
+  const isMuted = mutedContext ? mutedContext[0] : muted;
 
-  const { id } = useViewabilityMount({ videoRef, source: props.source });
+  const { id } = useViewabilityMount({
+    videoRef,
+    source: props.source,
+    isMuted,
+  });
   const bottomOffset = useMuteButtonBottomOffset();
+  const handleMuteChange = () => {
+    if (mutedContext) {
+      mutedContext[1](!isMuted);
+    } else {
+      setMuted(!isMuted);
+    }
+  };
 
   return (
     <>
@@ -59,7 +73,7 @@ function Video({
               useNativeControls={videoConfig?.useNativeControls}
               resizeMode={ResizeMode.COVER}
               posterSource={posterSource}
-              isMuted={muted}
+              isMuted={isMuted}
             />
             {showMuteButton ? (
               <View
@@ -69,7 +83,7 @@ function Video({
                   position: "absolute",
                 }}
               >
-                <MuteButton onPress={() => setMuted(!muted)} muted={muted} />
+                <MuteButton onPress={handleMuteChange} muted={isMuted} />
               </View>
             ) : null}
           </>


### PR DESCRIPTION
# Why
- If user unmutes a video, all the other videos should be played unmuted.
- Only implemented on native. On web, I'll pick it after working on [better visibility tracking](https://github.com/showtime-xyz/showtime-frontend/tree/video-feed-improvements). Also there are some more priority items so will cover them first. Web is also a bit tricky as it allows to play more than one video at a time.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- Use context state for mute on native
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Test unmuting a video, all other videos should play unmuted.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
