### PR TITLE
Use expo-application Application ID to register for push notifications between environments

### DIFF
--- a/packages/app/lib/register-push-notification.ts
+++ b/packages/app/lib/register-push-notification.ts
@@ -1,5 +1,6 @@
 import { Platform } from "react-native";
 
+import * as Application from "expo-application";
 import * as Device from "expo-device";
 import * as Notifications from "expo-notifications";
 
@@ -32,7 +33,7 @@ async function registerForPushNotificationsAsync() {
   }
 
   const experienceId = "@showtime-xyz/showtime";
-  const applicationId = "io.showtime";
+  const applicationId = Application.applicationId;
 
   let granted = await getNotificationPermissionStatus();
 


### PR DESCRIPTION
# Why

Token ID's are specific to environment. When running locally or in staging the bundle identifier needs to match what is configured by the environment in order to register for the appropriate push notifications.

# How

- Use value from `expo-application` since it's configured via env vars appropriately

# Test Plan

- Using local build and local backend
