### PR TITLE
fix: double clicking tolike on web

### DIFF
--- a/packages/app/components/feed/feed-item-tap-gesture.web.tsx
+++ b/packages/app/components/feed/feed-item-tap-gesture.web.tsx
@@ -41,7 +41,7 @@ export const FeedItemTapGesture = ({ children }: FeedItemTapGestureProps) => {
 
   const doubleTapHandle = Gesture.Tap()
     .numberOfTaps(2)
-    .onFinalize(() => {
+    .onEnd(() => {
       heartAnimation.value = withSequence(
         withSpring(1),
         withDelay(200, withSpring(0))


### PR DESCRIPTION
# Why

always trigger double click to like content when swiping. 

# How

move double-clicking to like logic to `onEnd` from `onFinalize`.


# Before 

https://user-images.githubusercontent.com/37520667/201911961-19615c2d-f06f-44fe-840d-83c58883255e.mov

# After 

https://user-images.githubusercontent.com/37520667/201911975-0b50d133-ec5b-4972-9931-e4de8604b467.mov


