### PR TITLE
fix: layout shift in drop screen

### DIFF
--- a/packages/app/components/feed-item/feed-item.md.tsx
+++ b/packages/app/components/feed-item/feed-item.md.tsx
@@ -196,15 +196,22 @@ export const FeedItemMD = memo<FeedItemProps>(function FeedItemMD({
             </View>
           </View>
           <View tw="flex-1 items-center justify-center px-20 pb-20">
-            <Media
-              item={nft}
-              numColumns={1}
-              sizeStyle={{
+            <View
+              style={{
                 height: mediaHeight,
                 width: mediaWidth,
               }}
-              resizeMode="contain"
-            />
+            >
+              <Media
+                item={nft}
+                numColumns={1}
+                sizeStyle={{
+                  height: mediaHeight,
+                  width: mediaWidth,
+                }}
+                resizeMode="contain"
+              />
+            </View>
           </View>
           {/* Control Swiper */}
           {swiper && (


### PR DESCRIPTION
# Why
Layout shift happens when media is loading in drop detail screen. We can add a placeholder skeleton later.

https://user-images.githubusercontent.com/23293248/199182480-6c13c5f9-df75-44a1-8269-03eb5634a949.mov


<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
Add media height/width to the container
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
Test drop screen
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
