### PR TITLE
fix: social buttons not clickable on native app

### DIFF
--- a/packages/design-system/snackbar/snackbar.tsx
+++ b/packages/design-system/snackbar/snackbar.tsx
@@ -106,6 +106,8 @@ export const Snackbar: React.FC<SnackbarProps> = ({ snackbar, show, hide }) => {
     [snackbar]
   );
 
+  if (!show) return null;
+
   return (
     // @ts-ignore
     <AnimatePresence>


### PR DESCRIPTION
# Why
Snackbar stays mounted, I think something is acting weird with `AnimatePresence`. Will need to repro in isolation. This PR adds a quick fix for now.
https://showtime-rq88331.slack.com/archives/C02PXGK3V8D/p1662427058514019
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- Unmount snackbar if not visible

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Test social buttons are clickable on native.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

@alantoa let me know wyt. I can do a new snackbar release later.
