### PR TITLE
fix: sometimes header incorrect height on Android

### DIFF
--- a/packages/app/components/feed-item/index.tsx
+++ b/packages/app/components/feed-item/index.tsx
@@ -29,6 +29,7 @@ import { useCreatorCollectionDetail } from "app/hooks/use-creator-collection-det
 import { usePlatformBottomHeight } from "app/hooks/use-platform-bottom-height";
 import { Blurhash } from "app/lib/blurhash";
 import { BlurView } from "app/lib/blurview";
+import { useHeaderHeight } from "app/lib/react-navigation/elements";
 import { useNavigation } from "app/lib/react-navigation/native";
 import type { NFT } from "app/types";
 import { getMediaUrl } from "app/utilities";
@@ -41,7 +42,6 @@ export type FeedItemProps = {
   detailStyle?: StyleProp<ViewStyle>;
   bottomPadding?: number;
   bottomMargin?: number;
-  headerHeight?: number;
   itemHeight: number;
   setMomentumScrollCallback?: (callback: any) => void;
 };
@@ -51,11 +51,11 @@ export const FeedItem = memo<FeedItemProps>(function FeedItem({
   nft,
   bottomPadding = 0,
   bottomMargin = 0,
-  headerHeight = 0,
   itemHeight,
   setMomentumScrollCallback,
 }) {
   const [detailHeight, setDetailHeight] = useState(0);
+  const headerHeight = useHeaderHeight();
   const { width: windowWidth, height: windowHeight } = useWindowDimensions();
   const navigation = useNavigation();
   const bottomHeight = usePlatformBottomHeight();
@@ -165,7 +165,13 @@ export const FeedItem = memo<FeedItemProps>(function FeedItem({
 
   return (
     <LikeContextProvider nft={nft} key={nft.nft_id}>
-      <View tw="w-full" style={{ height: itemHeight, overflow: "hidden" }}>
+      <View
+        tw="w-full"
+        style={{
+          height: itemHeight,
+          overflow: "hidden",
+        }}
+      >
         {Platform.OS !== "web" && (
           <View>
             {nft.blurhash ? (

--- a/packages/app/components/search/index.tsx
+++ b/packages/app/components/search/index.tsx
@@ -34,7 +34,6 @@ export const Search = () => {
     () => <View tw="h-[1px] bg-gray-200 dark:bg-gray-800" />,
     []
   );
-  const isiOS = Platform.OS === "ios";
 
   const renderItem = useCallback(
     ({ item }: ListRenderItemInfo<SearchResponseItem>) => {

--- a/packages/app/components/swipe-list.tsx
+++ b/packages/app/components/swipe-list.tsx
@@ -35,7 +35,6 @@ export const SwipeList = ({
 }: Props) => {
   const listRef = useRef<any>(null);
   const headerHeight = useHeaderHeight();
-  const headerHeightRef = useRef(headerHeight);
   useScrollToTop(listRef);
   const { height: safeAreaFrameHeight } = useSafeAreaFrame();
   const { height: windowHeight } = useWindowDimensions();
@@ -58,7 +57,6 @@ export const SwipeList = ({
           itemHeight,
           bottomPadding,
           setMomentumScrollCallback,
-          headerHeight: headerHeightRef.current,
         }}
       />
     ),

--- a/packages/app/navigation/navigator-screen-options.tsx
+++ b/packages/app/navigation/navigator-screen-options.tsx
@@ -29,6 +29,7 @@ export const screenOptions = ({
     // @ts-ignore
     headerStyle: {
       height: 64 + safeAreaTop,
+      position: "absolute",
       // Similar to `headerShadowVisible` but for web
       // @ts-ignore
       borderBottomWidth: 0,

--- a/packages/app/pages/home/index.tsx
+++ b/packages/app/pages/home/index.tsx
@@ -1,5 +1,3 @@
-import { View } from "react-native";
-
 import { Button } from "@showtime-xyz/universal.button";
 import { useIsDarkMode } from "@showtime-xyz/universal.hooks";
 import { useRouter } from "@showtime-xyz/universal.router";
@@ -13,11 +11,8 @@ import { HomeScreen } from "app/screens/home";
 
 const HomeStack = createStackNavigator<HomeStackParams>();
 
-const HeaderRight = () => {
+const NativeHeaderRight = () => {
   const router = useRouter();
-  const { isLoading, isAuthenticated } = useUser();
-
-  if (isAuthenticated || isLoading) return <View />;
 
   return (
     <Button
@@ -38,14 +33,14 @@ const HeaderRight = () => {
 function HomeNavigator() {
   const { top: safeAreaTop } = useSafeAreaInsets();
   const isDark = useIsDarkMode();
-
+  const { isLoading, isAuthenticated } = useUser();
   return (
     <HomeStack.Navigator
       // @ts-ignore
       screenOptions={screenOptions({
         safeAreaTop,
         isDark,
-        headerRight: HeaderRight,
+        headerRight: isAuthenticated || isLoading ? null : NativeHeaderRight,
       })}
     >
       <HomeStack.Screen name="home" component={HomeScreen} />

--- a/packages/app/pages/home/index.tsx
+++ b/packages/app/pages/home/index.tsx
@@ -36,7 +36,6 @@ function HomeNavigator() {
   const { isLoading, isAuthenticated } = useUser();
   return (
     <HomeStack.Navigator
-      // @ts-ignore
       screenOptions={screenOptions({
         safeAreaTop,
         isDark,


### PR DESCRIPTION
# Why
just noticed that sometimes the header is the incorrect height on the Android home tab screen, looks like is `HomeNavigator`'s `headerRight` prop of reason.


# How

adjust header height and use `null` to replace with `<View/>` when not logged in on home tab `HeaderRight`.

# Before 

https://user-images.githubusercontent.com/37520667/191244819-4e20f338-3152-497d-8d14-aa501617d21e.mov

# After

https://user-images.githubusercontent.com/37520667/191244886-cf1d914d-1683-425f-8d9a-26d9a1ca5544.mov

