### PR TITLE
fix: type & profile list router

### DIFF
--- a/packages/app/components/profile/profile-tab-list.tsx
+++ b/packages/app/components/profile/profile-tab-list.tsx
@@ -1,4 +1,4 @@
-import {
+import React, {
   useCallback,
   useContext,
   forwardRef,

--- a/packages/app/navigation/root-stack-navigator.tsx
+++ b/packages/app/navigation/root-stack-navigator.tsx
@@ -3,7 +3,6 @@ import { Platform } from "react-native";
 import { useIsDarkMode } from "@showtime-xyz/universal.hooks";
 import { useSafeAreaInsets } from "@showtime-xyz/universal.safe-area";
 
-import type { ProfileScreenProps } from "app/components/profile";
 import { useNetWorkConnection } from "app/hooks/use-network-connection";
 import { screenOptions } from "app/navigation/navigator-screen-options";
 import { ActivitiesScreen } from "app/screens/activities";
@@ -28,8 +27,9 @@ import { SwipeListScreen } from "app/screens/swipe-list";
 
 import { BottomTabNavigator } from "./bottom-tab-navigator";
 import { createStackNavigator } from "./create-stack-navigator";
+import { RootStackNavigatorParams } from "./types";
 
-const Stack = createStackNavigator();
+const Stack = createStackNavigator<RootStackNavigatorParams>();
 
 export function RootStackNavigator() {
   const { top: safeAreaTop } = useSafeAreaInsets();
@@ -51,7 +51,7 @@ export function RootStackNavigator() {
         <Stack.Screen
           name="profile"
           component={ProfileScreen}
-          getId={({ params }) => (params as ProfileScreenProps)?.username}
+          getId={({ params }) => params?.username}
         />
         <Stack.Screen name="settings" component={SettingsScreen} />
         <Stack.Screen
@@ -73,7 +73,9 @@ export function RootStackNavigator() {
         <Stack.Screen
           name="swipeList"
           component={SwipeListScreen}
-          getId={({ params }) => params?.type}
+          getId={({ params }) => {
+            return params?.profileId ?? params.type;
+          }}
         />
         <Stack.Screen name="nft" component={NftScreen} />
       </Stack.Group>

--- a/packages/app/navigation/types.ts
+++ b/packages/app/navigation/types.ts
@@ -63,11 +63,35 @@ type BottomTabNavigatorParams = {
   profileTab: NavigatorScreenParams<ProfileStackParams>;
 };
 
-declare global {
-  // namespace ReactNavigation {
-  //   interface RootParamList extends BottomTabNavigatorParams {}
-  // }
-}
+type RootStackNavigatorParams = {
+  bottomTabs: BottomTabNavigatorParams;
+  profile: ProfileStackParams["profile"];
+  settings: undefined;
+  privacySecuritySettings: undefined;
+  notificationSettings: undefined;
+  blockedList: undefined;
+  search: undefined;
+  swipeList: {
+    profileId?: string;
+    initialScrollIndex?: number;
+    collectionId?: number;
+    sortType?: string;
+    tabType?: string;
+    type: string;
+  };
+  nft: undefined;
+  login: undefined;
+  comments: undefined;
+  details: undefined;
+  activity: undefined;
+  editProfile: undefined;
+  followers: undefined;
+  following: undefined;
+  addEmail: undefined;
+  drop: undefined;
+  claim: undefined;
+  claimers: undefined;
+};
 
 export type {
   NextNavigationProps,
@@ -78,4 +102,5 @@ export type {
   NotificationsStackParams,
   ProfileStackParams,
   BottomTabNavigatorParams,
+  RootStackNavigatorParams,
 };

--- a/packages/app/pages/create/index.tsx
+++ b/packages/app/pages/create/index.tsx
@@ -7,11 +7,8 @@ const CreateStack = createStackNavigator<CreateStackParams>();
 
 function CreateNavigator() {
   return (
-    <CreateStack.Navigator
-      // @ts-ignore
-      screenOptions={screenOptions}
-    >
-      <CreateStack.Screen name="Drop" component={Drop} />
+    <CreateStack.Navigator screenOptions={screenOptions as {}}>
+      <CreateStack.Screen name="drop" component={Drop} />
     </CreateStack.Navigator>
   );
 }

--- a/packages/app/pages/profile/index.tsx
+++ b/packages/app/pages/profile/index.tsx
@@ -19,7 +19,6 @@ function ProfileNavigator() {
 
   return (
     <ProfileStack.Navigator
-      // @ts-ignore
       screenOptions={screenOptions({
         safeAreaTop,
         isDark,


### PR DESCRIPTION
# Why

navigate to incorrect index when from myself profile -> NFT -> creator profile -> press NFT.  

# Before  

https://user-images.githubusercontent.com/37520667/189112422-56ebb097-4694-4dfe-aae7-bfc780502c4b.MP4



# How
- change `swipeList` screen `getId`.
- add `RootStackNavigatorParams` type to  fixed `RootStackNavigator` types warnings.  

# Test Plan

check if the route to profile list flow is correct.

# After 

https://user-images.githubusercontent.com/37520667/189113026-91a72a5e-145e-448e-a477-28c0ca3e14b4.mov

