### PR TITLE
fix: pressing tab refreshes the page

### DIFF
--- a/packages/app/navigation/tab-bar-icons.tsx
+++ b/packages/app/navigation/tab-bar-icons.tsx
@@ -58,14 +58,14 @@ function TabBarIcon({ tab, children, tw, onPress }: TabBarButtonProps) {
 
     return (
       <Link href={tab}>
-        <PressableHover
+        <View
           tw={[
             "h-12 w-12 items-center justify-center rounded-full md:bg-gray-100 md:dark:bg-gray-900",
             tw ?? "",
           ]}
         >
           {children}
-        </PressableHover>
+        </View>
       </Link>
     );
   }


### PR DESCRIPTION
# Why
- Page is reloading on bottom tab press.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- Remove `PressableHover` from BottomTabs. Hover won't work for mobile devices so we can use a View instead.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Tapping Bottom tabs shouldn't reload the page
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
