### PR TITLE
Feature/show2 1207 pressing tab key takes to the next tab

### DIFF
--- a/packages/app/components/edit-profile.tsx
+++ b/packages/app/components/edit-profile.tsx
@@ -4,7 +4,7 @@ import { Platform, useWindowDimensions } from "react-native";
 import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { Controller, useForm } from "react-hook-form";
-import { KeyboardAwareScrollViewProps } from "react-native-keyboard-aware-scroll-view";
+import type { KeyboardAwareScrollViewProps } from "react-native-keyboard-aware-scroll-view";
 import { useSWRConfig } from "swr";
 
 import { Button } from "@showtime-xyz/universal.button";

--- a/packages/app/components/edit-profile.tsx
+++ b/packages/app/components/edit-profile.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useMemo, useState, useCallback } from "react";
-import { Platform, useWindowDimensions, ScrollView } from "react-native";
+import { Platform, useWindowDimensions } from "react-native";
 
 import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { Controller, useForm } from "react-hook-form";
-import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
+import { KeyboardAwareScrollViewProps } from "react-native-keyboard-aware-scroll-view";
 import { useSWRConfig } from "swr";
 
 import { Button } from "@showtime-xyz/universal.button";
@@ -13,6 +13,7 @@ import { Upload } from "@showtime-xyz/universal.icon";
 import { Pressable } from "@showtime-xyz/universal.pressable";
 import { useRouter } from "@showtime-xyz/universal.router";
 import { useSafeAreaInsets } from "@showtime-xyz/universal.safe-area";
+import { ScrollView } from "@showtime-xyz/universal.scroll-view";
 import {
   SceneRendererProps,
   TabView,
@@ -57,7 +58,19 @@ const EDIT_PROFILE_ROUTES = [
     index: 2,
   },
 ];
+type SceneViewProps = KeyboardAwareScrollViewProps & {
+  focused?: boolean;
+};
 
+const SceneView = ({ focused, style, ...props }: SceneViewProps) => {
+  return (
+    <ScrollView
+      style={[style, { display: focused ? "flex" : "none" }]}
+      asKeyboardAwareScrollView
+      {...props}
+    />
+  );
+};
 const editProfileValidationSchema = yup.object({
   username: yup
     .string()
@@ -272,14 +285,15 @@ export const EditProfile = () => {
 
   const renderScene = useCallback(
     ({
-      route: { key },
+      route: { key, index: routeIndex },
     }: SceneRendererProps & {
       route: Route;
     }) => {
+      const focused = index === routeIndex || Platform.OS !== "web";
       switch (key) {
         case "Profile":
           return (
-            <KeyboardAwareScrollView>
+            <SceneView focused={focused}>
               <Controller
                 control={control}
                 name="coverPicture"
@@ -438,12 +452,13 @@ export const EditProfile = () => {
                   )}
                 />
               </View>
-            </KeyboardAwareScrollView>
+            </SceneView>
           );
         case "Links":
           return (
-            <KeyboardAwareScrollView
+            <SceneView
               extraScrollHeight={extraScrollHeight}
+              focused={focused}
               style={{ padding: 16, marginTop: 16 }}
             >
               {hasNotSubmittedExternalLink ? (
@@ -496,11 +511,12 @@ export const EditProfile = () => {
                               style={{
                                 marginTop: Platform.select({
                                   ios: 1,
-                                  android: 4,
+                                  android: 8,
                                   default: 0,
                                 }),
                                 marginBottom: Platform.select({
                                   default: 4,
+                                  android: 0,
                                   web: 0,
                                 }),
                               }}
@@ -513,11 +529,11 @@ export const EditProfile = () => {
                     />
                   );
                 })}
-            </KeyboardAwareScrollView>
+            </SceneView>
           );
         case "Settings":
           return (
-            <ScrollView style={{ padding: 16, marginTop: 16 }}>
+            <SceneView style={{ padding: 16, marginTop: 16 }} focused={focused}>
               <View tw="z-2">
                 <Controller
                   control={control}
@@ -572,7 +588,7 @@ export const EditProfile = () => {
                   />
                 )}
               />
-            </ScrollView>
+            </SceneView>
           );
 
         default:
@@ -588,6 +604,7 @@ export const EditProfile = () => {
       errors.username?.message,
       extraScrollHeight,
       hasNotSubmittedExternalLink,
+      index,
       isMdWidth,
       isValid,
       pickFile,

--- a/packages/app/components/feed-item/index.tsx
+++ b/packages/app/components/feed-item/index.tsx
@@ -29,6 +29,7 @@ import { useCreatorCollectionDetail } from "app/hooks/use-creator-collection-det
 import { usePlatformBottomHeight } from "app/hooks/use-platform-bottom-height";
 import { Blurhash } from "app/lib/blurhash";
 import { BlurView } from "app/lib/blurview";
+import { useHeaderHeight } from "app/lib/react-navigation/elements";
 import { useNavigation } from "app/lib/react-navigation/native";
 import type { NFT } from "app/types";
 import { getMediaUrl } from "app/utilities";
@@ -41,7 +42,6 @@ export type FeedItemProps = {
   detailStyle?: StyleProp<ViewStyle>;
   bottomPadding?: number;
   bottomMargin?: number;
-  headerHeight?: number;
   itemHeight: number;
   setMomentumScrollCallback?: (callback: any) => void;
 };
@@ -51,11 +51,11 @@ export const FeedItem = memo<FeedItemProps>(function FeedItem({
   nft,
   bottomPadding = 0,
   bottomMargin = 0,
-  headerHeight = 0,
   itemHeight,
   setMomentumScrollCallback,
 }) {
   const [detailHeight, setDetailHeight] = useState(0);
+  const headerHeight = useHeaderHeight();
   const { width: windowWidth, height: windowHeight } = useWindowDimensions();
   const navigation = useNavigation();
   const bottomHeight = usePlatformBottomHeight();
@@ -165,7 +165,13 @@ export const FeedItem = memo<FeedItemProps>(function FeedItem({
 
   return (
     <LikeContextProvider nft={nft} key={nft.nft_id}>
-      <View tw="w-full" style={{ height: itemHeight, overflow: "hidden" }}>
+      <View
+        tw="w-full"
+        style={{
+          height: itemHeight,
+          overflow: "hidden",
+        }}
+      >
         {Platform.OS !== "web" && (
           <View>
             {nft.blurhash ? (

--- a/packages/app/components/search/index.tsx
+++ b/packages/app/components/search/index.tsx
@@ -34,7 +34,6 @@ export const Search = () => {
     () => <View tw="h-[1px] bg-gray-200 dark:bg-gray-800" />,
     []
   );
-  const isiOS = Platform.OS === "ios";
 
   const renderItem = useCallback(
     ({ item }: ListRenderItemInfo<SearchResponseItem>) => {

--- a/packages/app/components/swipe-list.tsx
+++ b/packages/app/components/swipe-list.tsx
@@ -35,7 +35,6 @@ export const SwipeList = ({
 }: Props) => {
   const listRef = useRef<any>(null);
   const headerHeight = useHeaderHeight();
-  const headerHeightRef = useRef(headerHeight);
   useScrollToTop(listRef);
   const { height: safeAreaFrameHeight } = useSafeAreaFrame();
   const { height: windowHeight } = useWindowDimensions();
@@ -58,7 +57,6 @@ export const SwipeList = ({
           itemHeight,
           bottomPadding,
           setMomentumScrollCallback,
-          headerHeight: headerHeightRef.current,
         }}
       />
     ),

--- a/packages/app/navigation/navigator-screen-options.tsx
+++ b/packages/app/navigation/navigator-screen-options.tsx
@@ -29,6 +29,7 @@ export const screenOptions = ({
     // @ts-ignore
     headerStyle: {
       height: 64 + safeAreaTop,
+      position: "absolute",
       // Similar to `headerShadowVisible` but for web
       // @ts-ignore
       borderBottomWidth: 0,

--- a/packages/app/pages/home/index.tsx
+++ b/packages/app/pages/home/index.tsx
@@ -1,5 +1,3 @@
-import { View } from "react-native";
-
 import { Button } from "@showtime-xyz/universal.button";
 import { useIsDarkMode } from "@showtime-xyz/universal.hooks";
 import { useRouter } from "@showtime-xyz/universal.router";
@@ -13,11 +11,8 @@ import { HomeScreen } from "app/screens/home";
 
 const HomeStack = createStackNavigator<HomeStackParams>();
 
-const HeaderRight = () => {
+const NativeHeaderRight = () => {
   const router = useRouter();
-  const { isLoading, isAuthenticated } = useUser();
-
-  if (isAuthenticated || isLoading) return <View />;
 
   return (
     <Button
@@ -38,14 +33,14 @@ const HeaderRight = () => {
 function HomeNavigator() {
   const { top: safeAreaTop } = useSafeAreaInsets();
   const isDark = useIsDarkMode();
-
+  const { isLoading, isAuthenticated } = useUser();
   return (
     <HomeStack.Navigator
       // @ts-ignore
       screenOptions={screenOptions({
         safeAreaTop,
         isDark,
-        headerRight: HeaderRight,
+        headerRight: isAuthenticated || isLoading ? null : NativeHeaderRight,
       })}
     >
       <HomeStack.Screen name="home" component={HomeScreen} />

--- a/packages/app/pages/home/index.tsx
+++ b/packages/app/pages/home/index.tsx
@@ -36,7 +36,6 @@ function HomeNavigator() {
   const { isLoading, isAuthenticated } = useUser();
   return (
     <HomeStack.Navigator
-      // @ts-ignore
       screenOptions={screenOptions({
         safeAreaTop,
         isDark,


### PR DESCRIPTION
# Why

- [pressing `tab key` takes to the next Tab content](https://linear.app/showtime/issue/SHOW2-1207/pressing-tab-key-takes-to-the-next-tab-content) 
- links input field is not aligned.
![image](https://user-images.githubusercontent.com/37520667/191258567-a6cef145-71a3-4ddf-afe5-f54bc8049b8b.png)

# How

- set `display: none;` when the tab is not visible on the web. 
- adjust input left element style.

# Test Plan

check if the `edit-profile` screen looks good on Android and Web!
