### PR TITLE
fix: tab selected state in edit profile

### DIFF
--- a/packages/app/components/edit-profile.tsx
+++ b/packages/app/components/edit-profile.tsx
@@ -101,13 +101,7 @@ export const EditProfile = () => {
   const pickFile = useFilePicker();
   // edit media regin
   const [selectedImg, setSelectedImg] = useState<any>(null);
-  const [index, setIndex] = useState(0);
-
-  const [currentCropField, setCurrentCropField] = useState<
-    null | "coverPicture" | "profilePicture"
-  >(null);
-
-  const [selected, setSelected] = useState(() =>
+  const [index, setIndex] = useState(() =>
     !user?.data?.profile.username ||
     !user?.data?.profile.bio ||
     !user?.data?.profile.img_url
@@ -117,8 +111,12 @@ export const EditProfile = () => {
       : 0
   );
 
+  const [currentCropField, setCurrentCropField] = useState<
+    null | "coverPicture" | "profilePicture"
+  >(null);
+
   const [hasNotSubmittedExternalLink, setHasNotSubmittedExternalLink] =
-    useState(selected === 1);
+    useState(index === 1);
 
   const defaultValues = useMemo(() => {
     const links: any = {};
@@ -192,7 +190,7 @@ export const EditProfile = () => {
     //@ts-ignore
     if (userHasIncompleteExternalLinks(newValues)) {
       setHasNotSubmittedExternalLink(true);
-      setSelected(1);
+      setIndex(1);
     } else {
       setHasNotSubmittedExternalLink(false);
 


### PR DESCRIPTION
# Why
fix controlled state in edit-profile form
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->


<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Test tab is changed to select website link if link is not filled by the user
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
