### PR TITLE
fix: profile nickname error

### DIFF
--- a/packages/app/components/profile/profile-social.tsx
+++ b/packages/app/components/profile/profile-social.tsx
@@ -78,7 +78,7 @@ export const ProfileSocial = memo<ProfileSocialProps>(function ProfileSocial({
         )}
       </Hidden>
 
-      <View tw="mt-4 flex-row items-center justify-end sm:mt-0">
+      <View tw="mt-2 flex-row items-center justify-end sm:mt-0">
         {twitter?.user_input && (
           <PressableScale
             onPress={() =>

--- a/packages/app/components/profile/profile-top.tsx
+++ b/packages/app/components/profile/profile-top.tsx
@@ -431,10 +431,14 @@ export const ProfileTop = ({
                   {name}
                 </Text>
                 <View tw="h-2 md:h-3" />
-                <View tw="h-6 flex-row items-center">
-                  <Text tw="text-base text-gray-600 dark:text-gray-400 md:text-lg">
-                    {username ? `@${username}` : null}
-                  </Text>
+                <View tw="flex-row items-center">
+                  {Boolean(username) && (
+                    <>
+                      <Text tw="text-base text-gray-600 dark:text-gray-400 md:text-lg">
+                        {`@${username}`}
+                      </Text>
+                    </>
+                  )}
 
                   {profileData?.profile.verified ? (
                     <View tw="ml-1">

--- a/packages/app/components/profile/profile.tsx
+++ b/packages/app/components/profile/profile.tsx
@@ -34,7 +34,7 @@ import { useContentWidth } from "app/hooks/use-content-width";
 import { useTabState } from "app/hooks/use-tab-state";
 import { useHeaderHeight } from "app/lib/react-navigation/elements";
 import { createParam } from "app/navigation/use-param";
-import { formatProfileRoutes } from "app/utilities";
+import { formatProfileRoutes, getProfileName } from "app/utilities";
 
 import { ErrorBoundary } from "../error-boundary";
 import { TabFallback } from "../error-boundary/tab-fallback";
@@ -198,9 +198,6 @@ const Profile = ({ username }: ProfileScreenProps) => {
       <View tw="dark:shadow-dark shadow-light bg-white dark:bg-black">
         <View tw="mx-auto w-full max-w-screen-xl">
           <ScollableAutoWidthTabBar {...props} />
-          {/* <View tw="z-1 relative w-full flex-row items-center justify-end bg-white py-2 px-4 dark:bg-black md:absolute md:bottom-1.5 md:right-10 md:my-0 md:w-auto md:py-0 md:px-0">
-            <ProfileListFilter />
-          </View> */}
         </View>
       </View>
     ),
@@ -210,10 +207,7 @@ const Profile = ({ username }: ProfileScreenProps) => {
     return (
       <View tw="h-full justify-center">
         <Text numberOfLines={1} tw="text-lg font-bold text-white">
-          {profileData?.data?.profile.name ??
-            profileData?.data?.profile.username ??
-            profileData?.data?.profile.primary_wallet.nickname ??
-            profileData?.data?.profile.primary_wallet.address}
+          {getProfileName(profileData?.data?.profile)}
         </Text>
       </View>
     );


### PR DESCRIPTION
# Why

it's haven't a nickname, name, or primary_wallet when a new wallet is, so will get an error.  


![image](https://user-images.githubusercontent.com/37520667/196154123-d75e60aa-dd6c-4e14-abe9-225b87a79811.png)

# How

Using the `getProfileName` method to get the nickname will be safe. 

# Test Plan

check if use the new wallet login and works.