### PR TITLE
eas build failing

### DIFF
--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -142,7 +142,7 @@
     "domain-browser": "^4.22.0",
     "dotenv": "^10.0.0",
     "events": "^3.3.0",
-    "expo": "~46.0.16",
+    "expo": "~46.0.17",
     "expo-app-loading": "~2.1.0",
     "expo-application": "~4.2.2",
     "expo-av": "12.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9120,7 +9120,7 @@ __metadata:
     dotenv: ^10.0.0
     esbuild: ^0.14.50
     events: ^3.3.0
-    expo: ~46.0.16
+    expo: ~46.0.17
     expo-app-loading: ~2.1.0
     expo-application: ~4.2.2
     expo-av: 12.0.4
@@ -20405,6 +20405,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expo-modules-core@npm:0.11.9":
+  version: 0.11.9
+  resolution: "expo-modules-core@npm:0.11.9"
+  dependencies:
+    compare-versions: ^3.4.0
+    invariant: ^2.2.4
+  checksum: af130f8dd82967a0bde598cd109d44a2feec5692e0990f0e0eb1157a6a88419d52f0cbae09902fb6eddc2ed633d7cf10bf458ce43bbcd3372035d6bc9469813d
+  languageName: node
+  linkType: hard
+
 "expo-navigation-bar@npm:1.3.0, expo-navigation-bar@npm:~1.3.0":
   version: 1.3.0
   resolution: "expo-navigation-bar@npm:1.3.0"
@@ -20609,6 +20619,40 @@ __metadata:
   bin:
     expo: bin/cli.js
   checksum: bddf54f4e0fdd72fb4f6dcf257a1494d02a484d4b161912d69125c0dc4eb90858cd08aa6b1ec0b8d32b34323edd64ccaeae4f251f95f46e90c3684c52a3c098b
+  languageName: node
+  linkType: hard
+
+"expo@npm:~46.0.17":
+  version: 46.0.17
+  resolution: "expo@npm:46.0.17"
+  dependencies:
+    "@babel/runtime": ^7.14.0
+    "@expo/cli": 0.3.2
+    "@expo/vector-icons": ^13.0.0
+    babel-preset-expo: ~9.2.0
+    cross-spawn: ^6.0.5
+    expo-application: ~4.2.2
+    expo-asset: ~8.6.1
+    expo-constants: ~13.2.4
+    expo-error-recovery: ~3.2.0
+    expo-file-system: ~14.1.0
+    expo-font: ~10.2.1
+    expo-keep-awake: ~10.2.0
+    expo-modules-autolinking: 0.10.3
+    expo-modules-core: 0.11.9
+    fbemitter: ^3.0.0
+    getenv: ^1.0.0
+    invariant: ^2.2.4
+    md5-file: ^3.2.3
+    node-fetch: ^2.6.7
+    pretty-format: ^26.5.2
+    uuid: ^3.4.0
+  dependenciesMeta:
+    expo-error-recovery:
+      optional: true
+  bin:
+    expo: bin/cli.js
+  checksum: 86c92de6359ae9fcc1c515934a173319104887c3706e4b80d77354a93d4d12c0ff2f9fd5133469c559fe92887f935a122a8b8240e545ae4758c196dab9e34c56
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Why
https://expo.dev/accounts/showtime-xyz/projects/showtime/builds/068975c7-1007-4d27-a8a0-395014e09066

I think it's failing as the dependency is changed on prebuild command. Trying this fix