### PR TITLE
fix: null check before adding query param

### DIFF
--- a/packages/app/components/add-wallet-or-set-primary/add-wallet-or-set-primary.tsx
+++ b/packages/app/components/add-wallet-or-set-primary/add-wallet-or-set-primary.tsx
@@ -12,7 +12,7 @@ export const AddWalletOrSetPrimary = ({
 }: {
   title: string;
   description: string;
-  contractAddress: string;
+  contractAddress?: string;
 }) => {
   const router = useRouter();
   return (
@@ -30,8 +30,11 @@ export const AddWalletOrSetPrimary = ({
           if (Platform.OS !== "web") {
             router.pop();
           }
-
-          router.push("/settings?editionContractAddress=" + contractAddress);
+          if (contractAddress) {
+            router.push("/settings?editionContractAddress=" + contractAddress);
+          } else {
+            router.push("/settings");
+          }
         }}
         size="regular"
       >


### PR DESCRIPTION
# Why
This can happen if user presses set primary wallet before the edition API is completed. Rare occurance.

https://showtime-rq88331.slack.com/archives/C02PXGK3V8D/p1663757734176539
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
