### PR TITLE
fix: image selection in edit-profile is weird

### DIFF
--- a/packages/app/components/edit-profile.tsx
+++ b/packages/app/components/edit-profile.tsx
@@ -310,9 +310,9 @@ export const EditProfile = () => {
                       });
                       const uri = getLocalFileURI(file.file);
 
+                      onChange(file.file);
                       setSelectedImg(uri);
                       setCurrentCropField("coverPicture");
-                      onChange(file.file);
                     }}
                     style={{
                       height: coverImageHeight,
@@ -351,9 +351,9 @@ export const EditProfile = () => {
                             option: { allowsEditing: true, aspect: [1, 1] },
                           });
 
+                          onChange(file.file);
                           setSelectedImg(getLocalFileURI(file.file));
                           setCurrentCropField("profilePicture");
-                          onChange(file.file);
                         }}
                         tw="h-24 w-24 overflow-hidden rounded-full border-2 border-gray-300 bg-white dark:border-gray-900 dark:bg-gray-800"
                       >

--- a/packages/app/components/edit-profile.tsx
+++ b/packages/app/components/edit-profile.tsx
@@ -74,6 +74,7 @@ const SceneView = ({ focused, style, ...props }: SceneViewProps) => {
 const editProfileValidationSchema = yup.object({
   username: yup
     .string()
+    .typeError("Please enter a valid username")
     .min(2)
     .max(30)
     .matches(


### PR DESCRIPTION
# Why
Image shows up when tried twice. 
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

https://user-images.githubusercontent.com/23293248/192231434-2768575c-5105-42b4-bb9f-dcbe3ebffc1f.mov


# How
- Not really sure why but changing the order of set state calls fixes it 😕 
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
Test changing image in edit-profile form
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
