### PR TITLE
fix: nft desc too height on desktop

### DIFF
--- a/packages/app/components/card/rows/description.tsx
+++ b/packages/app/components/card/rows/description.tsx
@@ -1,30 +1,29 @@
 import { StyleProp, ViewStyle } from "react-native";
 
-import Animated from "react-native-reanimated";
+import { ClampText } from "@showtime-xyz/universal.clamp-text";
+import { View, ViewProps } from "@showtime-xyz/universal.view";
 
 import { removeTags } from "app/utilities";
 
-import { ClampText } from "design-system/clamp-text";
-
-type Props = {
+type Props = ViewProps & {
   descriptionText?: string;
   style?: StyleProp<ViewStyle>;
   maxLines?: number;
 };
 
-function Description({ descriptionText = "", style, maxLines = 3 }: Props) {
+function Description({ descriptionText = "", maxLines = 3, ...rest }: Props) {
   if (!descriptionText || descriptionText === "") {
     return null;
   }
 
   return (
-    <Animated.View style={style}>
+    <View {...rest}>
       <ClampText
         tw="text-sm text-gray-600 dark:text-gray-400"
         maxLines={maxLines}
         text={removeTags(descriptionText)}
       />
-    </Animated.View>
+    </View>
   );
 }
 

--- a/packages/app/components/feed-item/details.tsx
+++ b/packages/app/components/feed-item/details.tsx
@@ -38,8 +38,8 @@ export const NFTDetails = ({ nft, edition }: NFTDetailsProps) => {
       </Text>
       <Description
         descriptionText={nft?.token_description}
-        style={{ paddingTop: 8 }}
         maxLines={2}
+        tw="max-h-[30vh] overflow-auto pt-2"
       />
       <View tw="h-4" />
 

--- a/packages/app/components/feed-item/feed-item.md.tsx
+++ b/packages/app/components/feed-item/feed-item.md.tsx
@@ -209,7 +209,7 @@ export const FeedItemMD = memo<FeedItemProps>(function FeedItemMD({
           </View>
           <Description
             descriptionText={nft?.token_description}
-            style={{ paddingHorizontal: 16, paddingBottom: 16 }}
+            tw="max-h-[30vh] overflow-auto p-4"
           />
           <View tw="flex-row items-center justify-between px-4">
             <Creator nft={nft} />

--- a/packages/design-system/clamp-text/clamp-text.tsx
+++ b/packages/design-system/clamp-text/clamp-text.tsx
@@ -54,13 +54,15 @@ export const ClampText = ({
         tw={tw}
         ref={textRef as any}
         style={Platform.select({
-          web: {
-            "-webkit-mask-image": showMore
-              ? `linear-gradient(to top, transparent 0%, transparent 2rem, rgb(0, 0, 0) 2rem, rgb(0, 0, 0) 100%), linear-gradient(to right, rgb(0, 0, 0) 0%, rgb(0, 0, 0) ${
-                  containerWidth / 2
-                }px, transparent ${containerWidth}px, transparent 100%)`
-              : null,
-          } as any,
+          web: isPureText
+            ? undefined
+            : ({
+                "-webkit-mask-image": showMore
+                  ? `linear-gradient(to top, transparent 0%, transparent 2rem, rgb(0, 0, 0) 2rem, rgb(0, 0, 0) 100%), linear-gradient(to right, rgb(0, 0, 0) 0%, rgb(0, 0, 0) ${
+                      containerWidth / 2
+                    }px, transparent ${containerWidth}px, transparent 100%)`
+                  : null,
+              } as any),
           default: undefined,
         })}
         onTextLayout={onTextLayout}


### PR DESCRIPTION
# Why

https://linear.app/showtime/issue/SHOW2-1058/nft-description 

# How

- just set `overflow-auto` to fix it.

# Test 

https://user-images.githubusercontent.com/37520667/191978932-f1267bc3-ed45-4af7-925b-8cd371ba339a.mov



