### PR TITLE
Feature/show2 1341 dont display the bottom tab bar on nft

### DIFF
--- a/packages/app/components/feed-item/feed-item.web.tsx
+++ b/packages/app/components/feed-item/feed-item.web.tsx
@@ -1,6 +1,5 @@
-import { memo, useState, useMemo, useContext } from "react";
+import { memo, useState, useMemo } from "react";
 import {
-  StatusBar,
   StyleProp,
   StyleSheet,
   useWindowDimensions,
@@ -15,12 +14,9 @@ import { PlayOnSpotify } from "app/components/play-on-spotify";
 import { LikeContextProvider } from "app/context/like-context";
 import { useCreatorCollectionDetail } from "app/hooks/use-creator-collection-detail";
 import { usePlatformBottomHeight } from "app/hooks/use-platform-bottom-height";
-import { useUser } from "app/hooks/use-user";
 import { BlurView } from "app/lib/blurview";
-import { useHeaderHeight } from "app/lib/react-navigation/elements";
 import type { NFT } from "app/types";
 
-import { SwiperActiveIndexContext } from "../swipe-list.web";
 import { NFTDetails } from "./details";
 import { FeedItemMD } from "./feed-item.md";
 
@@ -32,21 +28,17 @@ export type FeedItemProps = {
   itemHeight: number;
   setMomentumScrollCallback?: (callback: any) => void;
 };
-const StatusBarHeight = StatusBar.currentHeight ?? 0;
 
 export const FeedItem = memo<FeedItemProps>(function FeedItem({
   nft,
   itemHeight,
 }) {
-  const { isAuthenticated } = useUser();
-  const headerHeight = useHeaderHeight();
   const [detailHeight, setDetailHeight] = useState(0);
   const { width: windowWidth, height: windowHeight } = useWindowDimensions();
   const bottomHeight = usePlatformBottomHeight();
   const { data: edition } = useCreatorCollectionDetail(
     nft.creator_airdrop_edition_address
   );
-  const activeIndex = useContext(SwiperActiveIndexContext);
 
   const maxContentHeight = windowHeight - bottomHeight;
 
@@ -89,30 +81,6 @@ export const FeedItem = memo<FeedItemProps>(function FeedItem({
   return (
     <LikeContextProvider nft={nft} key={nft.nft_id}>
       <View tw="w-full" style={{ height: itemHeight, overflow: "hidden" }}>
-        {/* {activeIndex === 0 && isMobileWeb() && isAuthenticated ? (
-          <View
-            tw="dark:shadow-dark shadow-light absolute top-0 right-0 left-0 z-10 bg-white dark:bg-black"
-            style={{ paddingTop: headerHeight + StatusBarHeight }}
-          >
-            <View tw="flex flex-row items-center justify-between px-4 pb-4">
-              <Text tw="font-space-bold text-lg dark:text-white">
-                Get the app
-              </Text>
-              <Button
-                onPress={() => {
-                  window.open(
-                    isAndroid()
-                      ? "https://play.google.com/store/apps/details?id=io.showtime"
-                      : "https://apps.apple.com/us/app/showtime-nft-social-network/id1606611688",
-                    "_blank"
-                  );
-                }}
-              >
-                Download now
-              </Button>
-            </View>
-          </View>
-        ) : null} */}
         <View
           tw="duration-200"
           style={{

--- a/packages/app/components/footer/index.tsx
+++ b/packages/app/components/footer/index.tsx
@@ -6,6 +6,7 @@ import { View } from "@showtime-xyz/universal.view";
 
 import { MOBILE_WEB_TABS_HEIGHT } from "app/constants/layout";
 import { useUser } from "app/hooks/use-user";
+import { HIDE_LINK_FOOTER_ROUTER_LIST } from "app/lib/constants";
 import {
   CreateTabBarIcon,
   HomeTabBarIcon,
@@ -29,7 +30,11 @@ const Footer = () => {
     return <WebFooter />;
   }
 
-  if (!isAuthenticated || isTabBarHidden) {
+  if (
+    !isAuthenticated ||
+    isTabBarHidden ||
+    HIDE_LINK_FOOTER_ROUTER_LIST.includes(router.pathname)
+  ) {
     return null;
   }
 

--- a/packages/app/components/notifications/index.tsx
+++ b/packages/app/components/notifications/index.tsx
@@ -25,9 +25,15 @@ import { useHeaderHeight } from "app/lib/react-navigation/elements";
 import { useScrollToTop } from "app/lib/react-navigation/native";
 
 const Header = () => {
-  const headerHeight = useHeaderHeight();
-
-  return <View style={{ height: headerHeight }} />;
+  return (
+    <View tw="mx-auto w-full max-w-screen-xl">
+      <View tw="w-full flex-row justify-center self-center px-4 py-4 md:justify-between md:pb-8">
+        <Text tw="font-space-bold self-center text-2xl font-extrabold text-gray-900 dark:text-white">
+          Notifications
+        </Text>
+      </View>
+    </View>
+  );
 };
 
 export const Notifications = ({

--- a/packages/app/components/notifications/index.tsx
+++ b/packages/app/components/notifications/index.tsx
@@ -25,14 +25,16 @@ import { useHeaderHeight } from "app/lib/react-navigation/elements";
 import { useScrollToTop } from "app/lib/react-navigation/native";
 
 const Header = () => {
-  return (
-    <View tw="mx-auto w-full max-w-screen-xl">
-      <View tw="w-full flex-row justify-center self-center px-4 py-4 md:justify-between md:pb-8">
-        <Text tw="font-space-bold self-center text-2xl font-extrabold text-gray-900 dark:text-white">
-          Notifications
-        </Text>
-      </View>
+  const headerHeight = useHeaderHeight();
+
+  return Platform.OS === "web" ? (
+    <View tw="w-full flex-row justify-center px-4 py-4">
+      <Text tw="font-space-bold text-lg font-extrabold text-gray-900 dark:text-white md:text-2xl">
+        Notifications
+      </Text>
     </View>
+  ) : (
+    <View style={{ height: headerHeight }} />
   );
 };
 

--- a/packages/app/components/trending/trending.web.tsx
+++ b/packages/app/components/trending/trending.web.tsx
@@ -44,7 +44,7 @@ const Header = () => {
   return (
     <View tw="mx-auto w-full max-w-screen-xl">
       <View tw="w-full flex-row justify-center self-center px-4 py-4 md:justify-between md:pb-8">
-        <Text tw="font-space-bold self-center text-2xl font-extrabold text-gray-900 dark:text-white">
+        <Text tw="font-space-bold self-center text-lg font-extrabold text-gray-900 dark:text-white md:text-2xl">
           Trending
         </Text>
       </View>

--- a/packages/app/components/trending/trending.web.tsx
+++ b/packages/app/components/trending/trending.web.tsx
@@ -12,9 +12,9 @@ import { View } from "@showtime-xyz/universal.view";
 import { Card } from "app/components/card";
 import { EmptyPlaceholder } from "app/components/empty-placeholder";
 import { ErrorBoundary } from "app/components/error-boundary";
-import { MOBILE_WEB_TABS_HEIGHT } from "app/constants/layout";
 import { useTrendingNFTS } from "app/hooks/api-hooks";
 import { useContentWidth } from "app/hooks/use-content-width";
+import { usePlatformBottomHeight } from "app/hooks/use-platform-bottom-height";
 import { createParam } from "app/navigation/use-param";
 import { NFT } from "app/types";
 
@@ -43,7 +43,7 @@ const Header = () => {
 
   return (
     <View tw="mx-auto w-full max-w-screen-xl">
-      <View tw="w-full flex-row justify-between self-center px-4 py-4 md:pb-8">
+      <View tw="w-full flex-row justify-center self-center px-4 py-4 md:justify-between md:pb-8">
         <Text tw="font-space-bold self-center text-2xl font-extrabold text-gray-900 dark:text-white">
           Trending
         </Text>
@@ -62,6 +62,7 @@ const Header = () => {
 export const Trending = () => {
   const { height: screenHeight } = useWindowDimensions();
   const contentWidth = useContentWidth();
+  const bottomBarHeight = usePlatformBottomHeight();
   const isMdWidth = contentWidth >= breakpoints["md"];
   const numColumns =
     contentWidth <= breakpoints["md"]
@@ -121,9 +122,7 @@ export const Trending = () => {
       <EmptyPlaceholder title={"No results found"} tw="h-[50vh]" hideLoginBtn />
     );
   }, [isLoading]);
-  const ListFooterComponent = useCallback(() => {
-    return <View style={{ height: MOBILE_WEB_TABS_HEIGHT }} />;
-  }, []);
+
   return (
     <TrendingHeaderContext.Provider
       value={{
@@ -131,7 +130,7 @@ export const Trending = () => {
         setDays: setDays,
       }}
     >
-      <View tw="w-full pb-8 pt-16 md:pt-20">
+      <View tw="w-full pb-8 md:pt-20">
         <ErrorBoundary>
           <InfiniteScrollList
             useWindowScroll={isMdWidth}
@@ -145,9 +144,8 @@ export const Trending = () => {
               reverse: contentWidth / numColumns,
             }}
             style={{
-              height: screenHeight - 64,
+              height: screenHeight - bottomBarHeight,
             }}
-            ListFooterComponent={ListFooterComponent}
             ListEmptyComponent={ListEmptyComponent}
           />
         </ErrorBoundary>

--- a/packages/app/hooks/use-platform-bottom-height.ts
+++ b/packages/app/hooks/use-platform-bottom-height.ts
@@ -1,8 +1,10 @@
 import { Platform, useWindowDimensions } from "react-native";
 
+import { useRouter } from "@showtime-xyz/universal.router";
 import { useSafeAreaInsets } from "@showtime-xyz/universal.safe-area";
 
 import { MOBILE_WEB_TABS_HEIGHT } from "app/constants/layout";
+import { HIDE_LINK_FOOTER_ROUTER_LIST } from "app/lib/constants";
 import { useBottomTabBarHeight } from "app/lib/react-navigation/bottom-tabs";
 
 import { breakpoints } from "design-system/theme";
@@ -14,14 +16,20 @@ export const usePlatformBottomHeight = () => {
   const insets = useSafeAreaInsets();
   const { width } = useWindowDimensions();
   const nativeBottomTabBarHeight = useBottomTabBarHeight();
-
+  const router = useRouter();
   if (!isAuthenticated) return 0;
 
   if (Platform.OS === "web") {
+    const mobileWebBottomHeight = HIDE_LINK_FOOTER_ROUTER_LIST.includes(
+      router.pathname
+    )
+      ? 0
+      : insets.bottom + MOBILE_WEB_TABS_HEIGHT;
+
     const isMdWidth = width >= breakpoints["md"];
     const webBottomTabBarHeight = isMdWidth
       ? insets.bottom
-      : insets.bottom + MOBILE_WEB_TABS_HEIGHT;
+      : mobileWebBottomHeight;
     return webBottomTabBarHeight;
   }
 


### PR DESCRIPTION
# Why

- the NFT detail without the bottom tab bar looks good on native, we should use the same design on mobile web!  

![image](https://user-images.githubusercontent.com/37520667/198350835-87a95656-7a7e-44bb-be27-347f1d86ad9b.png) 

- move the Trending/Notifications title to the header center position, which can save more space, reference to [Figma](https://www.figma.com/file/720aUothRCUZMtMEVHfJV0/Showtime?node-id=1977%3A51355). 

![image](https://user-images.githubusercontent.com/37520667/198350470-2a7855a2-a110-41d8-a5d7-f3ac60946ae1.png) 