### PR TITLE
feat: add renderabsolutebackgroundcontent

### DIFF
--- a/packages/design-system/collapsible-tab-view/gesture-container.ios.tsx
+++ b/packages/design-system/collapsible-tab-view/gesture-container.ios.tsx
@@ -59,6 +59,7 @@ export const GestureContainer = React.forwardRef<
     initHeaderHeight = 0,
     renderScrollHeader,
     renderAbsoluteBackgroundContent,
+    renderAbsoluteForegroundContent,
     renderTabView,
     renderRefreshControl: renderRefreshControlProp,
     animationHeaderPosition,
@@ -701,12 +702,12 @@ export const GestureContainer = React.forwardRef<
       }}
     >
       <GestureDetector gesture={gestureHandler}>
-        {!!renderAbsoluteBackgroundContent && (
-          <View style={styles.absoluteBackground}>
-            {renderAbsoluteBackgroundContent(translateYValue)}
-          </View>
-        )}
         <Animated.View style={[styles.container, opacityStyle]}>
+          {!!renderAbsoluteBackgroundContent && (
+            <View style={styles.absoluteBackground}>
+              {renderAbsoluteBackgroundContent(translateYValue)}
+            </View>
+          )}
           <Animated.View
             style={[styles.container, animateStyle]}
             onLayout={containerOnLayout}
@@ -717,6 +718,11 @@ export const GestureContainer = React.forwardRef<
             })}
           </Animated.View>
           {renderRefreshControl()}
+          {!!renderAbsoluteForegroundContent && (
+            <View style={styles.absoluteBackground}>
+              {renderAbsoluteForegroundContent()}
+            </View>
+          )}
         </Animated.View>
       </GestureDetector>
     </HeaderTabContext.Provider>

--- a/packages/design-system/collapsible-tab-view/gesture-container.ios.tsx
+++ b/packages/design-system/collapsible-tab-view/gesture-container.ios.tsx
@@ -58,6 +58,7 @@ export const GestureContainer = React.forwardRef<
     initTabbarHeight = 49,
     initHeaderHeight = 0,
     renderScrollHeader,
+    renderAbsoluteBackgroundContent,
     renderTabView,
     renderRefreshControl: renderRefreshControlProp,
     animationHeaderPosition,
@@ -615,7 +616,9 @@ export const GestureContainer = React.forwardRef<
         <GestureDetector gesture={gestureHandlerHeader}>
           <Animated.View style={styles.container}>
             {renderScrollHeader && (
-              <View onLayout={headerOnLayout}>{renderScrollHeader()}</View>
+              <View onLayout={headerOnLayout}>
+                {renderScrollHeader(translateYValue)}
+              </View>
             )}
             {navigationState?.routes.length === 0 && emptyBodyComponent ? (
               <View style={{ marginTop: tabbarHeight }}>
@@ -698,6 +701,11 @@ export const GestureContainer = React.forwardRef<
       }}
     >
       <GestureDetector gesture={gestureHandler}>
+        {!!renderAbsoluteBackgroundContent && (
+          <View style={styles.absoluteBackground}>
+            {renderAbsoluteBackgroundContent(translateYValue)}
+          </View>
+        )}
         <Animated.View style={[styles.container, opacityStyle]}>
           <Animated.View
             style={[styles.container, animateStyle]}
@@ -725,5 +733,10 @@ const styles = StyleSheet.create({
     position: "absolute",
     right: 0,
     zIndex: 10,
+  },
+  absoluteBackground: {
+    position: "absolute",
+    top: 0,
+    width: "100%",
   },
 });

--- a/packages/design-system/collapsible-tab-view/gesture-container.tsx
+++ b/packages/design-system/collapsible-tab-view/gesture-container.tsx
@@ -58,6 +58,7 @@ export const GestureContainer = React.forwardRef<
     initHeaderHeight = 0,
     renderScrollHeader,
     renderAbsoluteBackgroundContent,
+    renderAbsoluteForegroundContent,
     renderTabView,
     renderRefreshControl: renderRefreshControlProp,
     animationHeaderPosition,
@@ -685,12 +686,12 @@ export const GestureContainer = React.forwardRef<
       }}
     >
       <GestureDetector gesture={gestureHandler}>
-        {!!renderAbsoluteBackgroundContent && (
-          <View style={styles.absoluteBackground}>
-            {renderAbsoluteBackgroundContent(translateYValue)}
-          </View>
-        )}
         <Animated.View style={[styles.container, opacityStyle]}>
+          {!!renderAbsoluteBackgroundContent && (
+            <View style={styles.absoluteBackground}>
+              {renderAbsoluteBackgroundContent(translateYValue)}
+            </View>
+          )}
           <Animated.View
             style={[styles.container, animateStyle]}
             onLayout={containerOnLayout}
@@ -701,6 +702,11 @@ export const GestureContainer = React.forwardRef<
             })}
           </Animated.View>
           {renderRefreshControl()}
+          {!!renderAbsoluteForegroundContent && (
+            <View style={styles.absoluteBackground}>
+              {renderAbsoluteForegroundContent()}
+            </View>
+          )}
         </Animated.View>
       </GestureDetector>
     </HeaderTabContext.Provider>

--- a/packages/design-system/collapsible-tab-view/gesture-container.tsx
+++ b/packages/design-system/collapsible-tab-view/gesture-container.tsx
@@ -57,6 +57,7 @@ export const GestureContainer = React.forwardRef<
     initTabbarHeight = 49,
     initHeaderHeight = 0,
     renderScrollHeader,
+    renderAbsoluteBackgroundContent,
     renderTabView,
     renderRefreshControl: renderRefreshControlProp,
     animationHeaderPosition,
@@ -599,7 +600,9 @@ export const GestureContainer = React.forwardRef<
         <GestureDetector gesture={gestureHandlerHeader}>
           <Animated.View style={styles.container}>
             {renderScrollHeader && (
-              <View onLayout={headerOnLayout}>{renderScrollHeader()}</View>
+              <View onLayout={headerOnLayout}>
+                {renderScrollHeader(translateYValue)}
+              </View>
             )}
             {navigationState?.routes.length === 0 && emptyBodyComponent ? (
               <View style={{ marginTop: tabbarHeight }}>
@@ -682,6 +685,11 @@ export const GestureContainer = React.forwardRef<
       }}
     >
       <GestureDetector gesture={gestureHandler}>
+        {!!renderAbsoluteBackgroundContent && (
+          <View style={styles.absoluteBackground}>
+            {renderAbsoluteBackgroundContent(translateYValue)}
+          </View>
+        )}
         <Animated.View style={[styles.container, opacityStyle]}>
           <Animated.View
             style={[styles.container, animateStyle]}
@@ -709,5 +717,10 @@ const styles = StyleSheet.create({
     position: "absolute",
     right: 0,
     zIndex: 10,
+  },
+  absoluteBackground: {
+    position: "absolute",
+    top: 0,
+    width: "100%",
   },
 });

--- a/packages/design-system/collapsible-tab-view/types.tsx
+++ b/packages/design-system/collapsible-tab-view/types.tsx
@@ -31,6 +31,7 @@ export type CollapsibleHeaderProps<T extends Route> = {
   renderAbsoluteBackgroundContent?: (
     translateYValue: Animated.SharedValue<number>
   ) => React.ReactElement | null;
+  renderAbsoluteForegroundContent?: () => React.ReactElement | null;
   initTabbarHeight?: number;
   minHeaderHeight?: number;
   overflowHeight?: number;

--- a/packages/design-system/collapsible-tab-view/types.tsx
+++ b/packages/design-system/collapsible-tab-view/types.tsx
@@ -25,7 +25,12 @@ export enum RefreshTypeEnum {
 
 export type CollapsibleHeaderProps<T extends Route> = {
   initHeaderHeight?: number;
-  renderScrollHeader: () => React.ReactElement | null;
+  renderScrollHeader: (
+    translateYValue: Animated.SharedValue<number>
+  ) => React.ReactElement | null;
+  renderAbsoluteBackgroundContent?: (
+    translateYValue: Animated.SharedValue<number>
+  ) => React.ReactElement | null;
   initTabbarHeight?: number;
   minHeaderHeight?: number;
   overflowHeight?: number;


### PR DESCRIPTION
# Why

Add the possibility to have a banner component (ex: an image) with zoom effect when doing pull to refresh
Cf this discussion :
https://github.com/showtime-xyz/showtime-frontend/discussions/1471

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
