### PR TITLE
fix: claim + snackbar flow

### DIFF
--- a/packages/app/components/claim/claim-button.tsx
+++ b/packages/app/components/claim/claim-button.tsx
@@ -38,7 +38,8 @@ export const ClaimButton = ({ edition, size = "small" }: ClaimButtonProps) => {
   const disabled =
     status === ClaimStatus.Claimed ||
     status === ClaimStatus.Soldout ||
-    isExpired;
+    isExpired ||
+    isProgress;
 
   return (
     <Button
@@ -46,7 +47,7 @@ export const ClaimButton = ({ edition, size = "small" }: ClaimButtonProps) => {
       disabled={disabled}
       style={bgIsGreen ? { backgroundColor: "#0CB504" } : undefined}
       size={size}
-      tw={isExpired && !bgIsGreen ? "opacity-50" : ""}
+      tw={(isExpired && !bgIsGreen) || isProgress ? "opacity-50" : ""}
     >
       {status === ClaimStatus.Claimed ? (
         <>
@@ -61,7 +62,7 @@ export const ClaimButton = ({ edition, size = "small" }: ClaimButtonProps) => {
       ) : status === ClaimStatus.Expired ? (
         "Drop expired"
       ) : isProgress ? (
-        "Claim in progress"
+        "Claiming in progress…"
       ) : (
         "Claim for free"
       )}

--- a/packages/app/components/claim/claim-form.tsx
+++ b/packages/app/components/claim/claim-form.tsx
@@ -85,13 +85,12 @@ export const ClaimForm = ({ edition }: { edition: CreatorEditionResponse }) => {
     ) {
       follow(nft?.data.item.creator_id);
     }
-
+    router.pop();
     const success = await claimNFT();
 
     if (comment.current.trim().length > 0 && success) {
       newComment(comment.current);
     }
-
     mutate();
   };
   const onSkipToShare = () => {

--- a/packages/app/hooks/use-claim-nft.ts
+++ b/packages/app/hooks/use-claim-nft.ts
@@ -73,6 +73,7 @@ export const reducer = (state: State, action: Action): State => {
       return {
         ...state,
         status: "success",
+        transactionHash: undefined,
         mint: action.mint,
       };
     case "transactionHash":
@@ -90,18 +91,21 @@ export const reducer = (state: State, action: Action): State => {
       return {
         ...state,
         signaturePrompt: false,
+        transactionHash: undefined,
       };
     }
     case "share":
       return {
         ...state,
         status: "share",
+        transactionHash: undefined,
       };
     case "error":
       return {
         ...state,
         status: "error",
         signaturePrompt: false,
+        transactionHash: undefined,
         error: action.error,
       };
     case "initial":

--- a/packages/app/providers/claim-provider.tsx
+++ b/packages/app/providers/claim-provider.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useReducer, useState, useEffect } from "react";
+import { ReactNode, useReducer, useState, useEffect, useCallback } from "react";
 
 import { useSnackbar } from "@showtime-xyz/universal.snackbar";
 
@@ -90,6 +90,12 @@ export function ClaimProvider({ children }: ClaimProviderProps) {
 
     dispatch({ type: "error", error: "polling timed out" });
   };
+  const snackbarAction = useCallback(() => {
+    redirectToClaimDrop(contractAddress);
+    dispatch({
+      type: "share",
+    });
+  }, [contractAddress, redirectToClaimDrop]);
 
   useEffect(() => {
     if (state.status === "success") {
@@ -97,19 +103,15 @@ export function ClaimProvider({ children }: ClaimProviderProps) {
         text: "Claimed!",
         iconStatus: "done",
         bottom,
-        hideAfter: 25000,
+        hideAfter: 5000,
         action: {
           text: "Share",
-          onPress: () => {
-            redirectToClaimDrop(contractAddress);
-            dispatch({
-              type: "share",
-            });
-          },
+          onPress: snackbarAction,
         },
       });
     }
-  }, [state, bottom, snackbar, redirectToClaimDrop, contractAddress]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state, bottom, contractAddress]);
 
   return (
     <ClaimContext.Provider value={{ state, dispatch, pollTransaction }}>


### PR DESCRIPTION
# Why

as per [Alex's feedback](https://showtime-rq88331.slack.com/archives/C02PXGK3V8D/p1665460476975579), the claim + snackbar flow is not correct, so I fix it.


# How 

- display claiming banner, and close the waiting modal when the first time claiming.
- disable the claim button when the claiming in progress.

# Test Plan 

This is the current Claim + Snackbar flow: 

https://user-images.githubusercontent.com/37520667/195036254-03c217c2-3101-4792-b51c-0e11256a707b.mov



