### PR TITLE
fix: rename Verify to Request

### DIFF
--- a/packages/app/components/drop/drop-form.tsx
+++ b/packages/app/components/drop/drop-form.tsx
@@ -507,7 +507,7 @@ export const DropForm = () => {
                     );
                   }}
                 >
-                  Verify
+                  Request
                 </Button>
               )}
             </View>


### PR DESCRIPTION
# Why
 
https://showtime-rq88331.slack.com/archives/C02PXGK3V8D/p1667257322639389
just rename `Verify` to `Request`.

