### PR TITLE
fix: prevent feed refresh after claim

### DIFF
--- a/packages/app/hooks/use-feed.ts
+++ b/packages/app/hooks/use-feed.ts
@@ -12,7 +12,8 @@ const useFeed = () => {
   const { accessToken } = useAuth();
   const { data, isLoading, mutate, error } = useSWR<FeedAPIResponse>(
     accessToken ? "/v4/feed/nfts" : "/v2/trending/nfts?timeframe=day",
-    fetcher
+    fetcher,
+    { revalidateOnFocus: false }
   );
 
   return { data: data ?? [], isLoading, mutate, error };


### PR DESCRIPTION
# Why
Noticed the feed refreshes if someone opens the claim modal. This could change the scroll position.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
set `revalidateOnFocus` false 
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Try claiming multiple items, feed should not be reloaded.

# Aside
- We can call the API in the background and let the user know to scroll up for new items if there are x new items.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
