### PR TITLE
fix: zeego sub menu on iOS

### DIFF
--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -189,7 +189,7 @@
     "react-native-fast-image": "^8.5.11",
     "react-native-flipper": "^0.131.1",
     "react-native-gesture-handler": "^2.7.1",
-    "react-native-ios-context-menu": "1.3.0",
+    "react-native-ios-context-menu": "^1.15.1",
     "react-native-level-fs": "^3.0.0",
     "react-native-localhost": "^1.0.0",
     "react-native-mmkv": "^2.4.3",

--- a/apps/storybook-react-native/package.json
+++ b/apps/storybook-react-native/package.json
@@ -66,7 +66,7 @@
     "react-native-fast-image": "^8.5.11",
     "react-native-flipper": "^0.131.1",
     "react-native-gesture-handler": "^2.7.1",
-    "react-native-ios-context-menu": "1.3.0",
+    "react-native-ios-context-menu": "^1.15.1",
     "react-native-mmkv": "^2.4.3",
     "react-native-pager-view": "^5.4.25",
     "react-native-quick-base64": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "react-native-svg": "12.3.0",
     "@jest/create-cache-key-function": "28.0.2",
     "expo-linear-gradient": "11.4.0",
-    "react-native-ios-context-menu": "1.3.0",
     "jest-runtime": "28.0.3",
     "react-native-reanimated": "2.11.0",
     "@types/react": "18.0.1",

--- a/packages/app/components/header-dropdown.tsx
+++ b/packages/app/components/header-dropdown.tsx
@@ -10,6 +10,7 @@ import {
   DropdownMenuTrigger,
   DropdownMenuSub,
   DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
 } from "@showtime-xyz/universal.dropdown-menu";
 import {
   User,
@@ -132,7 +133,7 @@ function HeaderDropdown({ type, withBackground = false }: HeaderDropdownProps) {
               Theme
             </DropdownMenuItemTitle>
           </DropdownMenuSubTrigger>
-          <DropdownMenuContent tw="w-30">
+          <DropdownMenuSubContent tw="w-30">
             <DropdownMenuItem
               onSelect={() => setColorScheme("light")}
               key="nested-group-1"
@@ -151,7 +152,7 @@ function HeaderDropdown({ type, withBackground = false }: HeaderDropdownProps) {
                 Dark
               </DropdownMenuItemTitle>
             </DropdownMenuItem>
-          </DropdownMenuContent>
+          </DropdownMenuSubContent>
         </DropdownMenuSub>
 
         <DropdownMenuItem destructive onSelect={logout} key="sign-out">

--- a/packages/design-system/dropdown-menu/index.tsx
+++ b/packages/design-system/dropdown-menu/index.tsx
@@ -18,6 +18,7 @@ const DropdownMenuGroup = DropdownMenu.Group;
 const DropdownMenuTrigger = DropdownMenu.Trigger;
 
 const DropdownMenuSub = DropdownMenu.Sub;
+const DropdownMenuSubContent = DropdownMenu.SubContent;
 
 const StyledDropdownMenuContent = styled(DropdownMenu.Content);
 
@@ -308,6 +309,7 @@ export {
   DropdownMenuSeparator,
   DropdownMenuSub,
   DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
   DropdownMenuItemIcon,
   DropdownMenuItemImage,
   DropdownMenuLabel,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3392,6 +3392,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@dominicstop/ts-event-emitter@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@dominicstop/ts-event-emitter@npm:1.1.0"
+  checksum: fcecf835de9049f58faf013d0a5b940b8b4b1c6c9293d98ab18c90fa800ca55407fcaf7d4cc148fbdc361aba5d4af64ae0fde813f8958c0903df3aa2b09e4325
+  languageName: node
+  linkType: hard
+
 "@egjs/hammerjs@npm:^2.0.17":
   version: 2.0.17
   resolution: "@egjs/hammerjs@npm:2.0.17"
@@ -7865,12 +7872,12 @@ __metadata:
   linkType: hard
 
 "@react-native-menu/menu@npm:^0.5.2":
-  version: 0.5.2
-  resolution: "@react-native-menu/menu@npm:0.5.2"
+  version: 0.5.3
+  resolution: "@react-native-menu/menu@npm:0.5.3"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 96d7537d2260c7779960ac9e8711edea9d6c83d8d1ba814946b09edb5914e50918457ebc52bf6bf0679580003a662cb0eecd3eb978bab4c0d633ced3c677bd69
+  checksum: 892d6858f6fa5df17e0cdf84343cc56163de95408bdfb4dbd0ee11099340311ec9f0507988f8f3a674cc2fd555106eba29d3f9e2760811fe8acf683035134ba0
   languageName: node
   linkType: hard
 
@@ -9646,7 +9653,7 @@ __metadata:
     react-native-fast-image: ^8.5.11
     react-native-flipper: ^0.131.1
     react-native-gesture-handler: ^2.7.1
-    react-native-ios-context-menu: 1.3.0
+    react-native-ios-context-menu: ^1.15.1
     react-native-level-fs: ^3.0.0
     react-native-localhost: ^1.0.0
     react-native-mmkv: ^2.4.3
@@ -9810,7 +9817,7 @@ __metadata:
     react-native-fast-image: ^8.5.11
     react-native-flipper: ^0.131.1
     react-native-gesture-handler: ^2.7.1
-    react-native-ios-context-menu: 1.3.0
+    react-native-ios-context-menu: ^1.15.1
     react-native-mmkv: ^2.4.3
     react-native-pager-view: ^5.4.25
     react-native-quick-base64: ^2.0.2
@@ -31577,13 +31584,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-ios-context-menu@npm:1.3.0":
-  version: 1.3.0
-  resolution: "react-native-ios-context-menu@npm:1.3.0"
+"react-native-ios-context-menu@npm:^1.15.1":
+  version: 1.15.1
+  resolution: "react-native-ios-context-menu@npm:1.15.1"
+  dependencies:
+    "@dominicstop/ts-event-emitter": ^1.1.0
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 9c265b8d93fc687714c167475f7305826449bd607db4275488018de5d35eb2ec4d41822197db20cc95c07044f94c7aff921d1fdc7bd2234d12f04f98f1ed757e
+  checksum: 3925783aa849e4af817ec2d7ad9e777da87587b0c95b44f1ee509c9a9b64d8471fb925f99ea9a5573a9028517fff75c441585b703f1d944c7451c0f7a708dd6e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Why
 the `Dropdown` sub menu not working on iOS, because `zeego` have a breaking change. 

![image](https://user-images.githubusercontent.com/37520667/199027170-95abf917-cb77-44a4-a129-939a01aa1f90.png)

# How 

- upgrade the `react-native-ios-context-menu` package version.
- use `DropdownMenu.SubContent` to replace `DropdownMenu.Content`.  




# Test Plan 

- check if the dropdown's sub-menu work on all platform. 

![image](https://user-images.githubusercontent.com/37520667/199027546-450dee7c-60fa-4df5-ad9a-697c25bd79a9.png)