### PR TITLE
fix: claim limit increase phone verification alert

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -23,7 +23,7 @@
     },
     "alert": {
         "scope": "showtime.universal",
-        "version": "0.0.68",
+        "version": "0.0.69",
         "mainFile": "index.tsx",
         "rootDir": "packages/design-system/alert"
     },

--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -74,7 +74,7 @@
     "@shopify/flash-list": "^1.2.1",
     "@showtime-xyz/universal.accordion": "^0.0.54",
     "@showtime-xyz/universal.activity-indicator": "^0.0.40",
-    "@showtime-xyz/universal.alert": "^0.0.68",
+    "@showtime-xyz/universal.alert": "^0.0.69",
     "@showtime-xyz/universal.avatar": "^0.0.45",
     "@showtime-xyz/universal.bottom-sheet": "^0.0.60",
     "@showtime-xyz/universal.button": "^0.0.58",

--- a/packages/app/components/login/login-input-field.tsx
+++ b/packages/app/components/login/login-input-field.tsx
@@ -100,7 +100,7 @@ export function LoginInputField({
 
       <Button
         onPress={handleSubmit(handleSubmitData)}
-        variant="tertiary"
+        variant="primary"
         size="regular"
         tw="mt-6"
         disabled={!inputValue}

--- a/packages/app/hooks/use-claim-nft.ts
+++ b/packages/app/hooks/use-claim-nft.ts
@@ -238,7 +238,12 @@ export const useClaimNFT = (edition?: IEdition) => {
       Logger.error("nft drop claim failed", e);
 
       if (e?.response?.status === 420) {
-        if (!userProfile?.data.profile.has_verified_phone_number) {
+        // Verified users have drop limit to 10 and users that have phone verified also have drop limit to 10.
+        // So increasing drop limit alert makes sense only when you're not verified and you've not verified your phone
+        if (
+          !userProfile?.data.profile.has_verified_phone_number &&
+          !userProfile?.data.profile.verified
+        ) {
           Alert.alert(
             "Wow, you love claiming drops!",
             "Prove you're a real person and we'll let you claim more. Please verify your phone number.",

--- a/packages/app/hooks/use-claim-nft.ts
+++ b/packages/app/hooks/use-claim-nft.ts
@@ -238,8 +238,8 @@ export const useClaimNFT = (edition?: IEdition) => {
       Logger.error("nft drop claim failed", e);
 
       if (e?.response?.status === 420) {
-        // Verified users have drop limit to 10 and users that have phone verified also have drop limit to 10.
-        // So increasing drop limit alert makes sense only when you're not verified and you've not verified your phone
+        // Verified users have claim limit to 10 and users that have phone verified also have claim limit to 10.
+        // So increasing claim limit alert makes sense only when you're not verified and you've not verified your phone
         if (
           !userProfile?.data.profile.has_verified_phone_number &&
           !userProfile?.data.profile.verified

--- a/packages/design-system/alert/index.tsx
+++ b/packages/design-system/alert/index.tsx
@@ -13,7 +13,6 @@ import {
   StyleSheet,
 } from "react-native";
 
-import { useIsDarkMode } from "@showtime-xyz/universal.hooks";
 import { View } from "@showtime-xyz/universal.view";
 
 import { AlertContainer } from "./alert-container";
@@ -38,7 +37,6 @@ export const AlertContext = createContext<AlertContextType>({
 export const AlertProvider: React.FC<{ children: JSX.Element }> = ({
   children,
 }) => {
-  const isDark = useIsDarkMode();
   const [show, setShow] = useState(false);
   const [title, setTitle] = useState("");
   const [message, setMessage] = useState("");
@@ -52,7 +50,8 @@ export const AlertProvider: React.FC<{ children: JSX.Element }> = ({
 
   const closeAlert = useCallback(() => {
     setShow(false);
-  }, []);
+    onModalDismiss();
+  }, [onModalDismiss]);
 
   const value = useMemo(
     () => ({

--- a/yarn.lock
+++ b/yarn.lock
@@ -7317,9 +7317,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@showtime-xyz/universal.alert@npm:^0.0.68":
-  version: 0.0.68
-  resolution: "@showtime-xyz/universal.alert@npm:0.0.68"
+"@showtime-xyz/universal.alert@npm:^0.0.69":
+  version: 0.0.69
+  resolution: "@showtime-xyz/universal.alert@npm:0.0.69"
   dependencies:
     "@radix-ui/react-portal": 0.1.4
     "@showtime-xyz/universal.button": 0.0.58
@@ -7337,7 +7337,7 @@ __metadata:
     react-dom: ^16.8.0 || ^17.0.0
     react-native: ^0.64.1
     react-native-web: ^0.16.0
-  checksum: 2f837ff36e4ca85f9daa5eb6e78ec5aa140f6dc1236d52d51ea1962c68d492da80c06db892d75189038d3fc9dadb43da819bb77de48ca3908e15941eefaab15a
+  checksum: 98f983c33c22ce08300e6b005c2d64461169596be5cb5460e99c4e2e924921a2959fbc36b74ef503425684b31eb03081fb10c0651b2fa743e59ec958a20bce08
   languageName: node
   linkType: hard
 
@@ -8231,7 +8231,7 @@ __metadata:
     "@shopify/flash-list": ^1.2.1
     "@showtime-xyz/universal.accordion": ^0.0.54
     "@showtime-xyz/universal.activity-indicator": ^0.0.40
-    "@showtime-xyz/universal.alert": ^0.0.68
+    "@showtime-xyz/universal.alert": ^0.0.69
     "@showtime-xyz/universal.avatar": ^0.0.45
     "@showtime-xyz/universal.bottom-sheet": ^0.0.60
     "@showtime-xyz/universal.button": ^0.0.58


### PR DESCRIPTION
# Why
- Alert can contain old state buttons, it was partially leading to bug where user might be shown verify phone button. 
- When user is verified (tickmark) they have drop limit to 10, showing increase claim limit alert to these users doesn't make sense. 
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- Show claim limit increase alert for users that are not verified and that haven't verified phone number
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Try a new account and try claiming more than 5 NFTs. Verify adding number increases it. Right now hard to test due to https://showtime-rq88331.slack.com/archives/C02QD3J7DJM/p1663668503893109
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
