### PR TITLE
Render profiles and NFTs with data from server

### DIFF
--- a/apps/next/src/pages/nft/[chainName]/[contractAddress]/[tokenId]/index.tsx
+++ b/apps/next/src/pages/nft/[chainName]/[contractAddress]/[tokenId]/index.tsx
@@ -2,7 +2,7 @@ import axios from "axios";
 
 import { CHAIN_IDENTIFIERS } from "app/lib/constants";
 import { NftScreen } from "app/screens/nft";
-import { NFT } from "app/types";
+import type { NFT } from "app/types";
 import { getMediaUrl } from "app/utilities";
 
 export async function getServerSideProps(context) {
@@ -11,6 +11,10 @@ export async function getServerSideProps(context) {
     const res = await axios.get(
       `${process.env.NEXT_PUBLIC_BACKEND_URL}/v2/token/${contractAddress}/${tokenId}?chain_identifier=${CHAIN_IDENTIFIERS[chainName]}`
     );
+    const fallback = {
+      [`/api/v2/token/${contractAddress}/${tokenId}?chain_identifier=${CHAIN_IDENTIFIERS[chainName]}`]:
+        res.data,
+    };
 
     const nft = res.data?.data?.item as NFT;
     const imageUrl = getMediaUrl({
@@ -21,6 +25,7 @@ export async function getServerSideProps(context) {
     if (nft) {
       return {
         props: {
+          fallback,
           meta: {
             title: nft.token_name + " | Showtime",
             description: nft.token_description,
@@ -30,7 +35,9 @@ export async function getServerSideProps(context) {
         },
       };
     }
-  } catch (e) {}
+  } catch (e) {
+    console.error(e);
+  }
 
   return {
     props: {},

--- a/apps/next/src/pages/profile/[username].tsx
+++ b/apps/next/src/pages/profile/[username].tsx
@@ -1,20 +1,21 @@
 import axios from "axios";
 
-import { UserType } from "app/types";
+import type { UserType } from "app/types";
 import { formatAddressShort } from "app/utilities";
-
-export { default } from "app/pages/profile";
 
 export async function getServerSideProps(context) {
   const username = context.params.username;
+
   try {
     const res = await axios.get(
       `${process.env.NEXT_PUBLIC_BACKEND_URL}/v4/profile_server/${username}`
     );
+    const fallback = {
+      [`/api/v4/profile_server/${username}`]: res.data,
+    };
 
     const user = res.data as UserType;
     let title;
-
     if (user.data.profile.username && user.data.profile.name) {
       title = `${user.data.profile.name} (@${user.data.profile.username})`;
     } else if (user.data.profile.name) {
@@ -26,12 +27,12 @@ export async function getServerSideProps(context) {
         user.data.profile.wallet_addresses_v2?.[0]?.address
       );
     }
-
-    title += " " + "| Showtime";
+    title += " | Showtime";
 
     if (user) {
       return {
         props: {
+          fallback,
           meta: {
             title,
             description: user.data.profile.bio,
@@ -40,9 +41,13 @@ export async function getServerSideProps(context) {
         },
       };
     }
-  } catch (e) {}
+  } catch (e) {
+    console.error(e);
+  }
 
   return {
     props: {},
   };
 }
+
+export { default } from "app/pages/profile";

--- a/packages/app/pages/profile/index.web.tsx
+++ b/packages/app/pages/profile/index.web.tsx
@@ -1,10 +1,12 @@
 import { useEffect } from "react";
 
+import { SWRConfig } from "swr";
+
 import { useRouter } from "@showtime-xyz/universal.router";
 
 import { ProfileScreen } from "app/screens/profile";
 
-function ProfileRouter() {
+function ProfileRouter({ fallback }: { fallback: any }) {
   const router = useRouter();
 
   useEffect(() => {
@@ -34,7 +36,11 @@ function ProfileRouter() {
     }
   }, [router]);
 
-  return <ProfileScreen />;
+  return (
+    <SWRConfig value={{ fallback }}>
+      <ProfileScreen />
+    </SWRConfig>
+  );
 }
 
 export default ProfileRouter;

--- a/packages/app/screens/nft.tsx
+++ b/packages/app/screens/nft.tsx
@@ -2,6 +2,7 @@ import { Suspense, useMemo } from "react";
 import { Dimensions, Platform, useWindowDimensions } from "react-native";
 
 import { useSharedValue } from "react-native-reanimated";
+import { SWRConfig } from "swr";
 
 import { useColorScheme } from "@showtime-xyz/universal.color-scheme";
 import {
@@ -41,7 +42,7 @@ type Query = {
 const { useParam } = createParam<Query>();
 const { height: screenHeight, width: screenWidth } = Dimensions.get("screen");
 
-function NftScreen() {
+function NftScreen({ fallback }: { fallback: any }) {
   useTrackPageViewed({ name: "NFT" });
   const { colorScheme } = useColorScheme();
   const videoConfig = useMemo(
@@ -55,35 +56,38 @@ function NftScreen() {
 
   const dummyId = 1;
   const visibileItems = useSharedValue([undefined, dummyId, undefined]);
+
   return (
     <ErrorBoundary>
-      <VideoConfigContext.Provider value={videoConfig}>
-        <ItemKeyContext.Provider value={dummyId}>
-          <ViewabilityItemsContext.Provider value={visibileItems}>
-            <Suspense
-              fallback={
-                <View tw="items-center">
-                  <Skeleton
-                    //@ts-ignore
-                    colorMode={colorScheme}
-                    height={screenHeight - 300}
-                    width={screenWidth}
-                  />
-                  <View tw="h-2" />
-                  <Skeleton
-                    //@ts-ignore
-                    colorMode={colorScheme}
-                    height={300}
-                    width={screenWidth}
-                  />
-                </View>
-              }
-            >
-              <NFTDetail />
-            </Suspense>
-          </ViewabilityItemsContext.Provider>
-        </ItemKeyContext.Provider>
-      </VideoConfigContext.Provider>
+      <SWRConfig value={{ fallback }}>
+        <VideoConfigContext.Provider value={videoConfig}>
+          <ItemKeyContext.Provider value={dummyId}>
+            <ViewabilityItemsContext.Provider value={visibileItems}>
+              <Suspense
+                fallback={
+                  <View tw="items-center">
+                    <Skeleton
+                      //@ts-ignore
+                      colorMode={colorScheme}
+                      height={screenHeight - 300}
+                      width={screenWidth}
+                    />
+                    <View tw="h-2" />
+                    <Skeleton
+                      //@ts-ignore
+                      colorMode={colorScheme}
+                      height={300}
+                      width={screenWidth}
+                    />
+                  </View>
+                }
+              >
+                <NFTDetail />
+              </Suspense>
+            </ViewabilityItemsContext.Provider>
+          </ItemKeyContext.Provider>
+        </VideoConfigContext.Provider>
+      </SWRConfig>
     </ErrorBoundary>
   );
 }


### PR DESCRIPTION
# Why

We can use the data from the server to pre-render the profiles and NFTs pages

# How

Pass `fallback` data to `getServerSideProps`: https://swr.vercel.app/docs/with-nextjs#pre-rendering-with-default-data

# Test Plan

On web, check if profiles and NFTs page are server-side rendered
