### PR TITLE
fix bug preventing to claim spotify gated drops

### DIFF
--- a/packages/app/hooks/use-spotify-gated-claim.ts
+++ b/packages/app/hooks/use-spotify-gated-claim.ts
@@ -15,7 +15,7 @@ export const useSpotifyGatedClaim = (edition: IEdition) => {
       // TODO: remove this after testing
       if (user?.user?.data.profile.has_spotify_token) {
         try {
-          const res = claimNFT();
+          const res = claimNFT({});
 
           return res;
         } catch (error: any) {


### PR DESCRIPTION
# Why

looks like I have to do https://github.com/showtime-xyz/showtime-frontend/pull/1680 again against staging as we have different histories on staging and dev

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
