### PR TITLE
fix bug preventing to claim spotify gated drops

### DIFF
--- a/packages/app/hooks/use-spotify-gated-claim.ts
+++ b/packages/app/hooks/use-spotify-gated-claim.ts
@@ -15,7 +15,7 @@ export const useSpotifyGatedClaim = (edition: IEdition) => {
       // TODO: remove this after testing
       if (user?.user?.data.profile.has_spotify_token) {
         try {
-          const res = claimNFT();
+          const res = claimNFT({});
 
           return res;
         } catch (error: any) {


### PR DESCRIPTION
# Why

Claiming spotify gated drops is currently broken on all platforms as far as I can tell

# How

It seems that `claimSpotifyGatedDrop` is calling `claimNFT` without any arguments, causing `claimNFT` to acces property `password` and `location` of `null`.

My fix is to pass an empty object to `claimNFT`

# Test Plan

I haven't tested it
I'm going to merge it into dev
