### PR TITLE
feat: add password in QRCode URL for drop owners

### DIFF
--- a/packages/app/components/drop/drop-form.tsx
+++ b/packages/app/components/drop/drop-form.tsx
@@ -114,6 +114,7 @@ export const DropForm = () => {
     formState: { errors },
     watch,
     setValue,
+    getValues,
     reset: resetForm,
   } = useForm<any>({
     resolver: yupResolver(dropValidationSchema),
@@ -185,7 +186,13 @@ export const DropForm = () => {
     const claimPath = `/t/${[process.env.NEXT_PUBLIC_CHAIN_ID]}/${
       state.edition?.contract_address
     }/0`;
-    const claimUrl = `https://${process.env.NEXT_PUBLIC_WEBSITE_DOMAIN}${claimPath}`;
+    let claimUrl = `https://${process.env.NEXT_PUBLIC_WEBSITE_DOMAIN}${claimPath}`;
+    const qrCodeUrl = new URL(claimUrl);
+
+    const password = getValues("password");
+    if (password) {
+      qrCodeUrl.searchParams.set("password", password);
+    }
 
     const isShareAPIAvailable = Platform.select({
       default: true,
@@ -273,7 +280,7 @@ export const DropForm = () => {
         <View tw="mt-4">
           <QRCode
             size={windowWidth >= 768 ? 400 : windowWidth >= 400 ? 250 : 300}
-            text={claimUrl}
+            text={qrCodeUrl.toString()}
           />
         </View>
       </View>

--- a/packages/app/components/nft-dropdown.tsx
+++ b/packages/app/components/nft-dropdown.tsx
@@ -34,6 +34,7 @@ import { QRCode } from "app/components/qr-code";
 import { useProfileTabType } from "app/context/profile-tabs-nft-context";
 import { useMyInfo } from "app/hooks/api-hooks";
 import { useBlock } from "app/hooks/use-block";
+import { useCreatorCollectionDetail } from "app/hooks/use-creator-collection-detail";
 import { useHideNFT } from "app/hooks/use-hide-nft";
 import { useRefreshMedadata } from "app/hooks/use-refresh-metadata";
 import { useReport } from "app/hooks/use-report";
@@ -315,15 +316,32 @@ function NFTDropdown({
                 width={32}
               />
             </Pressable>
-            <QRCode
-              text={getNFTURL(nft)}
-              size={windowWidth >= 768 ? 400 : windowWidth >= 400 ? 250 : 300}
-            />
+            <DropQRCode nft={nft} />
           </View>
         </View>
       </Modal>
     </>
   );
 }
+
+const DropQRCode = ({ nft }: { nft: NFT }) => {
+  const { data: edition } = useCreatorCollectionDetail(
+    nft?.creator_airdrop_edition_address
+  );
+  const qrCodeUrl = useMemo(() => {
+    const url = new URL(getNFTURL(nft));
+    if (edition && edition.password) {
+      url.searchParams.set("password", edition?.password);
+    }
+    return url;
+  }, [edition, nft]);
+
+  return (
+    <QRCode
+      text={qrCodeUrl.toString()}
+      size={windowWidth >= 768 ? 400 : windowWidth >= 400 ? 250 : 300}
+    />
+  );
+};
 
 export { NFTDropdown };

--- a/packages/app/hooks/use-creator-collection-detail.ts
+++ b/packages/app/hooks/use-creator-collection-detail.ts
@@ -7,6 +7,7 @@ import { fetcher } from "./use-infinite-list-query";
 export type CreatorEditionResponse = {
   creator_airdrop_edition: IEdition;
   is_already_claimed: boolean;
+  password: string | null;
   time_limit: string;
   total_claimed_count: number;
   gating_type: "spotify_save" | "password" | "location" | "multi";


### PR DESCRIPTION
# Why
We need to add password in QRCode URL if it's generated by drop owner.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- Append `password` if it's coming in the edition API 
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Test whether password in appended in URL
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
