### PR TITLE
fix: NextJS scroll restoration not working with virtuoso

### DIFF
--- a/apps/next/next.config.js
+++ b/apps/next/next.config.js
@@ -88,6 +88,7 @@ const nextConfig = {
     forceSwcTransforms: true,
     // concurrentFeatures: true,
     // nextScriptWorkers: true,
+    scrollRestoration: true,
     swcPlugins: [[require.resolve("./plugins/swc_plugin_reanimated.wasm")]],
   },
   typescript: {

--- a/apps/next/package.json
+++ b/apps/next/package.json
@@ -36,7 +36,7 @@
     "ethers": "^5.7.0",
     "fortmatic": "^2.2.1",
     "logrocket": "^2.2.1",
-    "next": "12.2.3-canary.2",
+    "next": "12.2.5",
     "next-fonts": "^1.5.1",
     "next-images": "^1.8.2",
     "next-transpile-modules": "^9.0.0",

--- a/apps/next/src/pages/_document.tsx
+++ b/apps/next/src/pages/_document.tsx
@@ -26,7 +26,6 @@ html, body, #__next {
   flex: 1;
 }
 html {
-  scroll-behavior: smooth;
   /* Prevent text size change on orientation change https://gist.github.com/tfausak/2222823#file-ios-8-web-app-html-L138 */
   -webkit-text-size-adjust: 100%;
   height: 100%;

--- a/apps/storybook-react/package.json
+++ b/apps/storybook-react/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "design-system": "*",
-    "next": "12.2.3-canary.2",
+    "next": "12.2.5",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-native-web": "0.18.7"

--- a/packages/design-system/infinite-scroll-list/infinite-scroll-list.web.tsx
+++ b/packages/design-system/infinite-scroll-list/infinite-scroll-list.web.tsx
@@ -3,7 +3,6 @@ import React, {
   useMemo,
   useRef,
   useEffect,
-  useState,
   MutableRefObject,
 } from "react";
 
@@ -128,12 +127,10 @@ export function VirtuosoListComponent<T>(
     onViewableItemsChanged,
     gridItemProps = {},
     viewabilityConfig,
-    estimatedItemSize,
   }: InfiniteScrollListWebProps<T>,
   ref: React.Ref<VirtuosoHandle> | React.Ref<VirtuosoGridHandle>
 ) {
   const viewableItems = useRef<ViewToken[]>([]);
-  const [listItemHeight, setListItemHeight] = useState(0);
 
   const renderItemContent = React.useCallback(
     (index: number) => {
@@ -186,27 +183,6 @@ export function VirtuosoListComponent<T>(
     [ItemSeparatorComponent, gridItemProps, numColumns]
   );
 
-  const styleWithMinHeight = useMemo(() => {
-    let minHeight = 0;
-    if (listItemHeight) {
-      minHeight = listItemHeight;
-    }
-    if (estimatedItemSize && data) {
-      minHeight = estimatedItemSize * data.length;
-    }
-
-    if (typeof style === "object") {
-      return {
-        minHeight: `${minHeight}px`,
-        ...style,
-      };
-    } else {
-      return {
-        minHeight: `${minHeight}px`,
-      };
-    }
-  }, [style, data, estimatedItemSize, listItemHeight]);
-
   if (data?.length === 0) {
     return renderComponent(ListEmptyComponent);
   }
@@ -218,7 +194,6 @@ export function VirtuosoListComponent<T>(
         <Virtuoso
           useWindowScroll={useWindowScroll}
           data={data ?? []}
-          defaultItemHeight={estimatedItemSize}
           endReached={onEndReached}
           itemContent={renderItemContent}
           components={{
@@ -226,8 +201,7 @@ export function VirtuosoListComponent<T>(
             Footer: () => renderComponent(ListFooterComponent),
           }}
           overscan={overscan}
-          style={styleWithMinHeight as CSSProperties}
-          totalListHeightChanged={setListItemHeight}
+          style={style as CSSProperties}
           ref={ref as React.Ref<VirtuosoHandle>}
         />
       ) : (

--- a/patches/next+12.2.5.patch
+++ b/patches/next+12.2.5.patch
@@ -1,0 +1,15 @@
+diff --git a/node_modules/next/dist/client/index.js b/node_modules/next/dist/client/index.js
+index 6fd8568..9d98ec5 100644
+--- a/node_modules/next/dist/client/index.js
++++ b/node_modules/next/dist/client/index.js
+@@ -693,7 +693,9 @@ function doRender(input) {
+             });
+         }
+         if (input.scroll) {
+-            window.scrollTo(input.scroll.x, input.scroll.y);
++            setTimeout(() => {
++                window.scrollTo(input.scroll.x, input.scroll.y);
++            }, 50)
+         }
+     }
+     function onRootCommit() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5211,6 +5211,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/env@npm:12.2.5":
+  version: 12.2.5
+  resolution: "@next/env@npm:12.2.5"
+  checksum: a44939e59b46d5951831529a43dba9daa2e4e467e8680ea96e21ae127d1bf7f11757aaf3a6cff8a51273abfe7af782903e1304405a481361c7ba3e66d47e3238
+  languageName: node
+  linkType: hard
+
 "@next/eslint-plugin-next@npm:12.2.0":
   version: 12.2.0
   resolution: "@next/eslint-plugin-next@npm:12.2.0"
@@ -5227,9 +5234,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/swc-android-arm-eabi@npm:12.2.5":
+  version: 12.2.5
+  resolution: "@next/swc-android-arm-eabi@npm:12.2.5"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@next/swc-android-arm64@npm:12.2.3-canary.2":
   version: 12.2.3-canary.2
   resolution: "@next/swc-android-arm64@npm:12.2.3-canary.2"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@next/swc-android-arm64@npm:12.2.5":
+  version: 12.2.5
+  resolution: "@next/swc-android-arm64@npm:12.2.5"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -5241,9 +5262,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/swc-darwin-arm64@npm:12.2.5":
+  version: 12.2.5
+  resolution: "@next/swc-darwin-arm64@npm:12.2.5"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@next/swc-darwin-x64@npm:12.2.3-canary.2":
   version: 12.2.3-canary.2
   resolution: "@next/swc-darwin-x64@npm:12.2.3-canary.2"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@next/swc-darwin-x64@npm:12.2.5":
+  version: 12.2.5
+  resolution: "@next/swc-darwin-x64@npm:12.2.5"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -5255,9 +5290,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/swc-freebsd-x64@npm:12.2.5":
+  version: 12.2.5
+  resolution: "@next/swc-freebsd-x64@npm:12.2.5"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@next/swc-linux-arm-gnueabihf@npm:12.2.3-canary.2":
   version: 12.2.3-canary.2
   resolution: "@next/swc-linux-arm-gnueabihf@npm:12.2.3-canary.2"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@next/swc-linux-arm-gnueabihf@npm:12.2.5":
+  version: 12.2.5
+  resolution: "@next/swc-linux-arm-gnueabihf@npm:12.2.5"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
@@ -5269,9 +5318,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/swc-linux-arm64-gnu@npm:12.2.5":
+  version: 12.2.5
+  resolution: "@next/swc-linux-arm64-gnu@npm:12.2.5"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@next/swc-linux-arm64-musl@npm:12.2.3-canary.2":
   version: 12.2.3-canary.2
   resolution: "@next/swc-linux-arm64-musl@npm:12.2.3-canary.2"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@next/swc-linux-arm64-musl@npm:12.2.5":
+  version: 12.2.5
+  resolution: "@next/swc-linux-arm64-musl@npm:12.2.5"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
@@ -5283,9 +5346,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/swc-linux-x64-gnu@npm:12.2.5":
+  version: 12.2.5
+  resolution: "@next/swc-linux-x64-gnu@npm:12.2.5"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@next/swc-linux-x64-musl@npm:12.2.3-canary.2":
   version: 12.2.3-canary.2
   resolution: "@next/swc-linux-x64-musl@npm:12.2.3-canary.2"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@next/swc-linux-x64-musl@npm:12.2.5":
+  version: 12.2.5
+  resolution: "@next/swc-linux-x64-musl@npm:12.2.5"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
@@ -5297,6 +5374,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/swc-win32-arm64-msvc@npm:12.2.5":
+  version: 12.2.5
+  resolution: "@next/swc-win32-arm64-msvc@npm:12.2.5"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@next/swc-win32-ia32-msvc@npm:12.2.3-canary.2":
   version: 12.2.3-canary.2
   resolution: "@next/swc-win32-ia32-msvc@npm:12.2.3-canary.2"
@@ -5304,9 +5388,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/swc-win32-ia32-msvc@npm:12.2.5":
+  version: 12.2.5
+  resolution: "@next/swc-win32-ia32-msvc@npm:12.2.5"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@next/swc-win32-x64-msvc@npm:12.2.3-canary.2":
   version: 12.2.3-canary.2
   resolution: "@next/swc-win32-x64-msvc@npm:12.2.3-canary.2"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@next/swc-win32-x64-msvc@npm:12.2.5":
+  version: 12.2.5
+  resolution: "@next/swc-win32-x64-msvc@npm:12.2.5"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -8370,7 +8468,7 @@ __metadata:
     ethers: ^5.7.0
     fortmatic: ^2.2.1
     logrocket: ^2.2.1
-    next: 12.2.3-canary.2
+    next: 12.2.5
     next-compose-plugins: ^2.2.1
     next-fonts: ^1.5.1
     next-images: ^1.8.2
@@ -8483,7 +8581,7 @@ __metadata:
     design-system: "*"
     eslint: 7
     eslint-config-next: ^12.2.0
-    next: 12.2.3-canary.2
+    next: 12.2.5
     path-browserify: ^1.0.1
     postcss: ^8.4.16
     react: 18.2.0
@@ -26185,6 +26283,75 @@ __metadata:
   languageName: node
   linkType: hard
 
+"next@npm:12.2.5":
+  version: 12.2.5
+  resolution: "next@npm:12.2.5"
+  dependencies:
+    "@next/env": 12.2.5
+    "@next/swc-android-arm-eabi": 12.2.5
+    "@next/swc-android-arm64": 12.2.5
+    "@next/swc-darwin-arm64": 12.2.5
+    "@next/swc-darwin-x64": 12.2.5
+    "@next/swc-freebsd-x64": 12.2.5
+    "@next/swc-linux-arm-gnueabihf": 12.2.5
+    "@next/swc-linux-arm64-gnu": 12.2.5
+    "@next/swc-linux-arm64-musl": 12.2.5
+    "@next/swc-linux-x64-gnu": 12.2.5
+    "@next/swc-linux-x64-musl": 12.2.5
+    "@next/swc-win32-arm64-msvc": 12.2.5
+    "@next/swc-win32-ia32-msvc": 12.2.5
+    "@next/swc-win32-x64-msvc": 12.2.5
+    "@swc/helpers": 0.4.3
+    caniuse-lite: ^1.0.30001332
+    postcss: 8.4.14
+    styled-jsx: 5.0.4
+    use-sync-external-store: 1.2.0
+  peerDependencies:
+    fibers: ">= 3.1.0"
+    node-sass: ^6.0.0 || ^7.0.0
+    react: ^17.0.2 || ^18.0.0-0
+    react-dom: ^17.0.2 || ^18.0.0-0
+    sass: ^1.3.0
+  dependenciesMeta:
+    "@next/swc-android-arm-eabi":
+      optional: true
+    "@next/swc-android-arm64":
+      optional: true
+    "@next/swc-darwin-arm64":
+      optional: true
+    "@next/swc-darwin-x64":
+      optional: true
+    "@next/swc-freebsd-x64":
+      optional: true
+    "@next/swc-linux-arm-gnueabihf":
+      optional: true
+    "@next/swc-linux-arm64-gnu":
+      optional: true
+    "@next/swc-linux-arm64-musl":
+      optional: true
+    "@next/swc-linux-x64-gnu":
+      optional: true
+    "@next/swc-linux-x64-musl":
+      optional: true
+    "@next/swc-win32-arm64-msvc":
+      optional: true
+    "@next/swc-win32-ia32-msvc":
+      optional: true
+    "@next/swc-win32-x64-msvc":
+      optional: true
+  peerDependenciesMeta:
+    fibers:
+      optional: true
+    node-sass:
+      optional: true
+    sass:
+      optional: true
+  bin:
+    next: dist/bin/next
+  checksum: e8fcbd93d74fda81640fd174a9d380f22db404d3ce0893730db3db806317ae18c86d1dbb502e63e47c92fb21a93812de62639c2f1204330cb569fdac4d3d0573
+  languageName: node
+  linkType: hard
+
 "nice-try@npm:^1.0.4":
   version: 1.0.5
   resolution: "nice-try@npm:1.0.5"
@@ -32933,6 +33100,20 @@ __metadata:
     babel-plugin-macros:
       optional: true
   checksum: 86d55819ebeabd283a574d2f44f7d3f8fa6b8c28fa41687ece161bf1e910e04965611618921d8f5cd33dc6dae1033b926a70421ae5ea045440a9861edc3e0d87
+  languageName: node
+  linkType: hard
+
+"styled-jsx@npm:5.0.4":
+  version: 5.0.4
+  resolution: "styled-jsx@npm:5.0.4"
+  peerDependencies:
+    react: ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+  peerDependenciesMeta:
+    "@babel/core":
+      optional: true
+    babel-plugin-macros:
+      optional: true
+  checksum: db7530155626e5eebc9d80ca117ea5aed6219b0a65469196b0b5727550fbe743117d7eea1499d80511ccb312d31f4a1027a58d1f94a83f0986c9acfdcce8bdd1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Why
- NextJS supports an experimental flag to enable scrollRestoration on pop state in browser.

# Root cause
- NextJS stores scroll positions in session storage and restores on router pop. Virtuoso does height calculation in async manner. There are props `defaultItemHeight` and `fixedItemHeight` supported by Virtuoso so my initial guess was `defaultItemHeight` will add initial height synchronously and will do async recalculation but this doesn't seem to be working. We should avoid using `fixedItemHeight` imo. Also, both of these props are not supported in VirtuosoGrid. 

Minimal demo - https://stackblitz.com/edit/nextjs-ayrjzn?file=pages/index.js
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- Hacky setTimeout when Next does scroll restoration.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Test scroll restores on pressing back button
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
