### PR TITLE
fix: push notifications on setting

### DIFF
--- a/packages/app/components/settings/tabs/push-notifications.tsx
+++ b/packages/app/components/settings/tabs/push-notifications.tsx
@@ -32,7 +32,8 @@ export const PushNotificationTab = ({ index = 0 }: PushNotificationTabProp) => {
 
   return (
     <ScrollComponent index={index}>
-      {Object.entries(pushNotificationsPreferences?.data)?.length > 0 &&
+      {pushNotificationsPreferences?.data &&
+        Object.entries(pushNotificationsPreferences?.data)?.length > 0 &&
         Object.entries(pushNotificationsPreferences?.data).map(
           (item, index) => {
             const [key, value] = item;


### PR DESCRIPTION
# Why

fix: https://github.com/showtime-xyz/showtime-frontend/issues/1666  

we haven't handled when the `PushNotificationTab` initial data, so cause an error.


