### PR TITLE
fix: video won't play unless muted

### DIFF
--- a/packages/app/hooks/use-previous-value.ts
+++ b/packages/app/hooks/use-previous-value.ts
@@ -1,0 +1,9 @@
+import { useEffect, useRef } from "react";
+
+export function usePreviousValue<T>(value: T) {
+  const ref = useRef<T>();
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+  return ref.current;
+}

--- a/packages/app/providers/mute-provider.tsx
+++ b/packages/app/providers/mute-provider.tsx
@@ -4,13 +4,33 @@ import {
   useState,
   Dispatch,
   SetStateAction,
+  useEffect,
 } from "react";
+
+import { useRouter } from "@showtime-xyz/universal.router";
+
+import { usePreviousValue } from "app/hooks/use-previous-value";
+import { isMobileWeb } from "app/utilities";
 
 export const MuteContext = createContext([true, () => {}] as
   | [boolean, Dispatch<SetStateAction<boolean>>]);
 
 export const MuteProvider = ({ children }: { children: any }) => {
+  const router = useRouter();
   const values = useState(true);
+  const setValue = values[1];
+
+  const prevRouter = usePreviousValue(router);
+
+  useEffect(() => {
+    if (
+      isMobileWeb() &&
+      (prevRouter?.pathname !== router.pathname ||
+        prevRouter?.query !== router.query)
+    ) {
+      setValue(true);
+    }
+  }, [router, prevRouter?.query, prevRouter?.pathname, setValue]);
 
   return <MuteContext.Provider value={values}>{children}</MuteContext.Provider>;
 };

--- a/packages/app/utilities.ts
+++ b/packages/app/utilities.ts
@@ -485,7 +485,7 @@ export function isIOS(): boolean {
 }
 
 export function isMobileWeb(): boolean {
-  return isAndroid() || isIOS();
+  return Platform.OS === "web" && (isAndroid() || isIOS());
 }
 
 // TODO: https://github.com/LedgerHQ/ledgerjs/issues/466


### PR DESCRIPTION
# Why
- Video doesn't autoplay when it is not muted on mobile browsers

> By default, autoplay executes only if the video doesn’t contain an audio track, or if the video element includes the muted attribute.

https://developer.apple.com/documentation/webkit/delivering_video_content_for_safari?language=objc

iOS Safari doesn't autoplay videos if it is not muted. Same can happen on [Android](https://stackoverflow.com/questions/52261078/autoplay-is-not-working-in-chrome-browser-on-android-device). So, we reset the global mute setting on route change for mobile browsers.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->


<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Test video autoplay works on mobile browsers even if user had unmuted it once.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
