### PR TITLE
fix: mute button location

### DIFF
--- a/apps/expo/app.config.js
+++ b/apps/expo/app.config.js
@@ -108,7 +108,10 @@ export default {
   extra: {
     STAGE: STAGE,
     eas: {
-      projectId: "45cbf5d5-24fe-4aa6-9580-acf540651abd",
+      projectId:
+        STAGE === "development"
+          ? "e77d5b68-bb27-45da-aa5c-96c1fdbf6706"
+          : "45cbf5d5-24fe-4aa6-9580-acf540651abd",
     },
   },
   plugins: [

--- a/apps/expo/app.config.js
+++ b/apps/expo/app.config.js
@@ -108,10 +108,7 @@ export default {
   extra: {
     STAGE: STAGE,
     eas: {
-      projectId:
-        STAGE === "development"
-          ? "e77d5b68-bb27-45da-aa5c-96c1fdbf6706"
-          : "45cbf5d5-24fe-4aa6-9580-acf540651abd",
+      projectId: "45cbf5d5-24fe-4aa6-9580-acf540651abd",
     },
   },
   plugins: [

--- a/apps/storybook-react-native/app.config.js
+++ b/apps/storybook-react-native/app.config.js
@@ -28,6 +28,11 @@ export default {
     jsEngine: "hermes",
     backgroundColor: "#FFFFFF",
   },
+  extra: {
+    eas: {
+      projectId: "e77d5b68-bb27-45da-aa5c-96c1fdbf6706",
+    },
+  },
   android: {
     package: "io.showtime.storybook",
     versionCode: 1,

--- a/packages/app/components/feed-item/index.tsx
+++ b/packages/app/components/feed-item/index.tsx
@@ -66,7 +66,6 @@ export const FeedItem = memo<FeedItemProps>(function FeedItem({
   const { data: edition } = useCreatorCollectionDetail(
     nft.creator_airdrop_edition_address
   );
-  const [muted, setMuted] = useMuted();
 
   const blurredBackgroundStyles = useBlurredBackgroundStyles(95);
   const maxContentHeight = windowHeight - bottomHeight;
@@ -245,16 +244,7 @@ export const FeedItem = memo<FeedItemProps>(function FeedItem({
             setDetailHeight(height);
           }}
         >
-          {Platform.OS !== "web" ? (
-            <View tw="z-9 absolute top-[-40px] right-4">
-              <MuteButton
-                onPress={() => {
-                  setMuted(!muted);
-                }}
-                muted={muted}
-              />
-            </View>
-          ) : null}
+          <FeedMutedButton nft={nft} />
 
           <BlurView
             tint={tint}
@@ -276,3 +266,22 @@ export const FeedItem = memo<FeedItemProps>(function FeedItem({
   );
 });
 FeedItem.displayName = "FeedItem";
+
+const FeedMutedButton = ({ nft }: { nft: NFT }) => {
+  const [muted, setMuted] = useMuted();
+
+  if (Platform.OS !== "web" && nft?.mime_type?.startsWith("video")) {
+    return (
+      <View tw="z-9 absolute top-[-40px] right-4">
+        <MuteButton
+          onPress={() => {
+            setMuted(!muted);
+          }}
+          muted={muted}
+        />
+      </View>
+    );
+  }
+
+  return null;
+};

--- a/packages/app/components/feed-item/index.tsx
+++ b/packages/app/components/feed-item/index.tsx
@@ -27,12 +27,13 @@ import { View } from "@showtime-xyz/universal.view";
 
 import { FeedItemTapGesture } from "app/components/feed/feed-item-tap-gesture";
 import { Media } from "app/components/media";
-import { MuteButtonOffsetProvider } from "app/components/mute-button/mute-button";
+import { MuteButton } from "app/components/mute-button/mute-button";
 import { LikeContextProvider } from "app/context/like-context";
 import { useCreatorCollectionDetail } from "app/hooks/use-creator-collection-detail";
 import { usePlatformBottomHeight } from "app/hooks/use-platform-bottom-height";
 import { Blurhash } from "app/lib/blurhash";
 import { useNavigation } from "app/lib/react-navigation/native";
+import { useMuted } from "app/providers/mute-provider";
 import type { NFT } from "app/types";
 import { getMediaUrl } from "app/utilities";
 
@@ -65,6 +66,8 @@ export const FeedItem = memo<FeedItemProps>(function FeedItem({
   const { data: edition } = useCreatorCollectionDetail(
     nft.creator_airdrop_edition_address
   );
+  const [muted, setMuted] = useMuted();
+
   const blurredBackgroundStyles = useBlurredBackgroundStyles(95);
   const maxContentHeight = windowHeight - bottomHeight;
 
@@ -167,11 +170,6 @@ export const FeedItem = memo<FeedItemProps>(function FeedItem({
     return <FeedItemMD nft={nft} itemHeight={itemHeight} />;
   }
 
-  const mediaEndY =
-    (itemHeight - bottomPadding - mediaHeight) / 2 + mediaHeight;
-  const detailStartY = itemHeight - bottomMargin - detailHeight;
-  const muteButtonOffsetY = mediaEndY - detailStartY;
-
   return (
     <LikeContextProvider nft={nft} key={nft.nft_id}>
       <View tw="w-full" style={{ height: itemHeight }}>
@@ -215,26 +213,20 @@ export const FeedItem = memo<FeedItemProps>(function FeedItem({
               contentStyle,
             ]}
           >
-            <MuteButtonOffsetProvider
-              bottomOffset={
-                !isNaN(muteButtonOffsetY) ? muteButtonOffsetY + 10 : 0
-              }
-            >
-              <Media
-                item={nft}
-                numColumns={1}
-                sizeStyle={{
-                  height: mediaHeight,
-                  width: windowWidth,
-                }}
-                resizeMode={Platform.select({
-                  web: "contain",
-                  default: "cover",
-                })}
-                onPinchStart={hideHeader}
-                onPinchEnd={showHeader}
-              />
-            </MuteButtonOffsetProvider>
+            <Media
+              item={nft}
+              numColumns={1}
+              sizeStyle={{
+                height: mediaHeight,
+                width: windowWidth,
+              }}
+              resizeMode={Platform.select({
+                web: "contain",
+                default: "cover",
+              })}
+              onPinchStart={hideHeader}
+              onPinchEnd={showHeader}
+            />
           </Animated.View>
         </FeedItemTapGesture>
 
@@ -253,6 +245,17 @@ export const FeedItem = memo<FeedItemProps>(function FeedItem({
             setDetailHeight(height);
           }}
         >
+          {Platform.OS !== "web" ? (
+            <View tw="z-9 absolute top-[-40px] right-4">
+              <MuteButton
+                onPress={() => {
+                  setMuted(!muted);
+                }}
+                muted={muted}
+              />
+            </View>
+          ) : null}
+
           <BlurView
             tint={tint}
             intensity={100}

--- a/packages/app/components/mute-button/mute-button.tsx
+++ b/packages/app/components/mute-button/mute-button.tsx
@@ -1,4 +1,3 @@
-import { createContext, useContext } from "react";
 import { Platform, Pressable, StyleSheet } from "react-native";
 
 import { Muted, Unmuted } from "@showtime-xyz/universal.icon";
@@ -43,25 +42,3 @@ const muteButtonStyle = StyleSheet.create({
     padding: 4,
   },
 });
-
-const MuteButtonOffsetContext = createContext({
-  bottomOffset: 10,
-});
-
-export const MuteButtonOffsetProvider = ({
-  bottomOffset,
-  children,
-}: {
-  bottomOffset: number;
-  children: any;
-}) => {
-  return (
-    <MuteButtonOffsetContext.Provider value={{ bottomOffset }}>
-      {children}
-    </MuteButtonOffsetContext.Provider>
-  );
-};
-
-export const useMuteButtonBottomOffset = () => {
-  return useContext(MuteButtonOffsetContext).bottomOffset;
-};

--- a/packages/app/components/mute-button/mute-button.tsx
+++ b/packages/app/components/mute-button/mute-button.tsx
@@ -10,7 +10,7 @@ export const MuteButton = ({
   muted,
   onPress,
 }: {
-  muted: boolean;
+  muted?: boolean;
   onPress: () => void;
 }) => {
   return (

--- a/packages/app/hooks/use-viewability-mount.ts
+++ b/packages/app/hooks/use-viewability-mount.ts
@@ -7,8 +7,7 @@ import {
   ItemKeyContext,
   ViewabilityItemsContext,
 } from "app/components/viewability-tracker-flatlist";
-
-import { useIsTabFocused } from "design-system/tabs/tablib";
+import { useIsFocused } from "app/lib/react-navigation/native";
 
 export const useViewabilityMount = ({
   videoRef,
@@ -23,7 +22,7 @@ export const useViewabilityMount = ({
   const context = useContext(ViewabilityItemsContext);
   const isItemInList = typeof id !== "undefined";
   const loaded = useRef(false);
-  let isListFocused = useIsTabFocused();
+  let isScreenFocused = useIsFocused();
 
   const loadPlayOrPause = useCallback(
     async (shouldPlay: boolean) => {
@@ -56,14 +55,21 @@ export const useViewabilityMount = ({
   // we mount or unmount the Video depending on the focus state
   useEffect(() => {
     if (isItemInList) {
-      if (!isListFocused) {
+      if (!isScreenFocused) {
         unload();
       } else if (context.value.includes(id)) {
         const shouldPlay = context.value[1] === id;
         loadPlayOrPause(shouldPlay);
       }
     }
-  }, [isItemInList, unload, isListFocused, id, context.value, loadPlayOrPause]);
+  }, [
+    isItemInList,
+    unload,
+    isScreenFocused,
+    id,
+    context.value,
+    loadPlayOrPause,
+  ]);
 
   useAnimatedReaction(
     () => context.value,

--- a/packages/app/providers/mute-provider.tsx
+++ b/packages/app/providers/mute-provider.tsx
@@ -6,9 +6,8 @@ import {
   SetStateAction,
 } from "react";
 
-export const MuteContext = createContext(
-  null as [boolean, Dispatch<SetStateAction<boolean>>] | null
-);
+export const MuteContext = createContext([true, () => {}] as
+  | [boolean, Dispatch<SetStateAction<boolean>>]);
 
 export const MuteProvider = ({ children }: { children: any }) => {
   const values = useState(true);

--- a/packages/design-system/video/index.tsx
+++ b/packages/design-system/video/index.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps, useRef, useState } from "react";
+import { ComponentProps, useRef } from "react";
 import { StyleSheet, Text } from "react-native";
 
 import { Video as ExpoVideo, ResizeMode } from "expo-av";
@@ -8,8 +8,6 @@ import { Image } from "@showtime-xyz/universal.image";
 import type { TW } from "@showtime-xyz/universal.tailwind";
 import { View } from "@showtime-xyz/universal.view";
 
-import { MuteButton } from "app/components/mute-button";
-import { useMuteButtonBottomOffset } from "app/components/mute-button/mute-button";
 import { useVideoConfig } from "app/context/video-config-context";
 import { useViewabilityMount } from "app/hooks/use-viewability-mount";
 import { useMuted } from "app/providers/mute-provider";
@@ -20,33 +18,16 @@ type VideoProps = {
   showMuteButton?: boolean;
 } & ComponentProps<typeof ExpoVideo>;
 
-function Video({
-  tw,
-  blurhash,
-  style,
-  posterSource,
-  showMuteButton,
-  ...props
-}: VideoProps) {
+function Video({ tw, blurhash, style, posterSource, ...props }: VideoProps) {
   const videoRef = useRef<ExpoVideo>(null);
   const videoConfig = useVideoConfig();
-  const mutedContext = useMuted();
-  const [muted, setMuted] = useState(true);
-  const isMuted = mutedContext ? mutedContext[0] : muted;
+  const [muted] = useMuted();
 
   const { id } = useViewabilityMount({
     videoRef,
     source: props.source,
-    isMuted,
+    isMuted: muted,
   });
-  const bottomOffset = useMuteButtonBottomOffset();
-  const handleMuteChange = () => {
-    if (mutedContext) {
-      mutedContext[1](!isMuted);
-    } else {
-      setMuted(!isMuted);
-    }
-  };
 
   return (
     <>
@@ -75,19 +56,8 @@ function Video({
               useNativeControls={videoConfig?.useNativeControls}
               resizeMode={ResizeMode.COVER}
               posterSource={posterSource}
-              isMuted={isMuted}
+              isMuted={muted}
             />
-            {showMuteButton ? (
-              <View
-                style={{
-                  bottom: bottomOffset,
-                  right: 10,
-                  position: "absolute",
-                }}
-              >
-                <MuteButton onPress={handleMuteChange} muted={isMuted} />
-              </View>
-            ) : null}
           </>
         )}
 

--- a/packages/design-system/video/index.web.tsx
+++ b/packages/design-system/video/index.web.tsx
@@ -1,10 +1,5 @@
 import { ComponentProps, useRef, useState } from "react";
-import {
-  StyleSheet,
-  ImageBackground,
-  ImageSourcePropType,
-  View,
-} from "react-native";
+import { StyleSheet, ImageBackground, ImageSourcePropType } from "react-native";
 
 import { Video as ExpoVideo } from "expo-av/src";
 import { BlurView, BlurTint } from "expo-blur";
@@ -14,6 +9,7 @@ import { useColorScheme } from "@showtime-xyz/universal.color-scheme";
 import { Image } from "@showtime-xyz/universal.image";
 import type { TW } from "@showtime-xyz/universal.tailwind";
 import { tw as tailwind } from "@showtime-xyz/universal.tailwind";
+import { View } from "@showtime-xyz/universal.view";
 
 import { MuteButton } from "app/components/mute-button";
 import { useVideoConfig } from "app/context/video-config-context";
@@ -80,13 +76,7 @@ export function Video({
             videoStyle={tailwind.style("relative")}
             {...props}
           />
-          <View
-            style={{
-              bottom: 10,
-              right: 10,
-              position: "absolute",
-            }}
-          >
+          <View tw="absolute bottom-12 right-5 md:bottom-2">
             <MuteButton onPress={() => setMuted(!muted)} muted={muted} />
           </View>
         </ImageBackground>


### PR DESCRIPTION
# Why
- Mute button hidden bug reappeared. 
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- Moved it to the feed item so it's always placed on top of detail section.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Mute button should not be hidden on native

# Aside
- I think we need to unify feed item NFT across web, android and iOS. Make it same as iOS. Will work on it after deciding the priority. This will make it much easier to modify stuff and improve viewing experience on web and android
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
