### PR TITLE
fix: google auth in spotify login

### DIFF
--- a/packages/app/screens/spotify-auth.tsx
+++ b/packages/app/screens/spotify-auth.tsx
@@ -42,7 +42,6 @@ export const SpotifyAuth = () => {
           }
           onMessage={async (s) => {
             if (s.nativeEvent.data) {
-              console.log("Efokfe ", s.nativeEvent.data);
               const { code } = JSON.parse(s.nativeEvent.data);
               await saveSpotifyToken({ code, redirectUri });
               router.pop();

--- a/packages/app/screens/spotify-auth.tsx
+++ b/packages/app/screens/spotify-auth.tsx
@@ -1,3 +1,7 @@
+import { useEffect } from "react";
+import { Platform } from "react-native";
+
+import { AvoidSoftInput } from "react-native-avoid-softinput";
 import { WebView } from "react-native-webview";
 
 import { useRouter } from "@showtime-xyz/universal.router";
@@ -18,14 +22,27 @@ export const SpotifyAuth = () => {
   const router = useRouter();
   const { saveSpotifyToken } = useSaveSpotifyToken();
 
+  useEffect(() => {
+    AvoidSoftInput.setEnabled(false);
+    return () => {
+      AvoidSoftInput.setEnabled(true);
+    };
+  }, []);
+
   if (uri) {
     return (
       <View tw="flex-1">
         <WebView
           style={{ flex: 1 }}
           source={{ uri }}
+          userAgent={
+            Platform.OS === "ios"
+              ? "AppleWebKit/602.1.50 (KHTML, like Gecko) CriOS/56.0.2924.75"
+              : undefined
+          }
           onMessage={async (s) => {
             if (s.nativeEvent.data) {
+              console.log("Efokfe ", s.nativeEvent.data);
               const { code } = JSON.parse(s.nativeEvent.data);
               await saveSpotifyToken({ code, redirectUri });
               router.pop();


### PR DESCRIPTION
# Why
- Sign in with google fails in Spotify. So we add a user agent string in webview that works.
- This is a hack on iOS. On Android, we use native Spotify SDK. iOS SDK doesn't have a way to get the auth code, it recommends a different auth flow on iOS. I've asked it [here](https://github.com/spotify/ios-sdk/issues/364). The code is also not open source so can't change the source. I'll look into it but this solution works for now.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- Add a user agent string
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
Test google login works in Spotify auth

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
