### PR TITLE
fix: crash on android when setting primary wallet

### DIFF
--- a/packages/app/hooks/api/use-set-primary-wallet.ts
+++ b/packages/app/hooks/api/use-set-primary-wallet.ts
@@ -17,6 +17,7 @@ export const useSetPrimaryWallet = () => {
       await axios({
         url: `/v2/wallet/${wallet.address}/primary`,
         method: "PATCH",
+        data: {},
       });
       onPrimaryWalletSetCallback?.();
       onPrimaryWalletSetCallback = null;


### PR DESCRIPTION
# Why
- cronet crashes when data is undefined on PATCH. 
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- Pass empty object 
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Test setting primary works
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
