### PR TITLE
fix: follow list not re-rendering

### DIFF
--- a/packages/app/components/follow-button.tsx
+++ b/packages/app/components/follow-button.tsx
@@ -1,4 +1,4 @@
-import { useCallback, memo } from "react";
+import { useCallback, memo, useMemo } from "react";
 
 import { useAlert } from "@showtime-xyz/universal.alert";
 import { Button } from "@showtime-xyz/universal.button";
@@ -7,17 +7,20 @@ import type { ButtonProps } from "@showtime-xyz/universal.button/types";
 import { useMyInfo } from "app/hooks/api-hooks";
 
 type ToggleFollowParams = Pick<ButtonProps, "size"> & {
-  isFollowing: boolean | 0 | undefined;
   name?: string;
   profileId: number;
   onToggleFollow?: () => void;
 };
 
 export const FollowButton = memo<ToggleFollowParams>(
-  ({ isFollowing, profileId, name, onToggleFollow, ...rest }) => {
-    const { unfollow, follow, data } = useMyInfo();
+  ({ profileId, name, onToggleFollow, ...rest }) => {
+    const { unfollow, follow, data, isFollowing: isFollowingFn } = useMyInfo();
 
     const Alert = useAlert();
+    const isFollowing = useMemo(
+      () => isFollowingFn(profileId),
+      [profileId, isFollowingFn]
+    );
 
     const toggleFollow = useCallback(async () => {
       if (isFollowing) {

--- a/packages/app/components/user-list.tsx
+++ b/packages/app/components/user-list.tsx
@@ -19,8 +19,6 @@ import { EmptyPlaceholder } from "./empty-placeholder";
 import { FollowButton } from "./follow-button";
 
 type FollowingListProp = {
-  follow: (profileId: number) => void;
-  unFollow: (profileId: number) => void;
   hideSheet: () => void;
 };
 
@@ -33,7 +31,6 @@ export const UserList = ({
   onClose: () => void;
   loading: boolean;
 }) => {
-  const { isFollowing, follow, unfollow } = useMyInfo();
   const modalListProps = useModalListProps();
 
   const keyExtractor = useCallback(
@@ -43,17 +40,9 @@ export const UserList = ({
 
   const renderItem = useCallback(
     ({ item }: { item: UserItemType }) => {
-      return (
-        <FollowingListUser
-          item={item}
-          isFollowingUser={isFollowing(item.profile_id)}
-          follow={follow}
-          unFollow={unfollow}
-          hideSheet={onClose}
-        />
-      );
+      return <FollowingListUser item={item} hideSheet={onClose} />;
     },
-    [isFollowing, unfollow, follow, onClose]
+    [onClose]
   );
   if (users && users?.length > 0) {
     return (
@@ -86,13 +75,8 @@ const Separator = () => (
 const ITEM_HEIGHT = 64 + SEPARATOR_HEIGHT;
 
 const FollowingListUser = memo(
-  ({
-    item,
-    isFollowingUser,
-    hideSheet,
-  }: { item: UserItemType; isFollowingUser: boolean } & FollowingListProp) => {
+  ({ item, hideSheet }: { item: UserItemType } & FollowingListProp) => {
     const { data } = useMyInfo();
-
     const { onToggleFollow } = useFollow({
       username: data?.data.profile.username,
     });
@@ -150,7 +134,6 @@ const FollowingListUser = memo(
           </View>
         </Link>
         <FollowButton
-          isFollowing={isFollowingUser}
           profileId={item.profile_id}
           name={item.name}
           onToggleFollow={onToggleFollow}


### PR DESCRIPTION
# Why
Fixes - https://linear.app/showtime/issue/SHOW2-1221/debug-follow-button-on-lists
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- Follow button was not re-rendering as state was calculated in `renderItem`. Moved state calculation in Follow button
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- Test pressing follow button updates the state to following on native
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
