### PR TITLE
fix: video not loading in grid on native

### DIFF
--- a/packages/app/components/card/card.tsx
+++ b/packages/app/components/card/card.tsx
@@ -8,7 +8,6 @@ import { Skeleton } from "@showtime-xyz/universal.skeleton";
 import { View } from "@showtime-xyz/universal.view";
 
 import { Creator } from "app/components/card/rows/elements/creator";
-import { Owner } from "app/components/card/rows/owner";
 import { Title } from "app/components/card/rows/title";
 import { Social } from "app/components/card/social";
 import { ClaimButton } from "app/components/claim/claim-button";
@@ -76,6 +75,7 @@ function Card({
   if (width < 768) {
     return (
       <RouteComponent href={href} onPress={handleOnPress}>
+        {/* <View style={{ width: 100, height: 100, backgroundColor: "red" }} /> */}
         <Media item={nft} numColumns={numColumns} />
       </RouteComponent>
     );

--- a/packages/app/components/card/card.tsx
+++ b/packages/app/components/card/card.tsx
@@ -75,7 +75,6 @@ function Card({
   if (width < 768) {
     return (
       <RouteComponent href={href} onPress={handleOnPress}>
-        {/* <View style={{ width: 100, height: 100, backgroundColor: "red" }} /> */}
         <Media item={nft} numColumns={numColumns} />
       </RouteComponent>
     );

--- a/packages/design-system/video/index.tsx
+++ b/packages/design-system/video/index.tsx
@@ -23,6 +23,8 @@ function Video({
   tw,
   blurhash,
   style,
+  width,
+  height,
   isMuted: isMutedProp,
   posterSource,
   ...props
@@ -46,7 +48,8 @@ function Video({
           <Image
             tw={tw}
             //@ts-ignore
-            style={[StyleSheet.absoluteFill, style]}
+            width={width}
+            height={height}
             blurhash={blurhash}
             source={posterSource as Source}
           />
@@ -54,6 +57,8 @@ function Video({
           <>
             <Image
               tw={tw}
+              width={width}
+              height={height}
               // @ts-ignore
               style={[StyleSheet.absoluteFill, style]}
               blurhash={blurhash}


### PR DESCRIPTION
We'll have to clean up dimension logic in all media. https://github.com/showtime-xyz/showtime-frontend/blob/staging/packages/design-system/image/image.tsx#L40 This sets default height, width to 0 so it was not rendering the image unless height and width were specified (So StyleSheet.absolute broke). I think we should avoid such defaults.

We should probably unify Image and Video on all platforms and make them as dumb as possible, also make dimension mandatory. I'll experiment after the wallet flow.