### PR TITLE
fix: remove mov file support in create drop

### DIFF
--- a/packages/app/components/drop/drop-form.tsx
+++ b/packages/app/components/drop/drop-form.tsx
@@ -20,7 +20,6 @@ import { useIsDarkMode } from "@showtime-xyz/universal.hooks";
 import { FlipIcon, Image as ImageIcon } from "@showtime-xyz/universal.icon";
 import { Pressable } from "@showtime-xyz/universal.pressable";
 import { useRouter } from "@showtime-xyz/universal.router";
-import { useSafeAreaInsets } from "@showtime-xyz/universal.safe-area";
 import { ScrollView } from "@showtime-xyz/universal.scroll-view";
 import { Text } from "@showtime-xyz/universal.text";
 import { View } from "@showtime-xyz/universal.view";
@@ -148,7 +147,6 @@ export const DropForm = () => {
   const pickFile = useFilePicker();
   const share = useShare();
   const router = useRouter();
-  const insets = useSafeAreaInsets();
   const modalScreenViewStyle = useModalScreenViewStyle({ mode: "margin" });
 
   // if (state.transactionHash) {
@@ -284,14 +282,17 @@ export const DropForm = () => {
     );
   }
 
-  const handleFileChange = (file: any) => {
+  const handleFileChange = (file: string | File) => {
     let extension;
     // On Native file is a string uri
     if (typeof file === "string") {
       extension = file.split(".").pop();
     }
 
-    if (file.type === "video/quicktime" || extension === "mov") {
+    if (
+      extension === "mov" ||
+      (typeof file === "object" && file.type === "video/quicktime")
+    ) {
       setError("file", { type: "custom", message: "File type not supported" });
       setValue("file", undefined);
     } else {

--- a/packages/app/components/drop/drop-form.tsx
+++ b/packages/app/components/drop/drop-form.tsx
@@ -105,6 +105,9 @@ export const DropForm = () => {
     control,
     handleSubmit,
     watch,
+    setError,
+    clearErrors,
+    setValue,
     formState: { errors },
     reset: resetForm,
   } = useForm<any>({
@@ -281,6 +284,22 @@ export const DropForm = () => {
     );
   }
 
+  const handleFileChange = (file: any) => {
+    let extension;
+    // On Native file is a string uri
+    if (typeof file === "string") {
+      extension = file.split(".").pop();
+    }
+
+    if (file.type === "video/quicktime" || extension === "mov") {
+      setError("file", { type: "custom", message: "File type not supported" });
+      setValue("file", undefined);
+    } else {
+      clearErrors("file");
+      setValue("file", file);
+    }
+  };
+
   return (
     <BottomSheetModalProvider>
       {Platform.OS === "ios" && <View style={{ height: headerHeight }} />}
@@ -290,16 +309,16 @@ export const DropForm = () => {
             <Controller
               control={control}
               name="file"
-              render={({ field: { onChange, value } }) => {
+              render={({ field: { value } }) => {
                 return (
-                  <DropFileZone onChange={onChange}>
+                  <DropFileZone onChange={handleFileChange}>
                     <View tw="z-1">
                       <Pressable
                         onPress={async () => {
                           const file = await pickFile({
                             mediaTypes: "all",
                           });
-                          onChange(file.file);
+                          handleFileChange(file.file);
                         }}
                         tw="h-[120px] w-[120px] items-center justify-center rounded-lg md:h-64 md:w-64"
                       >
@@ -309,16 +328,16 @@ export const DropForm = () => {
                               file={value}
                               width={windowWidth >= 768 ? 256 : 120}
                               height={windowWidth >= 768 ? 256 : 120}
-                              tw="rounded-2xl"
+                              style={{ borderRadius: 16 }}
                             />
                             <View tw="absolute h-full w-full items-center justify-center">
-                              <View tw="flex-row shadow-lg">
+                              <View tw="flex-row items-center shadow-lg">
                                 <FlipIcon
                                   width={20}
                                   height={20}
                                   color="white"
                                 />
-                                <Text tw=" ml-2 text-sm text-white">
+                                <Text tw="ml-2 text-sm text-white">
                                   Replace
                                 </Text>
                               </View>
@@ -338,7 +357,7 @@ export const DropForm = () => {
                             </View>
                             {errors.file?.message ? (
                               <View tw="mt-2">
-                                <Text tw="text-sm text-red-500">
+                                <Text tw="text-center text-sm text-red-500">
                                   {errors?.file?.message}
                                 </Text>
                               </View>
@@ -346,7 +365,7 @@ export const DropForm = () => {
 
                             <View tw="mt-2 hidden md:flex">
                               <Text tw="px-4 text-center text-gray-600 dark:text-gray-200">
-                                Tap to upload a JPG, PNG, GIF, MOV or MP4 file.
+                                Tap to upload a JPG, PNG, GIF, WebM or MP4 file.
                               </Text>
                             </View>
                           </View>
@@ -357,6 +376,7 @@ export const DropForm = () => {
                 );
               }}
             />
+
             <View tw="ml-4 flex-1">
               {/* <Text>Import media</Text> */}
               <Controller
@@ -401,6 +421,11 @@ export const DropForm = () => {
               </View>
             </View>
           </View>
+
+          <Text tw="mt-4 text-gray-600 dark:text-gray-200 md:hidden">
+            JPG, PNG, GIF, WebM or MP4 file
+          </Text>
+
           <View tw="mt-4 md:hidden">
             <Controller
               control={control}


### PR DESCRIPTION
# Why
Issue - https://linear.app/showtime/issue/SHOW2-1317/remove-mov-type-because-opensea-doesnt-support-it
- Remove .mov upload support from frontend
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How?
- Show error instead of using input `accept` prop. This is tricky with cross platform as native image picker doesn't seem to have a similar prop.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Try uploading .mov file on drop form
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
