### PR TITLE
fix(android): swipelist and profile screen

### DIFF
--- a/packages/app/components/header/header.tsx
+++ b/packages/app/components/header/header.tsx
@@ -1,5 +1,5 @@
 import React, { memo } from "react";
-import { Platform, StyleSheet } from "react-native";
+import { StyleSheet, Platform } from "react-native";
 
 import { BlurView } from "@react-native-community/blur";
 import Animated, {
@@ -9,6 +9,7 @@ import Animated, {
 
 import { useRouter } from "@showtime-xyz/universal.router";
 import { useSafeAreaInsets } from "@showtime-xyz/universal.safe-area";
+import { colors } from "@showtime-xyz/universal.tailwind";
 import { View } from "@showtime-xyz/universal.view";
 
 import { HeaderLeft } from ".";
@@ -71,25 +72,41 @@ export const Header = memo<HeaderProps>(function Header({
         },
       ]}
     >
-      {!disableBlur && (
-        <Animated.View
-          style={[StyleSheet.absoluteFillObject, animationBackgroundStyles]}
-        >
-          <BlurView
-            style={StyleSheet.absoluteFill}
-            blurAmount={30}
-            {...Platform.select({
-              ios: {
-                blurType: "ultraThinMaterialDark",
+      {!disableBlur ? (
+        Platform.OS === "android" ? (
+          // Reanimated View behaves weird on android here. Probably when BlurView is nested and Animated View is absolute.
+          // TODO: make a reproducible example and report to reanimated
+          <Animated.View
+            style={[
+              animationBackgroundStyles,
+              {
+                height: headerHeight,
+                width: "100%",
+                position: "absolute",
+                backgroundColor: colors.gray[600],
               },
-              default: {
-                blurType: "dark",
-                overlayColor: "rgba(0,0,0,.2)",
-              },
-            })}
+            ]}
           />
-        </Animated.View>
-      )}
+        ) : (
+          <Animated.View
+            style={[StyleSheet.absoluteFillObject, animationBackgroundStyles]}
+          >
+            <BlurView
+              style={StyleSheet.absoluteFill}
+              blurAmount={30}
+              {...Platform.select({
+                ios: {
+                  blurType: "ultraThinMaterialDark",
+                },
+                default: {
+                  blurType: "dark",
+                  overlayColor: "rgba(0,0,0,.2)",
+                },
+              })}
+            />
+          </Animated.View>
+        )
+      ) : null}
       <View tw="h-full w-full flex-row flex-nowrap justify-center px-4">
         <View tw="max-w-[80px] flex-1 items-start justify-center">
           {headerLeft ? (

--- a/packages/app/components/swipe-list.tsx
+++ b/packages/app/components/swipe-list.tsx
@@ -45,7 +45,7 @@ export const SwipeList = ({
 
   const itemHeight = Platform.select({
     web: windowHeight,
-    android: safeAreaFrameHeight,
+    android: safeAreaFrameHeight - headerHeight,
     default: screenHeight,
   });
 


### PR DESCRIPTION
# Why
Fixes
- Android swipe list dimensions. Claim button is not visible
- Sometimes profile page renders with black screen. This looks like reanimated/blurview combination issue. Will try a minimal repro. 

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Test swipelist and profile screen on android
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
