### PR TITLE
fix: avoid Twitter share username appear @@

### DIFF
--- a/packages/app/utilities.ts
+++ b/packages/app/utilities.ts
@@ -439,7 +439,7 @@ export const getTwitterIntentUsername = (profile?: Profile) => {
   )?.user_input;
 
   if (twitterUsername) {
-    return `@${twitterUsername}`;
+    return `@${twitterUsername.replace(/@/g, "")}`;
   }
 
   return profile.username


### PR DESCRIPTION
# Why

 Twitter Share: If the Twitter bio link starts with “@“, share drop/claim shows “@@“ 

# How

via regex to remove username's `@`

# Test Plan 
change username make sure it includes double `@` then share on Twitter.  
