### PR TITLE
fix: first video not playing on web

### DIFF
--- a/packages/app/components/swipe-list.web.tsx
+++ b/packages/app/components/swipe-list.web.tsx
@@ -46,7 +46,11 @@ export const SwipeList = ({
   const listRef = useRef<any>(null);
   useScrollToTop(listRef);
 
-  const visibleItems = useSharedValue<number[]>([]);
+  const visibleItems = useSharedValue<any[]>([
+    undefined,
+    0,
+    data.length > 1 ? 1 : undefined,
+  ]);
   const { height: windowHeight, width: windowWidth } = useWindowDimensions();
   const videoConfig = useMemo(
     () => ({
@@ -66,13 +70,17 @@ export const SwipeList = ({
 
   const onRealIndexChange = useCallback(
     (e: SwiperClass) => {
-      visibleItems.value = [e.previousIndex, e.activeIndex];
+      visibleItems.value = [
+        e.previousIndex,
+        e.activeIndex,
+        e.activeIndex + 1 < data.length ? e.activeIndex + 1 : undefined,
+      ];
       setInitialScrollIndex(e.activeIndex.toString());
       // const id = data[e.activeIndex].nft_id.toString();
       // id && setId(id);
       setActiveIndex(e.activeIndex);
     },
-    [visibleItems, setInitialScrollIndex]
+    [visibleItems, setInitialScrollIndex, data.length]
   );
 
   if (data.length === 0) return null;


### PR DESCRIPTION
# Why
our visible items "sliding window" size is 3. prev and next can be used in future optimisation like preloading (which we do on native). Keeping it same on web
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- Fix initial visible Items state
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
Test first video loads in swipe list on web
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
