### PR TITLE
fix: claim snackbar

### DIFF
--- a/packages/app/components/claim/claim-button.tsx
+++ b/packages/app/components/claim/claim-button.tsx
@@ -1,6 +1,5 @@
 import { useContext } from "react";
 
-import { useAlert } from "@showtime-xyz/universal.alert";
 import { Button } from "@showtime-xyz/universal.button";
 import { ButtonProps } from "@showtime-xyz/universal.button/types";
 import { Check } from "@showtime-xyz/universal.icon";
@@ -19,16 +18,10 @@ type ClaimButtonProps = {
 export const ClaimButton = ({ edition, size = "small" }: ClaimButtonProps) => {
   const redirectToClaimDrop = useRedirectToClaimDrop();
   const { state: claimStates } = useContext(ClaimContext);
-  const Alert = useAlert();
   const isProgress =
     claimStates.status === "loading" && claimStates.signaturePrompt === false;
 
   const onClaimPress = () => {
-    if (isProgress) {
-      return Alert.alert(
-        "You currently have a transaction in progress, please wait to complete it and try again!"
-      );
-    }
     redirectToClaimDrop(edition.creator_airdrop_edition.contract_address);
   };
 

--- a/packages/app/components/claim/claim-button.tsx
+++ b/packages/app/components/claim/claim-button.tsx
@@ -1,8 +1,12 @@
+import { useContext } from "react";
+
+import { useAlert } from "@showtime-xyz/universal.alert";
 import { Button } from "@showtime-xyz/universal.button";
 import { ButtonProps } from "@showtime-xyz/universal.button/types";
 import { Check } from "@showtime-xyz/universal.icon";
 import { Text } from "@showtime-xyz/universal.text";
 
+import { ClaimContext } from "app/context/claim-context";
 import { CreatorEditionResponse } from "app/hooks/use-creator-collection-detail";
 import { useRedirectToClaimDrop } from "app/hooks/use-redirect-to-claim-drop";
 
@@ -14,8 +18,17 @@ type ClaimButtonProps = {
 };
 export const ClaimButton = ({ edition, size = "small" }: ClaimButtonProps) => {
   const redirectToClaimDrop = useRedirectToClaimDrop();
+  const { state: claimStates } = useContext(ClaimContext);
+  const Alert = useAlert();
+  const isProgress =
+    claimStates.status === "loading" && claimStates.signaturePrompt === false;
 
   const onClaimPress = () => {
+    if (isProgress) {
+      return Alert.alert(
+        "You currently have a transaction in progress, please wait to complete it and try again!"
+      );
+    }
     redirectToClaimDrop(edition.creator_airdrop_edition.contract_address);
   };
 
@@ -54,6 +67,8 @@ export const ClaimButton = ({ edition, size = "small" }: ClaimButtonProps) => {
         </>
       ) : status === ClaimStatus.Expired ? (
         "Drop expired"
+      ) : isProgress ? (
+        "Claim in progress"
       ) : (
         "Claim for free"
       )}

--- a/packages/app/components/claim/claim-form.tsx
+++ b/packages/app/components/claim/claim-form.tsx
@@ -48,9 +48,9 @@ import {
 
 export const ClaimForm = ({ edition }: { edition: CreatorEditionResponse }) => {
   const { rudder } = useRudder();
-  const { state } = useContext(ClaimContext);
+  const { state, dispatch } = useContext(ClaimContext);
 
-  const { claimNFT, onReconnectWallet } = useClaimNFT(
+  const { claimNFT, onReconnectWallet, hideSnackbar } = useClaimNFT(
     edition.creator_airdrop_edition
   );
   const share = useShare();
@@ -94,7 +94,11 @@ export const ClaimForm = ({ edition }: { edition: CreatorEditionResponse }) => {
 
     mutate();
   };
-
+  const onSkipToShare = () => {
+    dispatch({ type: "initial" });
+    hideSnackbar();
+    router.pop();
+  };
   // const [ensName, setEnsName] = React.useState<string | null>(null);
   // React.useEffect(() => {
   //   web3
@@ -124,12 +128,6 @@ export const ClaimForm = ({ edition }: { edition: CreatorEditionResponse }) => {
       />
     );
   }
-
-  // if (state.status === "loading" && state.signaturePrompt === false) {
-  //   router.pop();
-
-  //   return null;
-  // }
 
   if (state.status === "share") {
     const claimUrl = `https://${process.env.NEXT_PUBLIC_WEBSITE_DOMAIN}/t/${[
@@ -195,7 +193,7 @@ export const ClaimForm = ({ edition }: { edition: CreatorEditionResponse }) => {
               ? "Share with your friends"
               : "Copy drop link 🔗"}
           </Button>
-          <Button variant="tertiary" tw="mt-4" onPress={router.pop}>
+          <Button variant="tertiary" tw="mt-4" onPress={onSkipToShare}>
             Skip for now
           </Button>
         </View>

--- a/packages/app/components/claim/claim-form.tsx
+++ b/packages/app/components/claim/claim-form.tsx
@@ -49,6 +49,7 @@ import {
 export const ClaimForm = ({ edition }: { edition: CreatorEditionResponse }) => {
   const { rudder } = useRudder();
   const { state } = useContext(ClaimContext);
+
   const { claimNFT, onReconnectWallet } = useClaimNFT(
     edition.creator_airdrop_edition
   );
@@ -124,11 +125,11 @@ export const ClaimForm = ({ edition }: { edition: CreatorEditionResponse }) => {
     );
   }
 
-  if (state.status === "loading" && state.signaturePrompt === false) {
-    router.pop();
+  // if (state.status === "loading" && state.signaturePrompt === false) {
+  //   router.pop();
 
-    return null;
-  }
+  //   return null;
+  // }
 
   if (state.status === "share") {
     const claimUrl = `https://${process.env.NEXT_PUBLIC_WEBSITE_DOMAIN}/t/${[
@@ -220,7 +221,7 @@ export const ClaimForm = ({ edition }: { edition: CreatorEditionResponse }) => {
     Platform.OS === "android" ? BottomSheetScrollView : ScrollView;
 
   return (
-    <ScrollComponent ref={scrollViewRef}>
+    <ScrollComponent ref={scrollViewRef as any}>
       <View tw="flex-1 items-start p-4">
         <View tw="flex-row">
           <Media

--- a/packages/app/components/media/index.tsx
+++ b/packages/app/components/media/index.tsx
@@ -28,7 +28,7 @@ const Dynamic3dModel = dynamic<ModelProps>(
 );
 
 type Props = {
-  item: NFT & { loading?: boolean };
+  item?: NFT & { loading?: boolean };
   numColumns?: number;
   tw?: string;
   sizeStyle?: ImageStyle;

--- a/packages/app/hooks/use-claim-nft.ts
+++ b/packages/app/hooks/use-claim-nft.ts
@@ -197,6 +197,7 @@ export const useClaimNFT = (edition: IEdition) => {
       }
     } catch (e: any) {
       dispatch({ type: "error", error: e?.message });
+      snackbar?.hide();
       forwarderRequestCached.current = null;
       Logger.error("nft drop claim failed", e);
 

--- a/packages/app/hooks/use-claim-nft.ts
+++ b/packages/app/hooks/use-claim-nft.ts
@@ -46,7 +46,7 @@ const getForwarderRequest = async ({
 };
 
 export type State = {
-  status: "idle" | "loading" | "success" | "share" | "error";
+  status: "idle" | "loading" | "success" | "share" | "error" | "initial";
   error?: string;
   transactionHash?: string;
   mint?: any;
@@ -103,6 +103,10 @@ export const reducer = (state: State, action: Action): State => {
         status: "error",
         signaturePrompt: false,
         error: action.error,
+      };
+    case "initial":
+      return {
+        ...initialState,
       };
     default:
       return state;
@@ -314,9 +318,13 @@ export const useClaimNFT = (edition: IEdition) => {
     });
   }, [dispatch]);
 
+  const hideSnackbar = () => {
+    snackbar?.hide();
+  };
   return {
     state,
     claimNFT,
     onReconnectWallet,
+    hideSnackbar,
   };
 };

--- a/packages/app/utilities.ts
+++ b/packages/app/utilities.ts
@@ -123,7 +123,7 @@ export const getMediaUrl = ({
   nft,
   stillPreview,
 }: {
-  nft: NFT;
+  nft?: NFT;
   stillPreview: boolean;
 }) => {
   if (!nft || (!nft.chain_name && !nft.contract_address && !nft.token_id)) {

--- a/packages/design-system/snackbar/snackbar-container.tsx
+++ b/packages/design-system/snackbar/snackbar-container.tsx
@@ -1,6 +1,5 @@
 import { View, Platform } from "react-native";
 
-import { AnimatePresence } from "moti";
 import { FullWindowOverlay } from "react-native-screens";
 
 import { Snackbar, SnackbarProps, SNACKBAR_HEIGHT } from "./snackbar";
@@ -13,7 +12,7 @@ export const SnackbarContainer = ({
   ...rest
 }: SnackbarProps) => {
   return (
-    <AnimatePresence>
+    <>
       {show && (
         <OverLayView
           style={{
@@ -21,11 +20,12 @@ export const SnackbarContainer = ({
             height: SNACKBAR_HEIGHT,
             width: "100%",
             bottom: snackbar.bottom,
+            backgroundColor: "red",
           }}
         >
           <Snackbar show={show} snackbar={snackbar} {...rest} />
         </OverLayView>
       )}
-    </AnimatePresence>
+    </>
   );
 };


### PR DESCRIPTION
# Why

- pressing the `Skip for now` button hasn't reset states when claimed.
- pressing the claim button no feedback when having a claim in progress.

# How

- reset all states and disappear snackbar immediately when pressing `Skip for now`.
- claim button text change to `Claim in progress` when claiming.

# Test Plan

check if the claim + snackbar flow looks good!

# Claim + snackbar flow 


https://user-images.githubusercontent.com/37520667/194920343-b54a8a7b-2dad-45ad-93fa-e3dffd58f5d0.mov

