### PR TITLE
perf: optimise fetches in grid items

### DIFF
--- a/packages/app/components/card/card.tsx
+++ b/packages/app/components/card/card.tsx
@@ -65,27 +65,18 @@ type Props = {
   style?: StyleProp<ViewStyle>;
 };
 
-function Card({
-  nft,
-  numColumns = 1,
-  tw = "",
-  sizeStyle,
-  onPress,
-  href = "",
-  showClaimButton = false,
-  style,
-}: Props) {
+function Card(props: Props) {
+  const {
+    nft,
+    numColumns = 1,
+    tw = "",
+    sizeStyle,
+    onPress,
+    href = "",
+    style,
+  } = props;
   const { width } = useWindowDimensions();
   const contentWidth = useContentWidth();
-
-  const { data: edition } = useCreatorCollectionDetail(
-    nft.creator_airdrop_edition_address
-  );
-  const { data: detailData } = useNFTDetailByTokenId({
-    contractAddress: nft?.contract_address,
-    tokenId: nft?.token_id,
-    chainName: nft?.chain_name,
-  });
 
   const cardMaxWidth = useMemo(() => {
     switch (numColumns) {
@@ -124,6 +115,33 @@ function Card({
     );
   }
 
+  return (
+    <CardLargeScreen
+      {...props}
+      handleOnPress={handleOnPress}
+      cardMaxWidth={cardMaxWidth}
+    />
+  );
+}
+
+const CardLargeScreen = ({
+  nft,
+  numColumns = 1,
+  tw = "",
+  sizeStyle,
+  href = "",
+  showClaimButton,
+  handleOnPress,
+  cardMaxWidth,
+}: Props & { handleOnPress: any; cardMaxWidth: number }) => {
+  const { data: edition } = useCreatorCollectionDetail(
+    nft.creator_airdrop_edition_address
+  );
+  const { data: detailData } = useNFTDetailByTokenId({
+    contractAddress: nft?.contract_address,
+    tokenId: nft?.token_id,
+    chainName: nft?.chain_name,
+  });
   return (
     <LikeContextProvider nft={nft} key={nft.nft_id}>
       <View
@@ -203,7 +221,7 @@ function Card({
       </View>
     </LikeContextProvider>
   );
-}
+};
 
 const MemoizedCard = withMemoAndColorScheme<typeof Card, Props>(Card);
 


### PR DESCRIPTION
# Why
- App makes too many requests https://showtime-rq88331.slack.com/archives/C02PTPFCZAA/p1668598439477099 (less than 1200 though)
- Right now grid items in mobile screen fetch NFT details and edition API for each item. This makes sense for large screen as we show gift count from edition API and multiple_owner_list from detail API (it can also be optimised, will do in next PR)/
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
Don't fetch detail/edition for mobile screen grid items
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Test mobile screen doesn't fetch detail/edition for each item.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
