### PR TITLE
fix: build error on iOS

### DIFF
--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -146,7 +146,7 @@
     "expo": "~46.0.17",
     "expo-app-loading": "~2.1.0",
     "expo-application": "~4.2.2",
-    "expo-av": "^13.0.1",
+    "expo-av": "12.0.4",
     "expo-blur": "~11.2.0",
     "expo-build-properties": "^0.2.0",
     "expo-camera": "~12.3.0",

--- a/patches/expo-av+12.0.4.patch
+++ b/patches/expo-av+12.0.4.patch
@@ -1,0 +1,48 @@
+diff --git a/node_modules/expo-av/src/Video.tsx b/node_modules/expo-av/src/Video.tsx
+index fbc5f1b..88c8056 100644
+--- a/node_modules/expo-av/src/Video.tsx
++++ b/node_modules/expo-av/src/Video.tsx
+@@ -334,6 +334,7 @@ class Video extends React.Component<VideoProps, VideoState> implements Playback
+         ...Object.keys(status),
+       ]),
+       style: StyleSheet.flatten([_STYLES.base, this.props.style]),
++      videoStyle: StyleSheet.flatten([_STYLES.video, this.props.videoStyle]),
+       source,
+       resizeMode: nativeResizeMode,
+       status,
+@@ -347,7 +348,7 @@ class Video extends React.Component<VideoProps, VideoState> implements Playback
+ 
+     return (
+       <View style={nativeProps.style} pointerEvents="box-none">
+-        <ExponentVideo ref={this._nativeRef} {...nativeProps} style={_STYLES.video} />
++        <ExponentVideo ref={this._nativeRef} {...nativeProps} style={nativeProps.videoStyle} />
+         {this._renderPoster()}
+       </View>
+     );
+diff --git a/node_modules/expo-av/src/Video.types.ts b/node_modules/expo-av/src/Video.types.ts
+index cf52ae0..8fd524e 100644
+--- a/node_modules/expo-av/src/Video.types.ts
++++ b/node_modules/expo-av/src/Video.types.ts
+@@ -1,5 +1,5 @@
+ import * as React from 'react';
+-import { ImageProps, ViewProps } from 'react-native';
++import { ImageProps, StyleProp, ViewProps, ViewStyle } from 'react-native';
+ 
+ import {
+   AVPlaybackNativeSource,
+@@ -242,6 +242,7 @@ export type VideoProps = {
+    * @hidden
+    */
+   rotation?: number;
++  videoStyle?: StyleProp<ViewStyle>;
+ } & ViewProps;
+ 
+ /**
+@@ -258,6 +259,7 @@ export type VideoNativeProps = {
+   onReadyForDisplay?: (event: { nativeEvent: VideoReadyForDisplayEvent }) => void;
+   onFullscreenUpdate?: (event: { nativeEvent: VideoFullscreenUpdateEvent }) => void;
+   useNativeControls?: boolean;
++  videoStyle?: StyleProp<ViewStyle>;
+ } & ViewProps;
+ 
+ // @docsMissing

--- a/yarn.lock
+++ b/yarn.lock
@@ -9134,7 +9134,7 @@ __metadata:
     expo: ~46.0.17
     expo-app-loading: ~2.1.0
     expo-application: ~4.2.2
-    expo-av: ^13.0.1
+    expo-av: 13.0.1
     expo-blur: ~11.2.0
     expo-build-properties: ^0.2.0
     expo-camera: ~12.3.0
@@ -9329,7 +9329,7 @@ __metadata:
     design-system: "*"
     expo: ~46.0.16
     expo-asset: ~8.5.0
-    expo-av: 12.0.4
+    expo-av: 13.0.1
     expo-blur: ~11.2.0
     expo-community-flipper: ^45.1.0
     expo-constants: ~13.2.3
@@ -20051,18 +20051,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expo-av@npm:12.0.4":
-  version: 12.0.4
-  resolution: "expo-av@npm:12.0.4"
-  dependencies:
-    "@expo/config-plugins": ~5.0.0
-  peerDependencies:
-    expo: "*"
-  checksum: 5d985ab18159f45e1a2857af8b671285d940c457797eef489888c019fb1a760e1dcc01ea7eaff6f06cd80d4d9b17f2573568cd4c01799e6f054df76f89e312ec
-  languageName: node
-  linkType: hard
-
-"expo-av@npm:^13.0.1":
+"expo-av@npm:13.0.1":
   version: 13.0.1
   resolution: "expo-av@npm:13.0.1"
   peerDependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -9134,7 +9134,7 @@ __metadata:
     expo: ~46.0.17
     expo-app-loading: ~2.1.0
     expo-application: ~4.2.2
-    expo-av: 13.0.1
+    expo-av: 12.0.4
     expo-blur: ~11.2.0
     expo-build-properties: ^0.2.0
     expo-camera: ~12.3.0
@@ -9329,7 +9329,7 @@ __metadata:
     design-system: "*"
     expo: ~46.0.16
     expo-asset: ~8.5.0
-    expo-av: 13.0.1
+    expo-av: 12.0.4
     expo-blur: ~11.2.0
     expo-community-flipper: ^45.1.0
     expo-constants: ~13.2.3
@@ -20051,12 +20051,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expo-av@npm:13.0.1":
-  version: 13.0.1
-  resolution: "expo-av@npm:13.0.1"
+"expo-av@npm:12.0.4":
+  version: 12.0.4
+  resolution: "expo-av@npm:12.0.4"
+  dependencies:
+    "@expo/config-plugins": ~5.0.0
   peerDependencies:
     expo: "*"
-  checksum: fb0469784b31a31561912df917008e22779f20c7bde34d15481bf94bd501b007c59e63f8bde026d974b0d939d3f523f72f5741668d962929be08106817f719be
+  checksum: 5d985ab18159f45e1a2857af8b671285d940c457797eef489888c019fb1a760e1dcc01ea7eaff6f06cd80d4d9b17f2573568cd4c01799e6f054df76f89e312ec
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Why 

building has some error on iOS because the latest `expo-av` version rely on `expo-core-module`, also related to `expo` `v47`, it should be upgraded in https://github.com/showtime-xyz/showtime-frontend/pull/1687 PR

# How

- downgrade `expo-av` to `12.0.4`.  
