### PR TITLE
fix: use netinfo replace to expo-network

### DIFF
--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -157,7 +157,6 @@
     "expo-linking": "~3.2.2",
     "expo-modules-core": "0.11.3",
     "expo-navigation-bar": "~1.3.0",
-    "expo-network": "~4.3.0",
     "expo-next-react-navigation": "^2.0.2",
     "expo-notifications": "~0.16.1",
     "expo-splash-screen": "~0.16.2",

--- a/packages/app/hooks/use-is-online.tsx
+++ b/packages/app/hooks/use-is-online.tsx
@@ -1,0 +1,21 @@
+import { useEffect, useState } from "react";
+
+import NetInfo from "@react-native-community/netinfo";
+
+export const useIsOnline = () => {
+  const [isOnline, setIsOnlie] = useState(true);
+  useEffect(() => {
+    NetInfo.fetch().then((s) => {
+      setIsOnlie(!!s.isConnected && !!s.isInternetReachable);
+    });
+
+    const unsubscribe = NetInfo.addEventListener((s) => {
+      setIsOnlie(!!s.isConnected && !!s.isInternetReachable);
+    });
+
+    return unsubscribe;
+  }, []);
+  return {
+    isOnline,
+  };
+};

--- a/packages/app/hooks/use-network-connection.tsx
+++ b/packages/app/hooks/use-network-connection.tsx
@@ -1,21 +1,20 @@
 import { useEffect } from "react";
 
-import * as Network from "expo-network";
-
 import { useSafeAreaInsets } from "@showtime-xyz/universal.safe-area";
 import { useSnackbar } from "@showtime-xyz/universal.snackbar";
 
 import { useIsForeground } from "./use-is-foreground";
+import { useIsOnline } from "./use-is-online";
 
 export const useNetWorkConnection = () => {
   const { bottom } = useSafeAreaInsets();
   const isForeground = useIsForeground();
   const snackbar = useSnackbar();
+  const { isOnline } = useIsOnline();
 
   useEffect(() => {
     const getNetwork = async () => {
-      const { isConnected } = await Network.getNetworkStateAsync();
-      if (isConnected) return;
+      if (isOnline) return;
       snackbar?.show({
         text: `No internet connection`,
         bottom: bottom + 64,

--- a/packages/app/providers/swr-provider.tsx
+++ b/packages/app/providers/swr-provider.tsx
@@ -72,7 +72,6 @@ export const SWRProvider = ({
           ) {
             return;
           }
-          console.log(error.status, "status");
 
           if (error.status === 404) {
             return;

--- a/packages/app/providers/swr-provider.tsx
+++ b/packages/app/providers/swr-provider.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useRef } from "react";
 import { AppState, AppStateStatus } from "react-native";
 
 import NetInfo from "@react-native-community/netinfo";
@@ -10,6 +9,7 @@ import type { PublicConfiguration } from "swr/dist/types";
 import { useToast } from "@showtime-xyz/universal.toast";
 
 import { useAccessTokenManager } from "app/hooks/auth/use-access-token-manager";
+import { useIsOnline } from "app/hooks/use-is-online";
 import { isUndefined } from "app/lib/swr/helper";
 
 function mmkvProvider() {
@@ -32,19 +32,7 @@ export const SWRProvider = ({
 }): JSX.Element => {
   const toast = useToast();
   const { refreshTokens } = useAccessTokenManager();
-  const isOnline = useRef<boolean>(true);
-
-  useEffect(() => {
-    NetInfo.fetch().then((s) => {
-      isOnline.current = !!s.isConnected && !!s.isInternetReachable;
-    });
-
-    const unsubscribe = NetInfo.addEventListener((s) => {
-      isOnline.current = !!s.isConnected && !!s.isInternetReachable;
-    });
-
-    return unsubscribe;
-  }, []);
+  const { isOnline } = useIsOnline();
 
   return (
     <SWRConfig
@@ -84,6 +72,7 @@ export const SWRProvider = ({
           ) {
             return;
           }
+          console.log(error.status, "status");
 
           if (error.status === 404) {
             return;
@@ -99,7 +88,7 @@ export const SWRProvider = ({
           return AppState.currentState === "active";
         },
         isOnline: () => {
-          return isOnline.current;
+          return isOnline;
         },
         // TODO: tab focus too
         initFocus(callback) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8255,7 +8255,6 @@ __metadata:
     expo-linking: ~3.2.2
     expo-modules-core: 0.11.3
     expo-navigation-bar: ~1.3.0
-    expo-network: ~4.3.0
     expo-next-react-navigation: ^2.0.2
     expo-notifications: ~0.16.1
     expo-splash-screen: ~0.16.2
@@ -19129,15 +19128,6 @@ __metadata:
   dependencies:
     lodash.get: ^4.4.2
   checksum: 4d979266fb5b90a78dc1317b8004d6f43088393decb311c91e3426e8e408a9fc474e51969469e0d8dc875042829141eeb342e297c405bab8f0d11c55d80a89c2
-  languageName: node
-  linkType: hard
-
-"expo-network@npm:~4.3.0":
-  version: 4.3.0
-  resolution: "expo-network@npm:4.3.0"
-  peerDependencies:
-    expo: "*"
-  checksum: 62297a922d3954004264ba0839fb6c941749921a0d6ea8811502b3038e85185d061356028817c50095810f42c895f50c3057228cd34d1b80b157501b54f97069
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Why

`expo-network` does not work, so just use `@react-native-community/netinfo` to replace `expo-network`

# How

- add `useIsOnline` hooks, and show snackbar when `isOnline` is `false`.

# Test Plan

- check if the `useIsOnline` hooks is works.
