### PR TITLE
fix: initial url set in swipelist

### DIFF
--- a/packages/app/components/swipe-list.web.tsx
+++ b/packages/app/components/swipe-list.web.tsx
@@ -72,11 +72,19 @@ export const SwipeList = ({
   );
 
   useEffect(() => {
-    if (!initialURLSet.current && isSwipeListScreen) {
-      window.history.replaceState(null, "", getNFTSlug(data[0]));
+    if (
+      !initialURLSet.current &&
+      isSwipeListScreen &&
+      typeof initialParamProp !== "undefined"
+    ) {
+      const nft = data[Number(initialParamProp)];
+      if (nft) {
+        window.history.replaceState(null, "", getNFTSlug(nft));
+      }
+
       initialURLSet.current = true;
     }
-  }, [data, isSwipeListScreen]);
+  }, [data, isSwipeListScreen, initialParamProp]);
   // const initialSlideIndex = useMemo(() => {
   //   const defaultIndex = clamp(initialScrollIndex, 0, data.length - 1);
   //   if (!id) return defaultIndex;


### PR DESCRIPTION
# Why
Bug - Swipelist on open sets first drop URL instead of `initialScrollIndex`
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->


<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Tapping drop in feed should set valid drop URL in swipelist screen
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
