### PR TITLE
fix: profile deeplinking

### DIFF
--- a/packages/app/components/header.tsx
+++ b/packages/app/components/header.tsx
@@ -28,6 +28,7 @@ import { SearchItem, SearchItemSkeleton } from "app/components/search";
 import { useMyInfo } from "app/hooks/api-hooks";
 import { SearchResponseItem, useSearch } from "app/hooks/api/use-search";
 import { useUser } from "app/hooks/use-user";
+import { Link } from "app/navigation/link";
 import {
   ShowtimeTabBarIcon,
   TrendingTabBarIcon,
@@ -363,8 +364,9 @@ const HeaderCenter = ({
 }) => {
   return (
     <View tw="flex flex-row">
-      <ShowtimeTabBarIcon color={isDark ? "black" : "white"} tw="mr-4" />
-
+      <Link href="/">
+        <ShowtimeTabBarIcon color={isDark ? "black" : "white"} tw="mr-4" />
+      </Link>
       {isMdWidth ? <SearchInHeader /> : null}
     </View>
   );

--- a/packages/app/hooks/use-is-online.tsx
+++ b/packages/app/hooks/use-is-online.tsx
@@ -3,14 +3,18 @@ import { useEffect, useState } from "react";
 import NetInfo from "@react-native-community/netinfo";
 
 export const useIsOnline = () => {
-  const [isOnline, setIsOnlie] = useState(true);
+  const [isOnline, setIsOnline] = useState(true);
   useEffect(() => {
     NetInfo.fetch().then((s) => {
-      setIsOnlie(!!s.isConnected && !!s.isInternetReachable);
+      if (typeof s.isInternetReachable === "boolean") {
+        setIsOnline(s.isInternetReachable);
+      }
     });
 
     const unsubscribe = NetInfo.addEventListener((s) => {
-      setIsOnlie(!!s.isConnected && !!s.isInternetReachable);
+      if (typeof s.isInternetReachable === "boolean") {
+        setIsOnline(s.isInternetReachable);
+      }
     });
 
     return unsubscribe;

--- a/packages/app/navigation/linking.ts
+++ b/packages/app/navigation/linking.ts
@@ -78,6 +78,12 @@ const linking: LinkingOptions<ReactNavigation.RootParamList> = {
       // URL handled by Wallet Mobile SDK
       return null;
     } else {
+      if (url) {
+        let urlObj = new URL(url);
+        urlObj.pathname = withRewrites(urlObj.pathname);
+        return urlObj.href;
+      }
+
       return url;
     }
   },
@@ -85,7 +91,13 @@ const linking: LinkingOptions<ReactNavigation.RootParamList> = {
     const linkingSubscription = Linking.addEventListener("url", ({ url }) => {
       const handledByMobileSDK = handleResponse(new URL(url));
       if (!handledByMobileSDK) {
-        listener(url);
+        if (url) {
+          let urlObj = new URL(url);
+          urlObj.pathname = withRewrites(urlObj.pathname);
+          listener(urlObj.href);
+        } else {
+          listener(url);
+        }
       }
     });
 


### PR DESCRIPTION
# Why
- Fixes profile deeplinking
- Sometimes `No internet message` is shown on app start even if it's connected. Tried a fix for that
- Tapping showtime icon should redirect to home screen. This can be a solution when user opens NFT from deeplinking. I tried adding back button but needed some hacks, will figure out a better solution
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->


<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Run app on simulator and type below commands on terminal to verify deeplinking

```
xcrun simctl openurl booted 'https://showtime.xyz/nft/polygon/0xA33bCd4fF80B8CE2A9d2d1D2Dd6E84F67bcf7b2F/0'

xcrun simctl openurl booted 'io.showtime.development:///@nishanbende'
```
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
