### PR TITLE
new drop/claim UX improvements

### DIFF
--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@bacons/link-assets": "^1.1.0",
     "@capsizecss/core": "^3.0.0",
-    "@coinbase/wallet-mobile-sdk": "^0.3.1",
+    "@coinbase/wallet-mobile-sdk": "0.3.1",
     "@ethersproject/shims": "^5.7.0",
     "@gorhom/bottom-sheet": "4.4.2",
     "@hookform/resolvers": "^2.8.5",

--- a/packages/app/components/add-wallet-or-set-primary/add-wallet-or-set-primary.tsx
+++ b/packages/app/components/add-wallet-or-set-primary/add-wallet-or-set-primary.tsx
@@ -20,7 +20,7 @@ export const AddWalletOrSetPrimary = ({
         </Text>
       </View>
       <TextLink
-        href="/settings"
+        href="/settings?popOnSuccess=true"
         tw="rounded-3xl bg-gray-900 py-3 px-4 text-sm font-bold text-white dark:bg-gray-200 dark:text-black"
       >
         Select Primary Wallet

--- a/packages/app/components/add-wallet-or-set-primary/add-wallet-or-set-primary.tsx
+++ b/packages/app/components/add-wallet-or-set-primary/add-wallet-or-set-primary.tsx
@@ -1,7 +1,9 @@
+import { Platform } from "react-native";
+
+import { Button } from "@showtime-xyz/universal.button";
+import { useRouter } from "@showtime-xyz/universal.router";
 import { Text } from "@showtime-xyz/universal.text";
 import { View } from "@showtime-xyz/universal.view";
-
-import { TextLink } from "app/navigation/link";
 
 export const AddWalletOrSetPrimary = ({
   title,
@@ -10,8 +12,9 @@ export const AddWalletOrSetPrimary = ({
   title: string;
   description: string;
 }) => {
+  const router = useRouter();
   return (
-    <View tw="items-center py-2">
+    <View tw="items-center p-2">
       <View tw="h-8" />
       <Text tw="text-center text-xl text-black dark:text-white">{title} </Text>
       <View tw="mt-8 mb-10">
@@ -19,12 +22,19 @@ export const AddWalletOrSetPrimary = ({
           {description}
         </Text>
       </View>
-      <TextLink
-        href="/settings?popOnSuccess=true"
-        tw="rounded-3xl bg-gray-900 py-3 px-4 text-sm font-bold text-white dark:bg-gray-200 dark:text-black"
+      <Button
+        onPress={() => {
+          // Close the native modal
+          if (Platform.OS !== "web") {
+            router.pop();
+          }
+
+          router.push("/settings?redirectTo=" + router.pathname);
+        }}
+        size="regular"
       >
         Select Primary Wallet
-      </TextLink>
+      </Button>
     </View>
   );
 };

--- a/packages/app/components/add-wallet-or-set-primary/add-wallet-or-set-primary.tsx
+++ b/packages/app/components/add-wallet-or-set-primary/add-wallet-or-set-primary.tsx
@@ -8,9 +8,11 @@ import { View } from "@showtime-xyz/universal.view";
 export const AddWalletOrSetPrimary = ({
   title,
   description,
+  contractAddress,
 }: {
   title: string;
   description: string;
+  contractAddress: string;
 }) => {
   const router = useRouter();
   return (
@@ -24,12 +26,12 @@ export const AddWalletOrSetPrimary = ({
       </View>
       <Button
         onPress={() => {
-          // Close the native modal
+          // Close modal on native
           if (Platform.OS !== "web") {
             router.pop();
           }
 
-          router.push("/settings?redirectTo=" + router.pathname);
+          router.push("/settings?editionContractAddress=" + contractAddress);
         }}
         size="regular"
       >

--- a/packages/app/components/claim/claim-button.tsx
+++ b/packages/app/components/claim/claim-button.tsx
@@ -16,7 +16,7 @@ export const ClaimButton = ({ edition, size = "small" }: ClaimButtonProps) => {
   const redirectToClaimDrop = useRedirectToClaimDrop();
 
   const onClaimPress = () => {
-    redirectToClaimDrop(edition);
+    redirectToClaimDrop(edition.creator_airdrop_edition.contract_address);
   };
 
   let isExpired = false;

--- a/packages/app/components/claim/claim-form.tsx
+++ b/packages/app/components/claim/claim-form.tsx
@@ -98,10 +98,11 @@ export const ClaimForm = ({ edition }: { edition: CreatorEditionResponse }) => {
   // }, [web3]);
 
   if (
-    !userProfile?.data.profile.username ||
-    userHasIncompleteExternalLinks(userProfile?.data.profile) ||
-    !userProfile?.data.profile.bio ||
-    !userProfile?.data.profile.img_url
+    userProfile &&
+    (!userProfile.data.profile.username ||
+      userHasIncompleteExternalLinks(userProfile.data.profile) ||
+      !userProfile.data.profile.bio ||
+      !userProfile.data.profile.img_url)
   ) {
     return (
       <CompleteProfileModalContent
@@ -191,6 +192,7 @@ export const ClaimForm = ({ edition }: { edition: CreatorEditionResponse }) => {
   if (!primaryWallet) {
     return (
       <AddWalletOrSetPrimary
+        contractAddress={edition?.creator_airdrop_edition.contract_address}
         title="Choose a primary wallet to receive your drop"
         description="Please choose which wallet will receive your drop. You only have to do this once!"
       />

--- a/packages/app/components/settings/add-email.tsx
+++ b/packages/app/components/settings/add-email.tsx
@@ -36,6 +36,8 @@ export const AddEmailModal = () => {
         const did = await magic.auth.loginWithMagicLink({ email });
         if (did) {
           await addEmail(email, did);
+          // logout user after magic login or else on next app mount wallet and magic both will be connected that can lead to wear bugs.
+          magic?.user?.logout();
           router.pop();
         }
       } catch (error) {

--- a/packages/app/components/settings/add-email.tsx
+++ b/packages/app/components/settings/add-email.tsx
@@ -34,10 +34,11 @@ export const AddEmailModal = () => {
 
       try {
         const did = await magic.auth.loginWithMagicLink({ email });
+        // logout user after magic login or else on next app mount wallet and magic both will be connected that can lead to wear bugs.
+        magic?.user?.logout();
+
         if (did) {
           await addEmail(email, did);
-          // logout user after magic login or else on next app mount wallet and magic both will be connected that can lead to wear bugs.
-          magic?.user?.logout();
           router.pop();
         }
       } catch (error) {

--- a/packages/app/components/settings/add-email.tsx
+++ b/packages/app/components/settings/add-email.tsx
@@ -34,7 +34,7 @@ export const AddEmailModal = () => {
 
       try {
         const did = await magic.auth.loginWithMagicLink({ email });
-        // logout user after magic login or else on next app mount wallet and magic both will be connected that can lead to wear bugs.
+        // logout user after magic login or else on next app mount wallet and magic both will be connected that can lead to weird bugs.
         magic?.user?.logout();
 
         if (did) {

--- a/packages/app/components/settings/settings-wallet-slot.tsx
+++ b/packages/app/components/settings/settings-wallet-slot.tsx
@@ -133,7 +133,7 @@ export const SettingsWalletSlot = (props: Props) => {
                 </Text>
               ) : null}
 
-              <View tw="md:mb-3 md:flex-row">
+              <View tw="mb-3 md:flex-row">
                 <Text tw="text-base font-bold text-gray-900 dark:text-white md:self-center">
                   {display}
                 </Text>
@@ -157,6 +157,7 @@ export const SettingsWalletSlot = (props: Props) => {
             <WalletDropdownMenu
               address={address}
               isCurrent={isConnectedAddress}
+              isMagicWallet={!!props.wallet.is_email || !!props.wallet.is_phone}
               onEditNickname={props.onEditNickname}
             />
           </View>

--- a/packages/app/components/settings/verify-phone-number.tsx
+++ b/packages/app/components/settings/verify-phone-number.tsx
@@ -35,7 +35,7 @@ export const VerifyPhoneNumberModal = () => {
         const did = await magic.auth.loginWithSMS({
           phoneNumber,
         });
-        // logout user after magic login or else on next app mount wallet and magic both will be connected that can lead to wear bugs.
+        // logout user after magic login or else on next app mount wallet and magic both will be connected that can lead to weird bugs.
         magic?.user?.logout();
 
         if (did) {

--- a/packages/app/components/settings/verify-phone-number.tsx
+++ b/packages/app/components/settings/verify-phone-number.tsx
@@ -35,10 +35,11 @@ export const VerifyPhoneNumberModal = () => {
         const did = await magic.auth.loginWithSMS({
           phoneNumber,
         });
+        // logout user after magic login or else on next app mount wallet and magic both will be connected that can lead to wear bugs.
+        magic?.user?.logout();
+
         if (did) {
           await verifyPhoneNumber(phoneNumber, did);
-          // logout user after magic login or else on next app mount wallet and magic both will be connected that can lead to wear bugs.
-          magic?.user?.logout();
           router.pop();
         }
       } catch (error) {

--- a/packages/app/components/settings/verify-phone-number.tsx
+++ b/packages/app/components/settings/verify-phone-number.tsx
@@ -37,6 +37,8 @@ export const VerifyPhoneNumberModal = () => {
         });
         if (did) {
           await verifyPhoneNumber(phoneNumber, did);
+          // logout user after magic login or else on next app mount wallet and magic both will be connected that can lead to wear bugs.
+          magic?.user?.logout();
           router.pop();
         }
       } catch (error) {

--- a/packages/app/components/settings/wallet-dropdown-menu.tsx
+++ b/packages/app/components/settings/wallet-dropdown-menu.tsx
@@ -1,9 +1,11 @@
+import { Linking } from "react-native";
+
 import { Button } from "@showtime-xyz/universal.button";
-import { Edit, MoreHorizontal } from "@showtime-xyz/universal.icon";
+import { Edit, MoreHorizontal, Wallet } from "@showtime-xyz/universal.icon";
 
 import { MenuItemIcon } from "app/components/dropdown/menu-item-icon";
 import { useManageAccount } from "app/hooks/use-manage-account";
-import { WalletAddressesExcludingEmailV2 } from "app/types";
+import { WalletAddressesV2 } from "app/types";
 
 import {
   DropdownMenuContent,
@@ -15,9 +17,10 @@ import {
 import { Trash } from "design-system/icon";
 
 type AddressMenuProps = {
-  address?: WalletAddressesExcludingEmailV2["address"] | undefined | null;
+  address?: WalletAddressesV2["address"] | undefined | null;
   isCurrent: boolean;
-  onEditNickname: (item: WalletAddressesExcludingEmailV2) => void;
+  onEditNickname: (item: WalletAddressesV2) => void;
+  isMagicWallet: boolean;
 };
 
 export const WalletDropdownMenu = (props: AddressMenuProps) => {
@@ -36,6 +39,18 @@ export const WalletDropdownMenu = (props: AddressMenuProps) => {
           <MenuItemIcon Icon={Edit} />
           <DropdownMenuItemTitle>Edit nickname</DropdownMenuItemTitle>
         </DropdownMenuItem>
+        {props.isMagicWallet ? (
+          <DropdownMenuItem
+            onSelect={() =>
+              Linking.openURL("https://reveal.magic.link/showtime")
+            }
+            key="export_key"
+          >
+            <MenuItemIcon Icon={Wallet} />
+
+            <DropdownMenuItemTitle>Export Private Key</DropdownMenuItemTitle>
+          </DropdownMenuItem>
+        ) : null}
 
         <DropdownMenuItem
           // @ts-ignore

--- a/packages/app/hooks/api/use-set-primary-wallet.ts
+++ b/packages/app/hooks/api/use-set-primary-wallet.ts
@@ -8,17 +8,14 @@ import { MY_INFO_ENDPOINT } from "app/providers/user-provider";
 import { WalletAddressesExcludingEmailV2 } from "app/types";
 
 type Query = {
-  popOnSuccess: boolean;
+  redirectTo: string;
 };
 
 const { useParam } = createParam<Query>();
 export const useSetPrimaryWallet = () => {
   const { mutate } = useSWRConfig();
   const router = useRouter();
-  const [popOnSuccess] = useParam("popOnSuccess", {
-    parse: (v) => v === "true",
-    initial: false,
-  });
+  const [redirectTo] = useParam("redirectTo");
 
   const setPrimaryWallet = async (wallet: WalletAddressesExcludingEmailV2) => {
     mutate(MY_INFO_ENDPOINT, async () => {
@@ -26,8 +23,8 @@ export const useSetPrimaryWallet = () => {
         url: `/v2/wallet/${wallet.address}/primary`,
         method: "PATCH",
       });
-      if (popOnSuccess) {
-        router.pop();
+      if (redirectTo) {
+        router.replace(redirectTo);
       }
     });
   };

--- a/packages/app/hooks/api/use-set-primary-wallet.ts
+++ b/packages/app/hooks/api/use-set-primary-wallet.ts
@@ -1,17 +1,34 @@
 import { useSWRConfig } from "swr";
 
+import { useRouter } from "@showtime-xyz/universal.router";
+
 import { axios } from "app/lib/axios";
+import { createParam } from "app/navigation/use-param";
 import { MY_INFO_ENDPOINT } from "app/providers/user-provider";
 import { WalletAddressesExcludingEmailV2 } from "app/types";
 
+type Query = {
+  popOnSuccess: boolean;
+};
+
+const { useParam } = createParam<Query>();
 export const useSetPrimaryWallet = () => {
   const { mutate } = useSWRConfig();
+  const router = useRouter();
+  const [popOnSuccess] = useParam("popOnSuccess", {
+    parse: (v) => v === "true",
+    initial: false,
+  });
+
   const setPrimaryWallet = async (wallet: WalletAddressesExcludingEmailV2) => {
     mutate(MY_INFO_ENDPOINT, async () => {
       await axios({
         url: `/v2/wallet/${wallet.address}/primary`,
         method: "PATCH",
       });
+      if (popOnSuccess) {
+        router.pop();
+      }
     });
   };
 

--- a/packages/app/hooks/api/use-set-primary-wallet.ts
+++ b/packages/app/hooks/api/use-set-primary-wallet.ts
@@ -1,21 +1,21 @@
 import { useSWRConfig } from "swr";
 
-import { useRouter } from "@showtime-xyz/universal.router";
-
 import { axios } from "app/lib/axios";
 import { createParam } from "app/navigation/use-param";
 import { MY_INFO_ENDPOINT } from "app/providers/user-provider";
 import { WalletAddressesExcludingEmailV2 } from "app/types";
 
+import { useRedirectToClaimDrop } from "../use-redirect-to-claim-drop";
+
 type Query = {
-  redirectTo: string;
+  editionContractAddress: string;
 };
 
 const { useParam } = createParam<Query>();
 export const useSetPrimaryWallet = () => {
   const { mutate } = useSWRConfig();
-  const router = useRouter();
-  const [redirectTo] = useParam("redirectTo");
+  const redirectToClaimDrop = useRedirectToClaimDrop();
+  const [editionContractAddress] = useParam("editionContractAddress");
 
   const setPrimaryWallet = async (wallet: WalletAddressesExcludingEmailV2) => {
     mutate(MY_INFO_ENDPOINT, async () => {
@@ -23,8 +23,8 @@ export const useSetPrimaryWallet = () => {
         url: `/v2/wallet/${wallet.address}/primary`,
         method: "PATCH",
       });
-      if (redirectTo) {
-        router.replace(redirectTo);
+      if (editionContractAddress) {
+        redirectToClaimDrop(editionContractAddress);
       }
     });
   };

--- a/packages/app/hooks/use-redirect-to-claim-drop.ts
+++ b/packages/app/hooks/use-redirect-to-claim-drop.ts
@@ -2,18 +2,17 @@ import { Platform } from "react-native";
 
 import { useRouter } from "@showtime-xyz/universal.router";
 
-import { CreatorEditionResponse } from "app/hooks/use-creator-collection-detail";
 import { useUser } from "app/hooks/use-user";
 
 export const useRedirectToClaimDrop = () => {
   const { isAuthenticated } = useUser();
   const router = useRouter();
 
-  const redirectToClaimDrop = (edition: CreatorEditionResponse) => {
+  const redirectToClaimDrop = (editionContractAddress: string) => {
     if (!isAuthenticated) {
       router.push("/login");
     } else {
-      const as = `/claim/${edition.creator_airdrop_edition.contract_address}`;
+      const as = `/claim/${editionContractAddress}`;
 
       router.push(
         Platform.select({
@@ -22,8 +21,7 @@ export const useRedirectToClaimDrop = () => {
             pathname: router.pathname,
             query: {
               ...router.query,
-              contractAddress:
-                edition?.creator_airdrop_edition.contract_address,
+              contractAddress: editionContractAddress,
               claimModal: true,
             },
           } as any,

--- a/packages/app/pages/home/index.tsx
+++ b/packages/app/pages/home/index.tsx
@@ -13,6 +13,9 @@ const HomeStack = createStackNavigator<HomeStackParams>();
 
 const NativeHeaderRight = () => {
   const router = useRouter();
+  const { isLoading, isAuthenticated } = useUser();
+
+  if (isLoading || isAuthenticated) return null;
 
   return (
     <Button
@@ -33,13 +36,12 @@ const NativeHeaderRight = () => {
 function HomeNavigator() {
   const { top: safeAreaTop } = useSafeAreaInsets();
   const isDark = useIsDarkMode();
-  const { isLoading, isAuthenticated } = useUser();
   return (
     <HomeStack.Navigator
       screenOptions={screenOptions({
         safeAreaTop,
         isDark,
-        headerRight: isAuthenticated || isLoading ? null : NativeHeaderRight,
+        headerRight: NativeHeaderRight,
       })}
     >
       <HomeStack.Screen name="home" component={HomeScreen} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2349,7 +2349,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@coinbase/wallet-mobile-sdk@npm:^0.3.1":
+"@coinbase/wallet-mobile-sdk@npm:0.3.1":
   version: 0.3.1
   resolution: "@coinbase/wallet-mobile-sdk@npm:0.3.1"
   dependencies:
@@ -8204,7 +8204,7 @@ __metadata:
     "@babel/runtime": ^7.18.9
     "@bacons/link-assets": ^1.1.0
     "@capsizecss/core": ^3.0.0
-    "@coinbase/wallet-mobile-sdk": ^0.3.1
+    "@coinbase/wallet-mobile-sdk": 0.3.1
     "@config-plugins/detox": ^1.1.0
     "@ethersproject/shims": ^5.7.0
     "@expo/xcpretty": ^4.2.2


### PR DESCRIPTION
# Why
- Go back to the claim page after set primary from the claim modal https://linear.app/showtime/issue/SHOW2-1224/go-back-after-set-primary-wallet-flow
- Fix claim happens with magic wallet after phone verification https://showtime-rq88331.slack.com/archives/C02PXGK3V8D/p1663705719814059
- Add export private key for magic wallet
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->


<!--
How did you build this feature or fix this bug and why?
-->



<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
