### PR TITLE
fix: deeplink initial route

### DIFF
--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -181,7 +181,7 @@
     "react-dom": "18.2.0",
     "react-hook-form": "^7.27.1",
     "react-native": "0.69.6",
-    "react-native-avoid-softinput": "^3.0.0",
+    "react-native-avoid-softinput": "^3.0.2",
     "react-native-bignumber": "^0.1.9",
     "react-native-blob-jsi-helper": "^0.2.3",
     "react-native-blurhash": "^1.1.10",

--- a/packages/app/navigation/linking.ts
+++ b/packages/app/navigation/linking.ts
@@ -35,6 +35,8 @@ const linking: LinkingOptions<ReactNavigation.RootParamList> = {
     `http://*.${url}/`,
   ],
   config: {
+    //@ts-ignore
+    initialRouteName: "bottomTabs",
     screens: {
       login: "login",
       nft: "nft/:chainName/:contractAddress/:tokenId",
@@ -60,6 +62,7 @@ const linking: LinkingOptions<ReactNavigation.RootParamList> = {
       blockedList: "settings/blocked-list",
       swipeList: "list",
       bottomTabs: {
+        initialRouteName: "homeTab",
         screens: {
           // Bottom Tab Navigator
           homeTab: "",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9638,7 +9638,7 @@ __metadata:
     react-dom: 18.2.0
     react-hook-form: ^7.27.1
     react-native: 0.69.6
-    react-native-avoid-softinput: ^3.0.0
+    react-native-avoid-softinput: ^3.0.2
     react-native-bignumber: ^0.1.9
     react-native-blob-jsi-helper: ^0.2.3
     react-native-blurhash: ^1.1.10
@@ -31450,13 +31450,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-avoid-softinput@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "react-native-avoid-softinput@npm:3.0.0"
+"react-native-avoid-softinput@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "react-native-avoid-softinput@npm:3.0.2"
   peerDependencies:
     react: ">=17.0.0"
     react-native: ">=0.65.0"
-  checksum: 94a5fb8387a14bddfb1c32c7b91e8b2d064d08f13ef8c6d9d56ff08960c633b4e73a609a9122521d5b195e9509112414bcce2e404a9acb3414592058b8134c48
+  checksum: de135b7e40e5e64ea4a0cec90f7af1aaca6b3b7cc28130307f9ced4471e866366afd18c89d6e187a7dee482c7d7e9b044775cc894b8895f8720f8de4ffd81209
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Why
We need to mount initial route along with deeplinking so back button works as expected in the deeplink screen route
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
After trying bunch of weird solutions, I found that react navigation has a prop for this exact usecase. `initalRouteName`. This will make sure that home is mounted before deeplink redirection
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Test deeplinks
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
