### PR TITLE
Handle error if failed to upload on IPFS

### DIFF
--- a/packages/app/hooks/use-drop-nft.ts
+++ b/packages/app/hooks/use-drop-nft.ts
@@ -247,6 +247,14 @@ export const useDropNFT = () => {
           notSafeForWork: params.notSafeForWork,
         });
 
+        if (!ipfsHash) {
+          dispatch({
+            type: "error",
+            error: "Failed to upload the media on IPFS. Please try again!",
+          });
+          return;
+        }
+
         const escapedTitle = JSON.stringify(params.title).slice(1, -1);
         const escapedDescription = JSON.stringify(params.description).slice(
           1,

--- a/packages/app/hooks/use-upload-media-to-pinata.ts
+++ b/packages/app/hooks/use-upload-media-to-pinata.ts
@@ -12,41 +12,45 @@ export const useUploadMediaToPinata = () => {
     file: File | string;
     notSafeForWork: boolean;
   }) => {
-    const formData = new FormData();
-    const fileFormData = await getFileFormData(file);
+    try {
+      const formData = new FormData();
+      const fileFormData = await getFileFormData(file);
 
-    if (!fileFormData) {
-      Logger.error("error in generating file form data");
-      return;
-    }
-
-    formData.append("file", fileFormData);
-    formData.append(
-      "pinataMetadata",
-      JSON.stringify({
-        name: uuid(),
-      })
-    );
-    if (notSafeForWork) {
-      formData.append(
-        "pinataContent",
-        JSON.stringify({ attributes: [{ value: "NSFW" }] })
-      );
-    }
-
-    const pinataToken = await getPinataToken();
-    const res = await axios.post(
-      "https://api.pinata.cloud/pinning/pinFileToIPFS",
-      formData,
-      {
-        headers: {
-          Authorization: `Bearer ${pinataToken}`,
-          "Content-Type": `multipart/form-data`,
-        },
+      if (!fileFormData) {
+        throw "Failed to generate the file form data";
       }
-    );
 
-    return res.data.IpfsHash;
+      formData.append("file", fileFormData);
+      formData.append(
+        "pinataMetadata",
+        JSON.stringify({
+          name: uuid(),
+        })
+      );
+      if (notSafeForWork) {
+        formData.append(
+          "pinataContent",
+          JSON.stringify({ attributes: [{ value: "NSFW" }] })
+        );
+      }
+
+      const pinataToken = await getPinataToken();
+      const res = await axios.post(
+        "https://api.pinata.cloud/pinning/pinFileToIPFS",
+        formData,
+        {
+          headers: {
+            Authorization: `Bearer ${pinataToken}`,
+            "Content-Type": `multipart/form-data`,
+          },
+        }
+      );
+
+      return res.data.IpfsHash;
+    } catch (error) {
+      Logger.error(error);
+      return null;
+    }
   };
 
   return uploadMedia;


### PR DESCRIPTION
# Why

We don't handle the error properly and the user is left without knowing what's happening

# How

- Catched the error
- Displayed an error message asking to the user to retry

# Test Plan

Throw an error in `uploadMedia` at the `https://api.pinata.cloud/pinning/pinFileToIPFS` call, run the app and create a new drop. You should see the error message