### PR TITLE
feat: use v2/follow-suggestions

### DIFF
--- a/packages/app/components/feed/feed.md.tsx
+++ b/packages/app/components/feed/feed.md.tsx
@@ -18,12 +18,17 @@ import { VideoConfigContext } from "app/context/video-config-context";
 import { withViewabilityInfiniteScrollList } from "app/hocs/with-viewability-infinite-scroll-list";
 import { useFeed } from "app/hooks/use-feed";
 import { useFollowSuggestions } from "app/hooks/use-follow-suggestions";
+import { Sticky } from "app/lib/stickynode";
 import type { NFT } from "app/types";
+
+import { Hidden } from "design-system/hidden";
 
 const CARD_HEIGHT = 825;
 const CARD_CONTAINER_WIDTH = 620;
 const HORIZONTAL_GAPS = 24;
 const CARD_WIDTH = CARD_CONTAINER_WIDTH - HORIZONTAL_GAPS;
+const LEFT_SLIDE_WIDTH = 320;
+const LEFT_SLIDE_MARGIN = 64 - HORIZONTAL_GAPS / 2;
 
 // type Tab = "following" | "curated" | "" | undefined;
 
@@ -64,6 +69,18 @@ export const FeedList = () => {
 
   return (
     <View tw="flex-row">
+      <Hidden until="xl">
+        <View
+          style={{
+            width: LEFT_SLIDE_WIDTH,
+            marginRight: LEFT_SLIDE_MARGIN,
+          }}
+        >
+          <Sticky enabled>
+            <SuggestedUsers />
+          </Sticky>
+        </View>
+      </Hidden>
       <View tw="flex-1" style={{ width: CARD_CONTAINER_WIDTH }}>
         {/* {isAuthenticated ? (
           <>

--- a/packages/app/hooks/use-follow-suggestions.ts
+++ b/packages/app/hooks/use-follow-suggestions.ts
@@ -10,13 +10,13 @@ export interface NFTDetailsPayload {
 
 export function useFollowSuggestions() {
   const { data, error } = useSWR<NFTDetailsPayload>(
-    "/v1/get_follow_suggestions?recache=1",
+    "/v2/follow-suggestions",
     fetcher,
     { revalidateOnFocus: false, refreshInterval: 5 * 60 * 1000 }
   );
 
   return {
-    data: data?.data,
+    data: data,
     loading: !data,
     error,
   };


### PR DESCRIPTION
# Why

@intergalacticspacehighway removed the follow suggestions because they have been broken for quite some time (we never updated the backend logic since shifting to Creator Airdrops)

Suggested users can still be valuable

# How

[Backend PR](https://github.com/showtime-xyz/stbackend/pull/530) -- this takes a very simple approach of suggested 3 random creators that have drops in the weekly trendings.

We don't have many trending weekly NFTs on staging, so it runs out pretty fast, but on prod it should be alright.

# Test Plan

manual testing against the staging backend