### PR TITLE
fix: claim flow

### DIFF
--- a/packages/app/components/claim/claim-button.tsx
+++ b/packages/app/components/claim/claim-button.tsx
@@ -17,11 +17,12 @@ type ClaimButtonProps = {
 };
 export const ClaimButton = ({ edition, size = "small" }: ClaimButtonProps) => {
   const redirectToClaimDrop = useRedirectToClaimDrop();
-  const { state: claimStates } = useContext(ClaimContext);
+  const { state: claimStates, dispatch } = useContext(ClaimContext);
   const isProgress =
     claimStates.status === "loading" && claimStates.signaturePrompt === false;
 
   const onClaimPress = () => {
+    dispatch({ type: "initial" });
     redirectToClaimDrop(edition.creator_airdrop_edition.contract_address);
   };
 


### PR DESCRIPTION
# Why

just fixed Rize's feedback:
- claim something
- leave the claim page and keep browsing
- Once the snackbar says the claim is complete, click on share at the bottom right
- Close the Success Modal
- Now, clicking on any “Claim for free” button on the page will open the Success Modal instead of opening the claim page.

# How

reset claim modal states when pressing a new `Claim` button. 

# Test Plan

check if the claim flow works.

# Video 



https://user-images.githubusercontent.com/37520667/195115386-a080884e-d0c6-49f9-9990-c86355b746dd.mov

