### PR TITLE
fix: image clip path

### DIFF
--- a/apps/next/src/styles/styles.css
+++ b/apps/next/src/styles/styles.css
@@ -157,8 +157,10 @@ body {
 }
 
 /* For Next.js <Image /> https://nextjs.org/docs/api-reference/next/image#known-browser-bugs */
-img[loading="lazy"] {
-  clip-path: inset(0.5px); /* Safari */
+@media not all and (min-resolution: 0.001dpcm) {
+  img[loading="lazy"] {
+    clip-path: inset(0.5px);
+  }
 }
 
 /* Hide scrollbar for Chrome, Safari and Opera */


### PR DESCRIPTION
# Why

just noticed that the image has a `0.5px` path bug on some browsers. 

![image](https://user-images.githubusercontent.com/37520667/203842801-0ba4ef4c-d321-49ca-aa13-d3be53b75ee7.png)

# How

add a media query on `img[loading="lazy"]` CSS following docs: https://nextjs.org/docs/api-reference/next/image#known-browser-bugs

# After 

![image](https://user-images.githubusercontent.com/37520667/203842921-d15101b0-035e-4cc3-aebd-db5023581915.png)


