### PR TITLE
Back button for swipe list on web

### DIFF
--- a/apps/next/src/pages/_app.tsx
+++ b/apps/next/src/pages/_app.tsx
@@ -146,6 +146,7 @@ export default function App({ Component, pageProps, router }: AppProps) {
           <Header
             canGoBack={
               router.pathname === "/search" ||
+              router.pathname === "/list" ||
               router.pathname.split("/").length - 1 >= 2
             }
           />


### PR DESCRIPTION
# Why

We should be able to go back if viewing swipe list on web

# How

Check if `router.pathname === "/list"`

# Test Plan

On the mobile web app, go to Trending or a user profile and press on a drop to display it inside the swipe list. You should be able to go back