### PR TITLE
fix: claim limit screen router name

### DIFF
--- a/packages/app/components/profile/profile-top.tsx
+++ b/packages/app/components/profile/profile-top.tsx
@@ -424,17 +424,17 @@ export const ProfileTop = ({
               onPress={() => {
                 router.push(
                   Platform.select({
-                    native: `/claim/claim-tank-explanation`,
+                    native: `/claim/claim-limit-explanation`,
                     web: {
                       pathname: router.pathname,
                       query: {
                         ...router.query,
-                        claimTankExplanation: true,
+                        claimLimitExplanation: true,
                       },
                     } as any,
                   }),
                   Platform.select({
-                    native: `/claim/claim-tank-explanation`,
+                    native: `/claim/claim-limit-explanation`,
                     web: router.asPath,
                   })
                 );

--- a/packages/app/navigation/linking.ts
+++ b/packages/app/navigation/linking.ts
@@ -41,7 +41,7 @@ const linking: LinkingOptions<ReactNavigation.RootParamList> = {
       drop: "drop",
       claim: "claim/:contractAddress",
       claimers: "claimers/:chainName/:contractAddress/:tokenId",
-      claimTankExplanation: "claim/claim-tank-explanation",
+      claimLimitExplanation: "claim/claim-limit-explanation",
       comments: "nft/:chainName/:contractAddress/:tokenId/comments",
       activity: "nft/:chainName/:contractAddress/:tokenId/activity",
       details: "nft/:chainName/:contractAddress/:tokenId/details",

--- a/packages/app/navigation/root-stack-navigator.tsx
+++ b/packages/app/navigation/root-stack-navigator.tsx
@@ -117,7 +117,7 @@ export function RootStackNavigator() {
         }}
       >
         <Stack.Screen
-          name="claimTankExplanation"
+          name="claimLimitExplanation"
           component={ClaimLimitExplanationScreen}
         />
       </Stack.Group>

--- a/packages/app/navigation/types.ts
+++ b/packages/app/navigation/types.ts
@@ -92,7 +92,7 @@ type RootStackNavigatorParams = {
   drop: undefined;
   claim: undefined;
   claimers: undefined;
-  claimTankExplanation: undefined;
+  claimLimitExplanation: undefined;
 };
 
 export type {


### PR DESCRIPTION
# Why

just fix the claim limit explanation screen router name, because I changed the name before due to Alex's feedback.


