### PR TITLE
Add check to go back home on native

### DIFF
--- a/packages/app/components/header/index.tsx
+++ b/packages/app/components/header/index.tsx
@@ -23,11 +23,13 @@ import { breakpoints } from "design-system/theme";
 import { NotificationsInHeader, SearchInHeader } from "./header";
 
 export * from "./header";
+
 type HeaderLeftProps = {
   canGoBack: boolean;
   withBackground?: boolean;
   color?: string;
 };
+
 export const HeaderLeft = ({
   canGoBack,
   withBackground = false,
@@ -35,7 +37,8 @@ export const HeaderLeft = ({
 }: HeaderLeftProps) => {
   const isDark = useIsDarkMode();
   const router = useRouter();
-  const Icon = canGoBack ? ArrowLeft : Search;
+  const canGoHome = router.pathname.split("/").length - 1 >= 2;
+  const Icon = canGoBack || canGoHome ? ArrowLeft : Search;
 
   return (
     <PressableScale
@@ -53,6 +56,8 @@ export const HeaderLeft = ({
       onPress={() => {
         if (canGoBack) {
           router.pop();
+        } else if (canGoHome) {
+          router.push("/home");
         } else {
           router.push("/search");
         }
@@ -68,6 +73,7 @@ export const HeaderLeft = ({
     </PressableScale>
   );
 };
+
 export const HeaderCenter = ({
   isDark,
   isMdWidth,


### PR DESCRIPTION
# Why

If you deep link to a drop or a user, you can get stuck if the back button is not displayed on native

# How

Added a check for the native header ([similar to the check on web](https://github.com/showtime-xyz/showtime-frontend/blob/2f599f3111df35da19b67cf224424fdfa716f644/apps/next/src/pages/_app.tsx#L149))

# Test Plan

Deep link to a drop screen on native and check if you can go back home