### PR TITLE
fix: screens are broken on Android

### DIFF
--- a/packages/app/components/drop/drop-form.tsx
+++ b/packages/app/components/drop/drop-form.tsx
@@ -261,7 +261,7 @@ export const DropForm = () => {
 
   return (
     <BottomSheetModalProvider>
-      {Platform.OS === "ios" ? <View style={{ height: headerHeight }} /> : null}
+      {Platform.OS !== "web" && <View style={{ height: headerHeight }} />}
       <ScrollView
         tw="p-4"
         ref={scrollViewRef}

--- a/packages/app/components/feed-item/index.tsx
+++ b/packages/app/components/feed-item/index.tsx
@@ -87,12 +87,16 @@ export const FeedItem = memo<FeedItemProps>(function FeedItem({
     windowWidth,
   ]);
   const platformHeaderHeight = Platform.select({
-    ios: headerHeight,
-    default: 0,
+    web: 0,
+    default: headerHeight,
   });
+
   const contentTransY = useDerivedValue(() => {
     const visibleContentHeight =
-      windowHeight - headerHeight - detailHeight - StatusBarHeight;
+      windowHeight -
+      detailHeight -
+      StatusBarHeight -
+      (Platform.OS === "android" ? 0 : headerHeight);
 
     if (mediaHeight < visibleContentHeight) {
       return (visibleContentHeight - mediaHeight) / 2 + platformHeaderHeight;

--- a/packages/app/components/feed-item/index.tsx
+++ b/packages/app/components/feed-item/index.tsx
@@ -93,10 +93,7 @@ export const FeedItem = memo<FeedItemProps>(function FeedItem({
 
   const contentTransY = useDerivedValue(() => {
     const visibleContentHeight =
-      windowHeight -
-      detailHeight -
-      StatusBarHeight -
-      (Platform.OS === "android" ? 0 : headerHeight);
+      windowHeight - detailHeight - StatusBarHeight - headerHeight;
 
     if (mediaHeight < visibleContentHeight) {
       return (visibleContentHeight - mediaHeight) / 2 + platformHeaderHeight;

--- a/packages/app/components/notifications/index.tsx
+++ b/packages/app/components/notifications/index.tsx
@@ -1,11 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Platform, useWindowDimensions } from "react-native";
+import { Platform, RefreshControl, useWindowDimensions } from "react-native";
 
 import { ListRenderItemInfo } from "@shopify/flash-list";
 
+import { useIsDarkMode } from "@showtime-xyz/universal.hooks";
 import { InfiniteScrollList } from "@showtime-xyz/universal.infinite-scroll-list";
 import { ModalSheet } from "@showtime-xyz/universal.modal-sheet";
 import { Spinner } from "@showtime-xyz/universal.spinner";
+import { colors } from "@showtime-xyz/universal.tailwind";
 import { Text } from "@showtime-xyz/universal.text";
 import { View } from "@showtime-xyz/universal.view";
 
@@ -26,11 +28,10 @@ export const Notifications = ({ useWindowScroll = true }) => {
   const { data, fetchMore, refresh, isRefreshing, isLoadingMore } =
     useNotifications();
   const { refetchMyInfo } = useMyInfo();
+  const isDark = useIsDarkMode();
   const bottomBarHeight = usePlatformBottomHeight();
   const headerHeight = useHeaderHeight();
   const { height: windowHeight } = useWindowDimensions();
-
-  const flatListHeight = windowHeight - bottomBarHeight - headerHeight;
 
   const [users, setUsers] = useState<Pick<Actor, "profile_id" | "username">[]>(
     []
@@ -96,22 +97,35 @@ export const Notifications = ({ useWindowScroll = true }) => {
         // for blur header effect on iOS
         style={{
           height: Platform.select({
-            default: flatListHeight,
-            ios: windowHeight,
+            web: windowHeight - bottomBarHeight - headerHeight,
+            default: windowHeight,
           }),
         }}
         overscan={{
           main: 100,
           reverse: 100,
         }}
-        // for blur header effect on iOS
+        // for blur header effect on Native
         contentContainerStyle={Platform.select({
-          ios: {
+          default: {
             paddingTop: headerHeight,
             paddingBottom: bottomBarHeight,
           },
-          default: {},
+          web: {},
         })}
+        // Todo: unity refresh control same as tab view
+        refreshControl={
+          <RefreshControl
+            refreshing={isRefreshing}
+            onRefresh={refresh}
+            progressViewOffset={headerHeight}
+            tintColor={isDark ? colors.gray[200] : colors.gray[700]}
+            colors={[colors.violet[500]]}
+            progressBackgroundColor={
+              isDark ? colors.gray[200] : colors.gray[100]
+            }
+          />
+        }
         renderItem={renderItem}
         keyExtractor={keyExtractor}
         ItemSeparatorComponent={Separator}

--- a/packages/app/components/profile/index.tsx
+++ b/packages/app/components/profile/index.tsx
@@ -163,7 +163,7 @@ const Profile = ({ username }: ProfileScreenProps) => {
           />
         )}
         <View tw="web:max-w-screen-xl w-full">
-          {Platform.OS === "ios" && <View style={{ height: headerHeight }} />}
+          {Platform.OS !== "web" && <View style={{ height: headerHeight }} />}
           <ProfileTop
             address={username}
             animationHeaderPosition={animationHeaderPosition}
@@ -198,14 +198,8 @@ const Profile = ({ username }: ProfileScreenProps) => {
           renderScene={renderScene}
           onIndexChange={setIndex}
           renderScrollHeader={renderHeader}
-          minHeaderHeight={Platform.select({
-            default: headerHeight,
-            android: 0,
-          })}
-          refreshControlTop={Platform.select({
-            ios: headerHeight,
-            default: 0,
-          })}
+          minHeaderHeight={headerHeight}
+          refreshControlTop={headerHeight}
           initialLayout={{
             width: contentWidth,
           }}

--- a/packages/app/components/search/index.tsx
+++ b/packages/app/components/search/index.tsx
@@ -52,7 +52,7 @@ export const Search = () => {
 
   return (
     <>
-      {isiOS ? <View style={{ height: headerHeight }} /> : null}
+      {Platform.OS !== "web" && <View style={{ height: headerHeight }} />}
       <View tw="px-4 py-2">
         <Input
           placeholder="Search for @name or name.eth"

--- a/packages/app/components/settings/blocked-list.tsx
+++ b/packages/app/components/settings/blocked-list.tsx
@@ -46,12 +46,10 @@ export const UserItem = (props: UserItemProps) => {
 
 export const BlockedList = () => {
   const headerHeight = useHeaderHeight();
-  const shouldRenderHeaderGap =
-    Platform.OS !== "web" && Platform.OS !== "android";
 
   return (
     <ScrollView tw="w-full">
-      {shouldRenderHeaderGap && <View style={{ height: headerHeight }} />}
+      {Platform.OS !== "web" && <View style={{ height: headerHeight }} />}
       <SettingHeaderSection title="Blocked List" />
       <SettingBody>
         <View tw="flex-1 px-4 pt-4">

--- a/packages/app/components/settings/index.tsx
+++ b/packages/app/components/settings/index.tsx
@@ -336,7 +336,7 @@ const SettingsTabs = () => {
   const renderHeader = useCallback(() => {
     return (
       <>
-        {Platform.OS === "ios" && <View style={{ height: headerHeight }} />}
+        {Platform.OS !== "web" && <View style={{ height: headerHeight }} />}
         <View tw="dark:shadow-dark shadow-light items-center bg-white dark:bg-black md:mb-4">
           <View tw="w-full max-w-screen-2xl flex-row justify-between self-center px-4 py-4 md:py-0">
             <Text tw="font-space-bold self-center text-2xl font-extrabold text-gray-900 dark:text-white">

--- a/packages/app/components/settings/privacy-and-security.tsx
+++ b/packages/app/components/settings/privacy-and-security.tsx
@@ -23,8 +23,6 @@ const list = [
 
 export const PrivacyAndSecuritySettings = () => {
   const headerHeight = useHeaderHeight();
-  const shouldRenderHeaderGap =
-    Platform.OS !== "web" && Platform.OS !== "android";
 
   const renderSetting = (item: AccountSettingItemProps) => {
     return (
@@ -37,7 +35,7 @@ export const PrivacyAndSecuritySettings = () => {
 
   return (
     <ScrollView tw="w-full">
-      {shouldRenderHeaderGap && <View style={{ height: headerHeight }} />}
+      {Platform.OS !== "web" && <View style={{ height: headerHeight }} />}
       <SettingHeaderSection title="Privacy & Security" />
       <SettingBody>{list.map(renderSetting)}</SettingBody>
     </ScrollView>

--- a/packages/app/components/swipe-list.tsx
+++ b/packages/app/components/swipe-list.tsx
@@ -46,7 +46,7 @@ export const SwipeList = ({
 
   const itemHeight = Platform.select({
     web: windowHeight - headerHeight,
-    android: safeAreaFrameHeight - headerHeight,
+    android: safeAreaFrameHeight,
     default: screenHeight,
   });
 

--- a/packages/app/components/trending/index.tsx
+++ b/packages/app/components/trending/index.tsx
@@ -106,7 +106,7 @@ export const Trending = () => {
   const renderHeader = useCallback(() => {
     return (
       <>
-        {Platform.OS === "ios" && <View style={{ height: headerHeight }} />}
+        {Platform.OS !== "web" && <View style={{ height: headerHeight }} />}
         <View tw="flex-row justify-between bg-white py-2 px-4 dark:bg-black">
           <Text tw="font-space-bold text-2xl font-extrabold text-gray-900 dark:text-white">
             Trending
@@ -126,14 +126,8 @@ export const Trending = () => {
           renderScene={renderScene}
           onIndexChange={setIndex}
           renderScrollHeader={renderHeader}
-          minHeaderHeight={Platform.select({
-            default: headerHeight,
-            android: 0,
-          })}
-          refreshControlTop={Platform.select({
-            ios: headerHeight,
-            default: 0,
-          })}
+          minHeaderHeight={headerHeight}
+          refreshControlTop={headerHeight}
           initialLayout={{
             width: contentWidth,
           }}

--- a/packages/app/hooks/use-expo-update.tsx
+++ b/packages/app/hooks/use-expo-update.tsx
@@ -50,7 +50,9 @@ export function useExpoUpdate() {
         captureException(error);
       }
     },
-    [snackbar, bottom]
+    // just use snackbar to prompt once
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [bottom]
   );
 
   useEffect(() => {

--- a/packages/app/navigation/bottom-tab-bar.tsx
+++ b/packages/app/navigation/bottom-tab-bar.tsx
@@ -49,7 +49,7 @@ export const BottomTabbar = ({
     >
       <BlurView
         blurRadius={20}
-        overlayColor="rgba(255,255,255,.8)"
+        overlayColor={isDark ? "rgba(0,0,0,.8)" : "rgba(255, 255, 255, 0.8)"}
         blurAmount={100}
       >
         <View tw="flex-row bg-transparent pt-2">

--- a/packages/app/screens/nft.tsx
+++ b/packages/app/screens/nft.tsx
@@ -122,7 +122,7 @@ const NFTDetail = () => {
         headerHeight -
         (isAuthenticated && !isMdWidth ? MOBILE_WEB_BOTTOM_NAV_HEIGHT : 0)
       : Platform.OS === "android"
-      ? safeAreaFrameHeight - headerHeight
+      ? safeAreaFrameHeight
       : screenHeight;
   const nft = data?.data?.item;
 


### PR DESCRIPTION
# Why

- due to the header's layout position being `absolute`, so many screens are broken on Android.
- the `refreshControl` progress view offset is not good on the notification screen.
- `refreshControl` color is weird on light mode.

# How

- handle headers like iOS.
- and add some props to `RefreshControl` on the notification list.

# Before 


https://user-images.githubusercontent.com/37520667/191218840-42f2b66f-b057-48c7-9f17-ddb6a50c31f7.mov

# After 

https://user-images.githubusercontent.com/37520667/191220095-6926a7ec-645f-4c99-a6ab-a702f6187bc3.mov




# Test Plan

check if all screen looks good on Android.
