### PR TITLE
fix: image overflowing on web mobile feed

### DIFF
--- a/packages/app/components/feed-item/index.tsx
+++ b/packages/app/components/feed-item/index.tsx
@@ -170,7 +170,7 @@ export const FeedItem = memo<FeedItemProps>(function FeedItem({
 
   return (
     <LikeContextProvider nft={nft} key={nft.nft_id}>
-      <View tw="w-full" style={{ height: itemHeight }}>
+      <View tw="w-full" style={{ height: itemHeight, overflow: "hidden" }}>
         {Platform.OS !== "web" && (
           <View>
             {nft.blurhash ? (


### PR DESCRIPTION
# Why
when image has more height, it overflows the card. It started happening after migrating to infinite query list from recyclerlist in this PR - https://github.com/showtime-xyz/showtime-frontend/pull/1436/files#diff-0e853deae0c6f7d92cf02e2874311dfb730a8c716c0733345be4903ba10e808eL1

<img width="414" alt="Screenshot 2022-08-26 at 4 31 21 PM" src="https://user-images.githubusercontent.com/23293248/186889857-aa155bfa-9ca7-49ec-b87e-bedcb138365e.png">

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- Add overflow hidden
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Test images are not overflowing card on mobile web
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
