### PR TITLE
Fix/next image border on safari

### DIFF
--- a/apps/next/package.json
+++ b/apps/next/package.json
@@ -41,7 +41,7 @@
     "fortmatic": "^2.2.1",
     "logrocket": "^2.2.1",
     "magic-sdk": "^10.0.0",
-    "next": "13.0.0",
+    "next": "13.0.5",
     "next-fonts": "^1.5.1",
     "next-images": "^1.8.2",
     "next-pwa": "^5.6.0",

--- a/apps/next/src/styles/styles.css
+++ b/apps/next/src/styles/styles.css
@@ -157,8 +157,19 @@ body {
 }
 
 /* For Next.js <Image /> https://nextjs.org/docs/api-reference/next/image#known-browser-bugs */
-img[loading="lazy"] {
-  clip-path: inset(0.5px);
+/* For Safari v10~15+ */
+@media not all and (min-resolution: 0.001dpcm) {
+  img[loading="lazy"] {
+    clip-path: inset(1px);
+  }
+}
+/* For Safari v16+ becuase Safari v16 is supported resolution media query */
+@media (min-resolution: 0.001dpcm) {
+  @supports (-webkit-appearance: none) and (stroke-color: transparent) {
+    img[loading="lazy"] {
+      clip-path: inset(1px);
+    }
+  }
 }
 /* Hide scrollbar for Chrome, Safari and Opera */
 .no-scrollbar::-webkit-scrollbar {

--- a/apps/next/src/styles/styles.css
+++ b/apps/next/src/styles/styles.css
@@ -157,12 +157,9 @@ body {
 }
 
 /* For Next.js <Image /> https://nextjs.org/docs/api-reference/next/image#known-browser-bugs */
-@media not all and (min-resolution: 0.001dpcm) {
-  img[loading="lazy"] {
-    clip-path: inset(0.5px);
-  }
+img[loading="lazy"] {
+  clip-path: inset(0.5px);
 }
-
 /* Hide scrollbar for Chrome, Safari and Opera */
 .no-scrollbar::-webkit-scrollbar {
   display: none;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9092,7 +9092,7 @@ __metadata:
     fortmatic: ^2.2.1
     logrocket: ^2.2.1
     magic-sdk: ^10.0.0
-    next: 13.0.0
+    next: 13.0.5
     next-compose-plugins: ^2.2.1
     next-fonts: ^1.5.1
     next-images: ^1.8.2


### PR DESCRIPTION
# Why

Safari v16 is supported [resolution media query](https://developer.apple.com/documentation/safari-release-notes/safari-16-release-notes), so before `@media not all and (min-resolution: 0.001dpcm)` query is not working.

# How  

add specifically media query conditions for safari `v16`. 


# Test Plan

- check if the image border exists on Safari. 
![image](https://user-images.githubusercontent.com/37520667/204493316-600acf1d-5cbd-4f52-9b12-ef9126461095.png)
- check if lose the 1px `path` on other browsers. 
![image](https://user-images.githubusercontent.com/37520667/204493756-f0888be7-3c8b-482b-aabc-c2fb9be35ce5.png)

