### PR TITLE
fix: notification list height on desktop

### DIFF
--- a/packages/app/components/notifications/index.tsx
+++ b/packages/app/components/notifications/index.tsx
@@ -115,7 +115,7 @@ export const Notifications = ({
         style={{
           height: Platform.select({
             default: windowHeight - bottomBarHeight,
-            web: windowHeight - bottomBarHeight,
+            web: useWindowScroll ? windowHeight - bottomBarHeight : "100%",
             ios: windowHeight,
           }),
         }}


### PR DESCRIPTION
# Why 
[SHOW2-1347](https://linear.app/showtime/issue/SHOW2-1347/notifications-list-height-incorrect-on-the-web)

fixed the notifications list height incorrectly on the desktop. 

# How

set height `100%` when the `useWindowScroll` prop is disabled. 

# Test Plan


https://user-images.githubusercontent.com/37520667/201590947-72827692-b042-445f-9ddd-1db33af9d3d0.mov


