### PR TITLE
fix: creator NFT API throwing error

### DIFF
--- a/.github/workflows/upload-build-to-waldo.yml
+++ b/.github/workflows/upload-build-to-waldo.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           DERIVED_DATA_PATH=/tmp/Showtime-$(uuidgen)
 
-          cd ios/ && FLIPPER_DISABLE=1 STAGE=development xcodebuild -workspace Showtime.xcworkspace    \
+          cd ios/ && E2E=true FLIPPER_DISABLE=1 STAGE=development xcodebuild -workspace Showtime.xcworkspace    \
                      -scheme Showtime                              \
                      -configuration Release                        \
                      -sdk iphonesimulator                          \

--- a/packages/app/components/creator-preview/index.tsx
+++ b/packages/app/components/creator-preview/index.tsx
@@ -72,7 +72,7 @@ export const CreatorPreview = withMemoAndColorScheme((props: Props) => {
         </View>
       </View>
       <View tw="mx-[-1px] mt-4 flex-row justify-center">
-        {props.creator.top_items.slice(0, 3).map((item, idx) => {
+        {props.creator.top_items?.slice(0, 3).map((item, idx) => {
           return (
             <Pressable
               key={item.nft_id}

--- a/packages/app/hooks/use-wallet/use-random-wallet.ts
+++ b/packages/app/hooks/use-wallet/use-random-wallet.ts
@@ -8,9 +8,12 @@ import { delay } from "app/utilities";
 import type { UseWalletReturnType } from "./types";
 
 let wallet: ethers.Wallet;
+async function initialiseRandomWallet() {
+  wallet = await getWallet();
+}
 // Only create wallet if E2E. imp. creating wallet can be a costly operation
 if (process.env.E2E) {
-  wallet = getWallet();
+  initialiseRandomWallet();
 }
 
 let connected = false;

--- a/packages/app/lib/random-wallet/random-wallet.ts
+++ b/packages/app/lib/random-wallet/random-wallet.ts
@@ -1,4 +1,4 @@
-export const getWallet = () => {
-  const ethers = require("ethers");
-  return ethers.Wallet.createRandom();
+export const getWallet = async () => {
+  const wallet = (await import("@ethersproject/wallet")).Wallet.createRandom();
+  return wallet;
 };

--- a/packages/app/types.ts
+++ b/packages/app/types.ts
@@ -60,7 +60,7 @@ export type Creator = {
   img_url?: string;
   love_count: number;
   verified: number;
-  top_items: NFT[];
+  top_items?: NFT[];
 };
 
 export interface WalletAddressesV2 {


### PR DESCRIPTION
# Why
- creator NFTs API is not returning `top_items` which leads to an error on web. Saw this error on dev, prod seems to be fine
- lazy load random wallet
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->


<!--
How did you build this feature or fix this bug and why?
-->


<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
