### PR TITLE
fix: attempt unable to open url

### DIFF
--- a/packages/app/components/profile/profile-social.tsx
+++ b/packages/app/components/profile/profile-social.tsx
@@ -42,14 +42,9 @@ export const ProfileSocial = memo<ProfileSocialProps>(function ProfileSocial({
     [profile?.website_url]
   );
 
-  const onPressLink = useCallback(
-    async (link: string) => {
-      const canOpenUrl = await Linking.canOpenURL(link);
-      if (!canOpenUrl) return Alert.alert("Unable to open the link.");
-      return Linking.openURL(link);
-    },
-    [Alert]
-  );
+  const onPressLink = useCallback(async (link: string) => {
+    return Linking.openURL(link);
+  }, []);
 
   return (
     <View tw="justify-center sm:flex-row">


### PR DESCRIPTION
# Why
Not sure what's causing [this](https://showtime-rq88331.slack.com/archives/C02PXGK3V8D/p1666963333401349). Looks like it could [sometimes fail](https://reactnative.dev/docs/linking#canopenurl) on Android. Removing the check as of now, the openUrl also returns a promise which acts mostly similar. 
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->


<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
Try opening social link URLs
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
