### PR TITLE
fix: pressing "more" in notifications should open profile's "owned" tab

### DIFF
--- a/packages/app/components/claim/claim-form.tsx
+++ b/packages/app/components/claim/claim-form.tsx
@@ -271,22 +271,25 @@ export const ClaimForm = ({ edition }: { edition: CreatorEditionResponse }) => {
             </Text>
           </View>
 
-          <Fieldset
-            tw="mt-4 flex-1"
-            label="Add a comment (optional)"
-            placeholder="wow, this is so cool!"
-            onChangeText={(v) => (comment.current = v)}
-          />
+          {state.status === "idle" ? (
+            <Fieldset
+              tw="mt-4 flex-1"
+              label="Add a comment (optional)"
+              placeholder="wow, this is so cool!"
+              onChangeText={(v) => (comment.current = v)}
+            />
+          ) : null}
+
           <View tw="mt-4">
             <Button
               size="regular"
               variant="primary"
               disabled={state.status === "loading"}
-              tw={state.status === "loading" ? "opacity-45" : ""}
+              tw={state.status === "loading" ? "opacity-[0.45]" : ""}
               onPress={handleClaimNFT}
             >
               {state.status === "loading"
-                ? "Claiming..."
+                ? "Claiming... wait up to 10 seconds"
                 : state.status === "error"
                 ? "Failed. Retry!"
                 : "Claim for free"}

--- a/packages/app/components/drop/drop-form.tsx
+++ b/packages/app/components/drop/drop-form.tsx
@@ -540,7 +540,7 @@ export const DropForm = () => {
             <Button
               variant="primary"
               size="regular"
-              tw={state.status === "loading" ? "opacity-45" : ""}
+              tw={state.status === "loading" ? "opacity-[0.45]" : ""}
               disabled={state.status === "loading"}
               onPress={handleSubmit(onSubmit)}
             >

--- a/packages/app/components/notifications/nfts-display-name.tsx
+++ b/packages/app/components/notifications/nfts-display-name.tsx
@@ -46,7 +46,7 @@ export const NFTSDisolayName = ({ nfts }: NotificationDescriptionProps) => {
       <TextLink
         href={`/@${
           nft.creator.username || nft.creator.wallet_address
-        }?type=owned`}
+        }?tabType=owned`}
         tw="text-13 font-bold text-gray-600 dark:text-gray-400"
       >{` and ${nfts.length - 1} more`}</TextLink>
     </>


### PR DESCRIPTION

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
Tapping `and 9 more` in the first notification below should open `owned` tab of that profile
![IMG_C412FF7F0423-1](https://user-images.githubusercontent.com/23293248/191884688-bc5070bd-466c-4f9b-b248-2772c5a04ab4.jpeg)


<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
