### PR TITLE
perf: notification badge use style to hide

### DIFF
--- a/packages/app/navigation/tab-bar-icons.tsx
+++ b/packages/app/navigation/tab-bar-icons.tsx
@@ -185,9 +185,12 @@ export const NotificationsTabBarIcon = ({
 const UnreadNotificationIndicator = () => {
   const { hasUnreadNotification } = useNotifications();
 
-  return hasUnreadNotification ? (
-    <View tw="absolute top-2 right-2 h-2 w-2 rounded-full bg-amber-500 dark:bg-violet-500" />
-  ) : null;
+  return (
+    <View
+      tw="absolute top-2 right-2 h-2 w-2 rounded-full bg-amber-500 dark:bg-violet-500"
+      style={{ opacity: hasUnreadNotification ? 1 : 0 }}
+    />
+  );
 };
 
 export const ProfileTabBarIcon = () => {


### PR DESCRIPTION
# Why

I just dig [badge still exist even reading notifications on native](https://linear.app/showtime/issue/SHOW2-1158/badge-still-exist-even-reading-notifications-on-native) issue, but always can't repro, I think hide/show notification badge use style will be better.
