### PR TITLE
fix: claim limit copy

### DIFF
--- a/packages/app/components/claim/claim-limit-explanation.tsx
+++ b/packages/app/components/claim/claim-limit-explanation.tsx
@@ -26,7 +26,7 @@ export const ClaimLimitExplanationModal = () => {
             </>
           ) : (
             <>
-              {`- You are currently earning 1 claim every 1 hours, up to ${dailyClaimLimit} claims. Verify your phone number to claim more drops.`}
+              {`- You are currently earning 1 claim every 3 hours, up to ${dailyClaimLimit} claims. Verify your phone number to claim more drops.`}
             </>
           )}
         </Text>


### PR DESCRIPTION
# Why

- non-sybiled accounts earn 1 every 3 hours.
- verified accounts earn 1 every 1 hour.  

so fixed the copy.

