### PR TITLE
fix: mention matching regex

### DIFF
--- a/packages/app/lib/linkify.tsx
+++ b/packages/app/lib/linkify.tsx
@@ -14,7 +14,7 @@ export const linkifyDescription = (text?: string, rest?: Props) => {
     return null;
   }
   // Match @-mentions
-  let replacedText = reactStringReplace(text, /@(\w+)/g, (match, i) => {
+  let replacedText = reactStringReplace(text, /^@(\w+)/g, (match, i) => {
     return (
       <Link
         key={match + i}


### PR DESCRIPTION
# Why
fix mention matching regex (until it breaks again)
https://showtime-rq88331.slack.com/archives/C02PXGK3V8D/p1666742290541129
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
detect mention only when it starts with `@` 
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Test drop description, bio and comments.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
