### PR TITLE
fix: share drop on twitter crash

### DIFF
--- a/packages/app/components/drop/drop-form.tsx
+++ b/packages/app/components/drop/drop-form.tsx
@@ -219,7 +219,7 @@ export const DropForm = () => {
 
           <Button
             onPress={() => {
-              track("Drop Shared", { type: "Twitter" });
+              rudder?.track("Drop Shared", { type: "Twitter" });
               Linking.openURL(
                 getTwitterIntent({
                   url: claimUrl,


### PR DESCRIPTION
# Why

https://showtime-rq88331.slack.com/archives/C02PXGK3V8D/p1662167414652279
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->
# Test Plan
- Tapping sharing on twitter after drop creation shouldn't crash the app
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
