### PR TITLE
Stop tracking `NFT Claimed` and `Drop Created` on the frontend

### DIFF
--- a/packages/app/hooks/use-drop-nft.ts
+++ b/packages/app/hooks/use-drop-nft.ts
@@ -127,7 +127,6 @@ export const useDropNFT = () => {
       });
 
       if (response.is_complete) {
-        rudder?.track("Drop Created");
         dispatch({ type: "success", edition: response.edition });
         mutate((key) => key.includes(PROFILE_NFTS_QUERY_KEY));
         return;

--- a/packages/app/providers/claim-provider.tsx
+++ b/packages/app/providers/claim-provider.tsx
@@ -39,8 +39,6 @@ export function ClaimProvider({ children }: ClaimProviderProps) {
       });
 
       if (response.is_complete) {
-        rudder?.track("NFT Claimed");
-
         dispatch({ type: "success", mint: response.mint });
         mutate((key) => key.includes(PROFILE_NFTS_QUERY_KEY));
         mutateEdition((d) => {


### PR DESCRIPTION
# Why

It's best to track on the backend
