### PR TITLE
fix: ethers error leading to 404 on NFT screen

### DIFF
--- a/packages/app/providers/wallet-provider.web.tsx
+++ b/packages/app/providers/wallet-provider.web.tsx
@@ -1,13 +1,11 @@
 import { getDefaultWallets, RainbowKitProvider } from "@rainbow-me/rainbowkit";
 import { chain, configureChains, createClient, WagmiConfig } from "wagmi";
-import { alchemyProvider } from "wagmi/providers/alchemy";
 import { publicProvider } from "wagmi/providers/public";
 
 const { chains, provider, webSocketProvider } = configureChains(
   [chain.mainnet, chain.polygon, chain.polygonMumbai],
   [
     //@ts-ignore
-    alchemyProvider({ alchemyId: process.env.NEXT_PUBLIC_ALCHEMY_ID }),
     publicProvider(),
   ]
 );


### PR DESCRIPTION
Not sure about the root cause but something from alchemy side, will analyse after merging this quick fix.