### PR TITLE
Fix images

### DIFF
--- a/packages/app/components/activity/avatar.tsx
+++ b/packages/app/components/activity/avatar.tsx
@@ -54,7 +54,9 @@ const Avatar = ({ url, icon = "none" }: Props) => {
   return (
     <View tw="relative h-12 w-12 rounded-full">
       <Image
-        tw="h-12 w-12 rounded-full"
+        tw="rounded-full"
+        width={48}
+        height={48}
         source={{
           uri: url,
         }}

--- a/packages/app/components/card/rows/collection.tsx
+++ b/packages/app/components/card/rows/collection.tsx
@@ -28,7 +28,9 @@ function Collection({ nft }: Props) {
           >
             <Image
               source={{ uri: nft.collection_img_url }}
-              tw="h-5 w-5 rounded-full"
+              tw="rounded-full"
+              width={20}
+              height={20}
             />
           </View>
         )}

--- a/packages/app/components/complete-profile-modal-content/complete-profile-modal-content.tsx
+++ b/packages/app/components/complete-profile-modal-content/complete-profile-modal-content.tsx
@@ -25,7 +25,9 @@ export const CompleteProfileModalContent = ({
           web: { uri: require("./complete-profile.png") },
           default: require("./complete-profile.png"),
         })}
-        tw={`h-25 w-25 rounded-xl`}
+        tw="rounded-xl"
+        width={100}
+        height={100}
         resizeMode="contain"
       />
       <Text tw="py-4 text-center text-base text-gray-900 dark:text-gray-100">

--- a/packages/app/components/search/index.tsx
+++ b/packages/app/components/search/index.tsx
@@ -126,7 +126,12 @@ export const SearchItem = ({
         <View tw="flex-row">
           <View tw="mr-2 h-8 w-8 rounded-full bg-gray-200">
             {item.img_url && (
-              <Image source={{ uri: item.img_url }} tw="h-8 w-8 rounded-full" />
+              <Image
+                source={{ uri: item.img_url }}
+                tw="rounded-full"
+                width={32}
+                height={32}
+              />
             )}
           </View>
           <View tw="mr-1 justify-center">

--- a/packages/app/components/settings/blocked-list.tsx
+++ b/packages/app/components/settings/blocked-list.tsx
@@ -23,6 +23,8 @@ export const UserItem = (props: UserItemProps) => {
       <View tw="mr-2 h-6 w-6 rounded-xl bg-gray-200">
         <Image
           tw={"h-full w-full rounded-full"}
+          width={24}
+          height={24}
           source={{ uri: props.image_url }}
         />
       </View>

--- a/packages/app/components/user-list.tsx
+++ b/packages/app/components/user-list.tsx
@@ -110,7 +110,9 @@ const FollowingListUser = memo(
               {item?.img_url && (
                 <Image
                   source={{ uri: item.img_url }}
-                  tw="h-8 w-8 rounded-full"
+                  tw="rounded-full"
+                  width={32}
+                  height={32}
                 />
               )}
             </View>

--- a/packages/app/providers/wallet-provider.tsx
+++ b/packages/app/providers/wallet-provider.tsx
@@ -90,7 +90,9 @@ function WalletConnectQRCodeModalComponent(props: RenderQrcodeModalProps) {
           >
             <Image
               source={require("./coinbase-wallet-icon.png")}
-              tw="h-10 w-10 rounded-md"
+              tw="rounded-md"
+              width={40}
+              height={40}
             />
             <View tw="w-4" />
             <Text tw="text-lg text-black dark:text-white">Coinbase Wallet</Text>
@@ -116,7 +118,9 @@ function WalletConnectQRCodeModalComponent(props: RenderQrcodeModalProps) {
                 <Image
                   // @ts-ignore
                   source={{ uri: walletService.image_url.lg }}
-                  tw="h-10 w-10 rounded-md"
+                  tw="rounded-md"
+                  width={40}
+                  height={40}
                 />
                 <View tw="w-4" />
                 <Text tw="text-lg text-black dark:text-white">

--- a/packages/design-system/model/index.tsx
+++ b/packages/design-system/model/index.tsx
@@ -16,6 +16,8 @@ export type Props = {
   resizeMode?: ResizeMode;
   numColumns: number;
   style?: object;
+  width: number;
+  height: number;
 };
 
 const StyledCanvas = styled(Canvas);
@@ -60,6 +62,8 @@ function ModelViewer({
   resizeMode,
   style,
   numColumns,
+  width,
+  height,
 }: Props) {
   if (fallbackUrl && numColumns > 1) {
     return (
@@ -71,6 +75,8 @@ function ModelViewer({
         style={style}
         blurhash={blurhash}
         resizeMode={resizeMode}
+        width={width}
+        height={height}
       />
     );
   }


### PR DESCRIPTION
# Why

We need to set the `width` and `height` as props

# How

Pass `width` and `height`

# Test Plan

Check the wallet connect screen on mobile for example:

<img width="519" alt="Screenshot 2022-09-12 at 15 30 55" src="https://user-images.githubusercontent.com/10477267/189668158-7a79d369-5174-4c8d-b059-d66bcd36070c.png">
