### PR TITLE
feat: override shareanimatedvalue and translateyvalue

### DIFF
--- a/packages/design-system/collapsible-tab-view/gesture-container.ios.tsx
+++ b/packages/design-system/collapsible-tab-view/gesture-container.ios.tsx
@@ -58,8 +58,8 @@ export const GestureContainer = React.forwardRef<
     initTabbarHeight = 49,
     initHeaderHeight = 0,
     renderScrollHeader,
-    renderAbsoluteBackgroundContent,
-    renderAbsoluteForegroundContent,
+    overridenShareAnimatedValue,
+    overridenTranslateYValue,
     renderTabView,
     renderRefreshControl: renderRefreshControlProp,
     animationHeaderPosition,
@@ -75,7 +75,11 @@ export const GestureContainer = React.forwardRef<
   forwardedRef
 ) {
   //#region animation value
-  const shareAnimatedValue = useSharedValue(0);
+  const defaultShareAnimatedValue = useSharedValue(0);
+  const shareAnimatedValue =
+    overridenShareAnimatedValue || defaultShareAnimatedValue;
+  const defaultTranslateYValue = useSharedValue(0);
+  const translateYValue = overridenTranslateYValue || defaultTranslateYValue;
   const curIndexValue = useSharedValue(initialPage);
   const isSlidingHeader = useSharedValue(false);
   const slideIndex = useSharedValue(curIndexValue.value);
@@ -578,7 +582,7 @@ export const GestureContainer = React.forwardRef<
     };
   });
 
-  const translateYValue = useRefreshDerivedValue({
+  useRefreshDerivedValue(translateYValue, {
     animatedValue: tabsTrans,
     refreshHeight,
     overflowPull,
@@ -617,9 +621,7 @@ export const GestureContainer = React.forwardRef<
         <GestureDetector gesture={gestureHandlerHeader}>
           <Animated.View style={styles.container}>
             {renderScrollHeader && (
-              <View onLayout={headerOnLayout}>
-                {renderScrollHeader(translateYValue)}
-              </View>
+              <View onLayout={headerOnLayout}>{renderScrollHeader()}</View>
             )}
             {navigationState?.routes.length === 0 && emptyBodyComponent ? (
               <View style={{ marginTop: tabbarHeight }}>
@@ -703,11 +705,6 @@ export const GestureContainer = React.forwardRef<
     >
       <GestureDetector gesture={gestureHandler}>
         <Animated.View style={[styles.container, opacityStyle]}>
-          {!!renderAbsoluteBackgroundContent && (
-            <View style={styles.absoluteBackground}>
-              {renderAbsoluteBackgroundContent(translateYValue)}
-            </View>
-          )}
           <Animated.View
             style={[styles.container, animateStyle]}
             onLayout={containerOnLayout}
@@ -718,11 +715,6 @@ export const GestureContainer = React.forwardRef<
             })}
           </Animated.View>
           {renderRefreshControl()}
-          {!!renderAbsoluteForegroundContent && (
-            <View style={styles.absoluteBackground}>
-              {renderAbsoluteForegroundContent()}
-            </View>
-          )}
         </Animated.View>
       </GestureDetector>
     </HeaderTabContext.Provider>
@@ -739,10 +731,5 @@ const styles = StyleSheet.create({
     position: "absolute",
     right: 0,
     zIndex: 10,
-  },
-  absoluteBackground: {
-    position: "absolute",
-    top: 0,
-    width: "100%",
   },
 });

--- a/packages/design-system/collapsible-tab-view/gesture-container.tsx
+++ b/packages/design-system/collapsible-tab-view/gesture-container.tsx
@@ -57,8 +57,8 @@ export const GestureContainer = React.forwardRef<
     initTabbarHeight = 49,
     initHeaderHeight = 0,
     renderScrollHeader,
-    renderAbsoluteBackgroundContent,
-    renderAbsoluteForegroundContent,
+    overridenShareAnimatedValue,
+    overridenTranslateYValue,
     renderTabView,
     renderRefreshControl: renderRefreshControlProp,
     animationHeaderPosition,
@@ -74,7 +74,11 @@ export const GestureContainer = React.forwardRef<
   forwardedRef
 ) {
   //#region animation value
-  const shareAnimatedValue = useSharedValue(0);
+  const defaultShareAnimatedValue = useSharedValue(0);
+  const shareAnimatedValue =
+    overridenShareAnimatedValue || defaultShareAnimatedValue;
+  const defaultTranslateYValue = useSharedValue(0);
+  const translateYValue = overridenTranslateYValue || defaultTranslateYValue;
   const curIndexValue = useSharedValue(initialPage);
   const isSlidingHeader = useSharedValue(false);
   const slideIndex = useSharedValue(curIndexValue.value);
@@ -562,7 +566,7 @@ export const GestureContainer = React.forwardRef<
     };
   });
 
-  const translateYValue = useRefreshDerivedValue({
+  useRefreshDerivedValue(translateYValue, {
     animatedValue: tabsTrans,
     refreshHeight,
     overflowPull,
@@ -601,9 +605,7 @@ export const GestureContainer = React.forwardRef<
         <GestureDetector gesture={gestureHandlerHeader}>
           <Animated.View style={styles.container}>
             {renderScrollHeader && (
-              <View onLayout={headerOnLayout}>
-                {renderScrollHeader(translateYValue)}
-              </View>
+              <View onLayout={headerOnLayout}>{renderScrollHeader()}</View>
             )}
             {navigationState?.routes.length === 0 && emptyBodyComponent ? (
               <View style={{ marginTop: tabbarHeight }}>
@@ -687,11 +689,6 @@ export const GestureContainer = React.forwardRef<
     >
       <GestureDetector gesture={gestureHandler}>
         <Animated.View style={[styles.container, opacityStyle]}>
-          {!!renderAbsoluteBackgroundContent && (
-            <View style={styles.absoluteBackground}>
-              {renderAbsoluteBackgroundContent(translateYValue)}
-            </View>
-          )}
           <Animated.View
             style={[styles.container, animateStyle]}
             onLayout={containerOnLayout}
@@ -702,11 +699,6 @@ export const GestureContainer = React.forwardRef<
             })}
           </Animated.View>
           {renderRefreshControl()}
-          {!!renderAbsoluteForegroundContent && (
-            <View style={styles.absoluteBackground}>
-              {renderAbsoluteForegroundContent()}
-            </View>
-          )}
         </Animated.View>
       </GestureDetector>
     </HeaderTabContext.Provider>
@@ -723,10 +715,5 @@ const styles = StyleSheet.create({
     position: "absolute",
     right: 0,
     zIndex: 10,
-  },
-  absoluteBackground: {
-    position: "absolute",
-    top: 0,
-    width: "100%",
   },
 });

--- a/packages/design-system/collapsible-tab-view/hooks/use-refresh-value.tsx
+++ b/packages/design-system/collapsible-tab-view/hooks/use-refresh-value.tsx
@@ -3,19 +3,22 @@ import Animated, {
   useDerivedValue,
 } from "react-native-reanimated";
 
-export const useRefreshDerivedValue = ({
-  refreshHeight,
-  overflowPull,
-  animatedValue,
-  pullExtendedCoefficient,
-}: {
-  refreshHeight: number;
-  overflowPull: number;
-  animatedValue: Animated.SharedValue<number>;
-  pullExtendedCoefficient: number;
-}) => {
+export const useRefreshDerivedValue = (
+  translateYValue: Animated.SharedValue<number>,
+  {
+    refreshHeight,
+    overflowPull,
+    animatedValue,
+    pullExtendedCoefficient,
+  }: {
+    refreshHeight: number;
+    overflowPull: number;
+    animatedValue: Animated.SharedValue<number>;
+    pullExtendedCoefficient: number;
+  }
+) => {
   return useDerivedValue(() => {
-    return interpolate(
+    translateYValue.value = interpolate(
       animatedValue.value,
       [0, refreshHeight + overflowPull, refreshHeight + overflowPull + 1],
       [

--- a/packages/design-system/collapsible-tab-view/types.tsx
+++ b/packages/design-system/collapsible-tab-view/types.tsx
@@ -25,13 +25,9 @@ export enum RefreshTypeEnum {
 
 export type CollapsibleHeaderProps<T extends Route> = {
   initHeaderHeight?: number;
-  renderScrollHeader: (
-    translateYValue?: Animated.SharedValue<number>
-  ) => React.ReactElement | null;
-  renderAbsoluteBackgroundContent?: (
-    translateYValue: Animated.SharedValue<number>
-  ) => React.ReactElement | null;
-  renderAbsoluteForegroundContent?: () => React.ReactElement | null;
+  renderScrollHeader: () => React.ReactElement | null;
+  overridenShareAnimatedValue?: Animated.SharedValue<number>;
+  overridenTranslateYValue?: Animated.SharedValue<number>;
   initTabbarHeight?: number;
   minHeaderHeight?: number;
   overflowHeight?: number;


### PR DESCRIPTION
# Why

I realized this pr : #1476 was not great 

With this pr it's possible to override : 
- `shareAnimatedValue` with `overridenShareAnimatedValue?: SharedValue<number>` prop
- `translateYValue` with `overridenTranslateYValue?: SharedValue<number>` prop

That way it's easier to integrate this library in a page with a scroll animated header and a banner with zoom effect when doing pull to refresh (cf: example)

Example: 
https://github.com/Daavidaviid/showtime-scrollview-with-zoom-pull-to-refresh




https://user-images.githubusercontent.com/32457364/189254665-e227fb29-d45d-4590-8eae-d33e3d72591c.mov



<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
