### PR TITLE
stop persistent caching on all requests

### DIFF
--- a/packages/app/providers/swr-cache.ts
+++ b/packages/app/providers/swr-cache.ts
@@ -11,7 +11,7 @@ export const setupSWRCache = ({ set, get }: SWRCacheType) => {
     appCache ? JSON.parse(appCache) : []
   );
 
-  const onAppBackgroundCallback = () => {
+  const persistCache = () => {
     const prevCache = get("app-cache");
     const prevMap = new Map(prevCache ? JSON.parse(prevCache) : []);
 
@@ -27,7 +27,7 @@ export const setupSWRCache = ({ set, get }: SWRCacheType) => {
   };
 
   return {
-    onAppBackgroundCallback,
+    persistCache,
     mmkvCacheMap,
   };
 };

--- a/packages/app/providers/swr-cache.ts
+++ b/packages/app/providers/swr-cache.ts
@@ -7,7 +7,7 @@ const persistCacheKeys = ["/v2/trending/nfts", "/v2/myinfo"];
 
 export const setupSWRCache = ({ set, get }: SWRCacheType) => {
   const appCache = get("app-cache");
-  const mmkvCacheMap = new Map<string, string>(
+  const swrCacheMap = new Map<string, string>(
     appCache ? JSON.parse(appCache) : []
   );
 
@@ -16,7 +16,7 @@ export const setupSWRCache = ({ set, get }: SWRCacheType) => {
     const prevMap = new Map(prevCache ? JSON.parse(prevCache) : []);
 
     persistCacheKeys.forEach((key) => {
-      for (const [k, val] of mmkvCacheMap.entries()) {
+      for (const [k, val] of swrCacheMap.entries()) {
         if (k.includes(key)) {
           prevMap.set(k, val);
         }
@@ -28,6 +28,6 @@ export const setupSWRCache = ({ set, get }: SWRCacheType) => {
 
   return {
     persistCache,
-    mmkvCacheMap,
+    swrCacheMap,
   };
 };

--- a/packages/app/providers/swr-cache.ts
+++ b/packages/app/providers/swr-cache.ts
@@ -1,0 +1,33 @@
+type SWRCacheType = {
+  set: (key: string, value: any) => void;
+  get: (key: string) => any;
+};
+
+const persistCacheKeys = ["/v2/trending/nfts", "/v2/myinfo"];
+
+export const setupSWRCache = ({ set, get }: SWRCacheType) => {
+  const appCache = get("app-cache");
+  const mmkvCacheMap = new Map<string, string>(
+    appCache ? JSON.parse(appCache) : []
+  );
+
+  const onAppBackgroundCallback = () => {
+    const prevCache = get("app-cache");
+    const prevMap = new Map(prevCache ? JSON.parse(prevCache) : []);
+
+    persistCacheKeys.forEach((key) => {
+      for (const [k, val] of mmkvCacheMap.entries()) {
+        if (k.includes(key)) {
+          prevMap.set(k, val);
+        }
+      }
+    });
+    const newAppCache = JSON.stringify(Array.from(prevMap.entries()));
+    set("app-cache", newAppCache);
+  };
+
+  return {
+    onAppBackgroundCallback,
+    mmkvCacheMap,
+  };
+};

--- a/packages/app/providers/swr-provider.tsx
+++ b/packages/app/providers/swr-provider.tsx
@@ -16,14 +16,14 @@ import { setupSWRCache } from "./swr-cache";
 
 function mmkvProvider() {
   const storage = new MMKV();
-  const { mmkvCacheMap, onAppBackgroundCallback } = setupSWRCache({
+  const { mmkvCacheMap, persistCache } = setupSWRCache({
     set: storage.set.bind(storage),
     get: storage.getString.bind(storage),
   });
 
   AppState.addEventListener("change", function persistCacheOnAppBackground(s) {
     if (s === "background") {
-      onAppBackgroundCallback();
+      persistCache();
     }
   });
 

--- a/packages/app/providers/swr-provider.tsx
+++ b/packages/app/providers/swr-provider.tsx
@@ -12,17 +12,22 @@ import { useAccessTokenManager } from "app/hooks/auth/use-access-token-manager";
 import { useIsOnline } from "app/hooks/use-is-online";
 import { isUndefined } from "app/lib/swr/helper";
 
+import { setupSWRCache } from "./swr-cache";
+
 function mmkvProvider() {
   const storage = new MMKV();
-  const appCache = storage.getString("app-cache");
-  const map = new Map(appCache ? JSON.parse(appCache) : []);
-
-  AppState.addEventListener("change", () => {
-    const appCache = JSON.stringify(Array.from(map.entries()));
-    storage.set("app-cache", appCache);
+  const { mmkvCacheMap, onAppBackgroundCallback } = setupSWRCache({
+    set: storage.set.bind(storage),
+    get: storage.getString.bind(storage),
   });
 
-  return map;
+  AppState.addEventListener("change", function persistCacheOnAppBackground(s) {
+    if (s === "background") {
+      onAppBackgroundCallback();
+    }
+  });
+
+  return mmkvCacheMap;
 }
 
 export const SWRProvider = ({

--- a/packages/app/providers/swr-provider.tsx
+++ b/packages/app/providers/swr-provider.tsx
@@ -16,7 +16,7 @@ import { setupSWRCache } from "./swr-cache";
 
 function mmkvProvider() {
   const storage = new MMKV();
-  const { mmkvCacheMap, persistCache } = setupSWRCache({
+  const { swrCacheMap, persistCache } = setupSWRCache({
     set: storage.set.bind(storage),
     get: storage.getString.bind(storage),
   });
@@ -27,7 +27,7 @@ function mmkvProvider() {
     }
   });
 
-  return mmkvCacheMap;
+  return swrCacheMap;
 }
 
 export const SWRProvider = ({

--- a/packages/app/providers/swr-provider.web.tsx
+++ b/packages/app/providers/swr-provider.web.tsx
@@ -11,12 +11,12 @@ import { isUndefined } from "app/lib/swr/helper";
 import { setupSWRCache } from "./swr-cache";
 
 const localStorageProvider = () => {
-  const { mmkvCacheMap, onAppBackgroundCallback } = setupSWRCache({
+  const { mmkvCacheMap, persistCache } = setupSWRCache({
     set: localStorage.setItem.bind(localStorage),
     get: localStorage.getItem.bind(localStorage),
   });
 
-  window.addEventListener("beforeunload", onAppBackgroundCallback);
+  window.addEventListener("beforeunload", persistCache);
 
   return mmkvCacheMap;
 };

--- a/packages/app/providers/swr-provider.web.tsx
+++ b/packages/app/providers/swr-provider.web.tsx
@@ -8,17 +8,17 @@ import { useAccessTokenManager } from "app/hooks/auth/use-access-token-manager";
 import { isServer } from "app/lib/is-server";
 import { isUndefined } from "app/lib/swr/helper";
 
-const localStorageProvider = () => {
-  const map = new Map<any, any>(
-    JSON.parse(localStorage.getItem("app-cache") as string) || []
-  );
+import { setupSWRCache } from "./swr-cache";
 
-  window.addEventListener("beforeunload", () => {
-    const appCache = JSON.stringify(Array.from(map.entries()));
-    localStorage?.setItem("app-cache", appCache);
+const localStorageProvider = () => {
+  const { mmkvCacheMap, onAppBackgroundCallback } = setupSWRCache({
+    set: localStorage.setItem.bind(localStorage),
+    get: localStorage.getItem.bind(localStorage),
   });
 
-  return map;
+  window.addEventListener("beforeunload", onAppBackgroundCallback);
+
+  return mmkvCacheMap;
 };
 
 export const SWRProvider = ({

--- a/packages/app/providers/swr-provider.web.tsx
+++ b/packages/app/providers/swr-provider.web.tsx
@@ -11,14 +11,14 @@ import { isUndefined } from "app/lib/swr/helper";
 import { setupSWRCache } from "./swr-cache";
 
 const localStorageProvider = () => {
-  const { mmkvCacheMap, persistCache } = setupSWRCache({
+  const { swrCacheMap, persistCache } = setupSWRCache({
     set: localStorage.setItem.bind(localStorage),
     get: localStorage.getItem.bind(localStorage),
   });
 
   window.addEventListener("beforeunload", persistCache);
 
-  return mmkvCacheMap;
+  return swrCacheMap;
 };
 
 export const SWRProvider = ({


### PR DESCRIPTION
# Why
- We currently persist all requests! drops, editions, profiles and even comments.
- This PR adds a feature where we can specify what to cache in persistent storage.
- Some redundancy clean up between web and native
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# Test
- It should only persist `trending` and `myinfo` API
<!--
How did you build this feature or fix this bug and why?
-->


<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
