### PR TITLE
fix: image border on Safari

### DIFF
--- a/apps/next/src/styles/styles.css
+++ b/apps/next/src/styles/styles.css
@@ -157,12 +157,9 @@ body {
 }
 
 /* For Next.js <Image /> https://nextjs.org/docs/api-reference/next/image#known-browser-bugs */
-@media not all and (min-resolution: 0.001dpcm) {
-  img[loading="lazy"] {
-    clip-path: inset(0.5px);
-  }
+img[loading="lazy"] {
+  clip-path: inset(0.5px);
 }
-
 /* Hide scrollbar for Chrome, Safari and Opera */
 .no-scrollbar::-webkit-scrollbar {
   display: none;


### PR DESCRIPTION
# Why 

just bring back https://github.com/showtime-xyz/showtime-frontend/pull/1722.

