### PR TITLE
fix: crash when pressing claim limit modal

### DIFF
--- a/packages/app/components/profile/profile-top.tsx
+++ b/packages/app/components/profile/profile-top.tsx
@@ -205,7 +205,7 @@ export const ProfileTop = ({
     () =>
       router.push(
         Platform.select({
-          native: `/claim-limit-explanation`,
+          native: `/claim/claim-limit-explanation`,
           web: {
             pathname: router.pathname,
             query: {
@@ -215,7 +215,7 @@ export const ProfileTop = ({
           } as any,
         }),
         Platform.select({
-          native: `/claim-limit-explanation`,
+          native: `/claim/claim-limit-explanation`,
           web: router.asPath,
         }),
         {


### PR DESCRIPTION
# Why

the app will crash when pressing the claim limit modal because the path is not correct, so quickly fix it.

