### PR TITLE
fix: replace modals with stack screens for user list components

### DIFF
--- a/packages/app/components/collectors-modal.tsx
+++ b/packages/app/components/collectors-modal.tsx
@@ -1,9 +1,7 @@
 import { Suspense } from "react";
-import { Platform } from "react-native";
 
 import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
 
-import { useRouter } from "@showtime-xyz/universal.router";
 import { Spinner } from "@showtime-xyz/universal.spinner";
 import { View } from "@showtime-xyz/universal.view";
 
@@ -24,7 +22,6 @@ const { useParam } = createParam<Query>();
 
 export const CollectorsModal = () => {
   useTrackPageViewed({ name: "Collectors" });
-  const router = useRouter();
   const [tokenId] = useParam("tokenId");
   const [contractAddress] = useParam("contractAddress");
   const [chainName] = useParam("chainName");
@@ -48,10 +45,6 @@ export const CollectorsModal = () => {
           <UserList
             loading={isLoading}
             users={data?.data?.item?.multiple_owners_list}
-            onClose={Platform.select({
-              ios: () => router.pop(),
-              default: () => false,
-            })}
           />
         </Suspense>
       </ErrorBoundary>

--- a/packages/app/components/comments-modal.tsx
+++ b/packages/app/components/comments-modal.tsx
@@ -1,0 +1,38 @@
+import { Suspense } from "react";
+
+import { Comments } from "app/components/comments";
+import { CommentsStatus } from "app/components/comments/comments-status";
+import { ErrorBoundary } from "app/components/error-boundary";
+import { useNFTDetailByTokenId } from "app/hooks/use-nft-detail-by-token-id";
+import { useTrackPageViewed } from "app/lib/analytics";
+import { createParam } from "app/navigation/use-param";
+
+type Query = {
+  tokenId: string;
+  contractAddress: string;
+  chainName: string;
+};
+
+const { useParam } = createParam<Query>();
+
+export function CommentsModal() {
+  useTrackPageViewed({ name: "Comments" });
+  const [tokenId] = useParam("tokenId");
+  const [contractAddress] = useParam("contractAddress");
+  const [chainName] = useParam("chainName");
+  const { data } = useNFTDetailByTokenId({
+    chainName: chainName as string,
+    tokenId: tokenId as string,
+    contractAddress: contractAddress as string,
+  });
+
+  return (
+    <ErrorBoundary>
+      <Suspense
+        fallback={<CommentsStatus isLoading={true} error={undefined} />}
+      >
+        {data?.data?.item && <Comments nft={data?.data.item} />}
+      </Suspense>
+    </ErrorBoundary>
+  );
+}

--- a/packages/app/components/comments/index.tsx
+++ b/packages/app/components/comments/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useEffect, Fragment } from "react";
+import { useCallback, useMemo, useRef, Fragment, useEffect } from "react";
 import {
   Platform,
   StyleSheet,
@@ -49,7 +49,7 @@ export function Comments({ nft }: { nft: NFT }) {
     if (Platform.OS !== "web") {
       setTimeout(() => {
         commentInputRef.current?.focus?.();
-      }, 100);
+      }, 800);
     }
     return () => {
       if (Platform.OS === "ios") {

--- a/packages/app/components/comments/index.tsx
+++ b/packages/app/components/comments/index.tsx
@@ -147,7 +147,7 @@ export function Comments({ nft }: { nft: NFT }) {
         text="Be the first to add a comment!"
         title="💬 No comments yet..."
         titleTw="pt-1"
-        tw="-mt-5 h-full flex-1 items-center justify-center"
+        tw="mt-5 h-full flex-1 items-center justify-center"
       />
     ),
     []

--- a/packages/app/components/follow-modal.tsx
+++ b/packages/app/components/follow-modal.tsx
@@ -1,8 +1,4 @@
-import { Platform } from "react-native";
-
 import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
-
-import { useRouter } from "@showtime-xyz/universal.router";
 
 import { createParam } from "app/navigation/use-param";
 
@@ -16,36 +12,18 @@ const { useParam } = createParam<Query>();
 
 export const FollowingModal = () => {
   const [profileId] = useParam("profileId");
-  const router = useRouter();
   if (!profileId) return null;
 
-  return (
-    <BottomSheetModalProvider>
-      <FollowingList
-        profileId={+profileId}
-        hideSheet={Platform.select({
-          ios: () => router.pop(),
-          default: () => false,
-        })}
-      />
-    </BottomSheetModalProvider>
-  );
+  return <FollowingList profileId={+profileId} />;
 };
 
 export const FollowerModal = () => {
   const [profileId] = useParam("profileId");
-  const router = useRouter();
 
   if (!profileId) return null;
   return (
     <BottomSheetModalProvider>
-      <FollowersList
-        profileId={+profileId}
-        hideSheet={Platform.select({
-          ios: () => router.pop(),
-          default: () => false,
-        })}
-      />
+      <FollowersList profileId={+profileId} />
     </BottomSheetModalProvider>
   );
 };

--- a/packages/app/components/following-user-list.tsx
+++ b/packages/app/components/following-user-list.tsx
@@ -4,24 +4,14 @@ import {
   useFollowersList,
 } from "app/hooks/api/use-follow-list";
 
-export const FollowersList = (props: {
-  profileId?: number;
-  hideSheet: () => void;
-}) => {
+export const FollowersList = (props: { profileId?: number }) => {
   const { data, loading } = useFollowersList(props.profileId);
 
-  return (
-    <UserList loading={loading} users={data?.list} onClose={props.hideSheet} />
-  );
+  return <UserList loading={loading} users={data?.list} />;
 };
 
-export const FollowingList = (props: {
-  profileId?: number;
-  hideSheet: () => void;
-}) => {
+export const FollowingList = (props: { profileId?: number }) => {
   const { data, loading } = useFollowingList(props.profileId);
 
-  return (
-    <UserList loading={loading} users={data?.list} onClose={props.hideSheet} />
-  );
+  return <UserList loading={loading} users={data?.list} />;
 };

--- a/packages/app/components/likers-modal.tsx
+++ b/packages/app/components/likers-modal.tsx
@@ -1,9 +1,7 @@
 import { Suspense } from "react";
-import { Platform } from "react-native";
 
 import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
 
-import { useRouter } from "@showtime-xyz/universal.router";
 import { Spinner } from "@showtime-xyz/universal.spinner";
 import { View } from "@showtime-xyz/universal.view";
 
@@ -22,7 +20,6 @@ const { useParam } = createParam<Query>();
 
 export const LikersModal = () => {
   useTrackPageViewed({ name: "Likers" });
-  const router = useRouter();
   const [nftId] = useParam("nftId");
   const { data, loading } = useLikes(Number(nftId));
 
@@ -36,14 +33,7 @@ export const LikersModal = () => {
             </View>
           }
         >
-          <UserList
-            loading={loading}
-            users={data?.likers}
-            onClose={Platform.select({
-              ios: () => router.pop(),
-              default: () => false,
-            })}
-          />
+          <UserList loading={loading} users={data?.likers} />
         </Suspense>
       </ErrorBoundary>
     </BottomSheetModalProvider>

--- a/packages/app/components/messages/message-row.tsx
+++ b/packages/app/components/messages/message-row.tsx
@@ -153,12 +153,8 @@ export function MessageRow({
     });
   }, [createdAt]);
   const contentWithTags = useMemo(() => {
-    return onTagPress
-      ? linkifyDescription(content, {
-          onUserMentionPress: router.pop,
-        })
-      : content;
-  }, [content, onTagPress, router.pop]);
+    return onTagPress ? linkifyDescription(content) : content;
+  }, [content, onTagPress]);
   const userNameText = useMemo(() => {
     return username || formatAddressShort(address);
   }, [address, username]);

--- a/packages/app/components/user-list.tsx
+++ b/packages/app/components/user-list.tsx
@@ -26,22 +26,19 @@ import { FollowButton } from "./follow-button";
 type FollowingListProp = {
   follow: (profileId: number) => void;
   unFollow: (profileId: number) => void;
-  hideSheet: () => void;
 };
 type UserListProps = Pick<InfiniteScrollListProps<any>, "style"> & {
   users?: UserItemType[];
-  onClose: () => void;
   loading: boolean;
   emptyTitle?: string;
 };
 export const UserList = ({
   users,
   loading,
-  onClose,
   emptyTitle = "No results found",
   ...rest
 }: UserListProps) => {
-  const { isFollowing, follow, unfollow } = useMyInfo();
+  const { follow, unfollow } = useMyInfo();
   const modalListProps = useModalListProps();
   const bottom = usePlatformBottomHeight();
   const keyExtractor = useCallback(
@@ -52,15 +49,10 @@ export const UserList = ({
   const renderItem = useCallback(
     ({ item }: { item: UserItemType }) => {
       return (
-        <FollowingListUser
-          item={item}
-          follow={follow}
-          unFollow={unfollow}
-          hideSheet={onClose}
-        />
+        <FollowingListUser item={item} follow={follow} unFollow={unfollow} />
       );
     },
-    [unfollow, follow, onClose]
+    [unfollow, follow]
   );
   const listEmptyComponent = useCallback(
     () => (
@@ -103,7 +95,7 @@ const Separator = () => (
 const ITEM_HEIGHT = 64 + SEPARATOR_HEIGHT;
 
 const FollowingListUser = memo(
-  ({ item, hideSheet }: { item: UserItemType } & FollowingListProp) => {
+  ({ item }: { item: UserItemType } & FollowingListProp) => {
     const { data } = useMyInfo();
 
     const { onToggleFollow } = useFollow({
@@ -116,7 +108,6 @@ const FollowingListUser = memo(
       >
         <Link
           href={`/@${item.username ?? item.wallet_address}`}
-          onPress={hideSheet}
           tw="flex-1"
           viewProps={{ style: { flex: 1 } }}
         >

--- a/packages/app/hooks/use-modal-list-props.tsx
+++ b/packages/app/hooks/use-modal-list-props.tsx
@@ -1,8 +1,6 @@
 import { useMemo } from "react";
 import { Platform } from "react-native";
 
-import { BottomSheetScrollView } from "@gorhom/bottom-sheet";
-
 import { useRouter } from "@showtime-xyz/universal.router";
 
 const ModalListScreenQueryParamList = [
@@ -29,9 +27,5 @@ export const useModalListProps = () => {
       default: null,
     }),
     useWindowScroll: false,
-    ...Platform.select({
-      android: { renderScrollComponent: BottomSheetScrollView as any },
-      default: {},
-    }),
   };
 };

--- a/packages/app/lib/linkify.tsx
+++ b/packages/app/lib/linkify.tsx
@@ -4,10 +4,6 @@ import { Link } from "solito/link";
 import { Text } from "@showtime-xyz/universal.text";
 import { View } from "@showtime-xyz/universal.view";
 
-type Props = {
-  onUserMentionPress?: any;
-};
-
 // This function replaces mention tags (@showtime) and URL (http://) with Link components
 export const linkifyDescription = (text?: string, rest?: Props) => {
   if (!text) {
@@ -16,15 +12,7 @@ export const linkifyDescription = (text?: string, rest?: Props) => {
   // Match @-mentions
   let replacedText = reactStringReplace(text, /@(\w+)/g, (match, i) => {
     return (
-      <Link
-        key={match + i}
-        href={`/@${match}`}
-        viewProps={{
-          //@ts-ignore. This will only work on native.
-          onPress: rest?.onUserMentionPress,
-        }}
-        target="_blank"
-      >
+      <Link key={match + i} href={`/@${match}`} target="_blank">
         <Text tw="text-13 font-bold text-gray-900 dark:text-gray-100">
           @{match}
         </Text>

--- a/packages/app/navigation/navigator-screen-options.tsx
+++ b/packages/app/navigation/navigator-screen-options.tsx
@@ -20,7 +20,7 @@ export const screenOptions = ({
     headerTitle: HeaderCenter,
     headerTitleAlign: "center" as "center",
     headerRight: headerRight ?? null,
-    headerTintColor: "#000",
+    headerTintColor: isDark ? "#fff" : "#000",
     headerTransparent: Platform.OS === "android" ? false : true,
     headerBlurEffect: isDark ? "dark" : "light",
     headerBackVisible: false,

--- a/packages/app/navigation/root-stack-navigator.tsx
+++ b/packages/app/navigation/root-stack-navigator.tsx
@@ -84,6 +84,32 @@ export function RootStackNavigator() {
             return params?.profileId ?? params.type;
           }}
         />
+        <Stack.Screen
+          name="followers"
+          component={FollowersScreen}
+          options={{ headerTitle: "Followers" }}
+        />
+        <Stack.Screen
+          name="following"
+          options={{ headerTitle: "Following" }}
+          component={FollowingScreen}
+        />
+        <Stack.Screen
+          name="collectors"
+          options={{ headerTitle: "Collectors" }}
+          component={CollectorsScreen}
+        />
+        <Stack.Screen
+          name="likers"
+          options={{ headerTitle: "Likers" }}
+          component={LikersScreen}
+        />
+        <Stack.Screen
+          name="comments"
+          options={{ headerTitle: "Comments" }}
+          component={CommentsScreen}
+        />
+
         <Stack.Screen name="nft" component={NftScreen} />
       </Stack.Group>
 
@@ -97,7 +123,6 @@ export function RootStackNavigator() {
         }}
       >
         <Stack.Screen name="login" component={LoginScreen} />
-        <Stack.Screen name="comments" component={CommentsScreen} />
         <Stack.Screen name="details" component={DetailsScreen} />
         <Stack.Screen name="editProfile" component={EditProfileScreen} />
         <Stack.Screen
@@ -105,8 +130,6 @@ export function RootStackNavigator() {
           component={CompleteProfileScreen}
         />
 
-        <Stack.Screen name="followers" component={FollowersScreen} />
-        <Stack.Screen name="following" component={FollowingScreen} />
         <Stack.Screen name="addEmail" component={AddEmailScreen} />
         <Stack.Screen
           name="verifyPhoneNumber"
@@ -114,8 +137,6 @@ export function RootStackNavigator() {
         />
         <Stack.Screen name="drop" component={DropScreen} />
         <Stack.Screen name="claim" component={ClaimScreen} />
-        <Stack.Screen name="collectors" component={CollectorsScreen} />
-        <Stack.Screen name="likers" component={LikersScreen} />
       </Stack.Group>
       <Stack.Group
         screenOptions={{

--- a/packages/app/screens/collectors.tsx
+++ b/packages/app/screens/collectors.tsx
@@ -1,11 +1,17 @@
-import { withModalScreen } from "@showtime-xyz/universal.modal-screen";
+import { Platform } from "react-native";
+
+import { View } from "@showtime-xyz/universal.view";
 
 import { CollectorsModal } from "app/components/collectors-modal";
+import { useHeaderHeight } from "app/lib/react-navigation/elements";
 
-export const CollectorsScreen = withModalScreen(CollectorsModal, {
-  title: "Collectors",
-  matchingPathname: "/collectors/[chainName]/[contractAddress]/[tokenId]",
-  matchingQueryParam: "collectorsModal",
-  enableContentPanningGesture: false,
-  snapPoints: ["90%"],
-});
+export const CollectorsScreen = () => {
+  const headerHeight = useHeaderHeight();
+  return (
+    <>
+      {Platform.OS !== "android" && <View style={{ height: headerHeight }} />}
+
+      <CollectorsModal />
+    </>
+  );
+};

--- a/packages/app/screens/collectors.web.tsx
+++ b/packages/app/screens/collectors.web.tsx
@@ -1,0 +1,11 @@
+import { withModalScreen } from "@showtime-xyz/universal.modal-screen";
+
+import { CollectorsModal } from "app/components/collectors-modal";
+
+export const CollectorsScreen = withModalScreen(CollectorsModal, {
+  title: "Collectors",
+  matchingPathname: "/collectors/[chainName]/[contractAddress]/[tokenId]",
+  matchingQueryParam: "collectorsModal",
+  enableContentPanningGesture: false,
+  snapPoints: ["90%"],
+});

--- a/packages/app/screens/comments.tsx
+++ b/packages/app/screens/comments.tsx
@@ -1,47 +1,17 @@
-import { Suspense } from "react";
+import { Platform } from "react-native";
 
-import { withModalScreen } from "@showtime-xyz/universal.modal-screen";
+import { View } from "@showtime-xyz/universal.view";
 
-import { Comments } from "app/components/comments";
-import { CommentsStatus } from "app/components/comments/comments-status";
-import { ErrorBoundary } from "app/components/error-boundary";
-import { useNFTDetailByTokenId } from "app/hooks/use-nft-detail-by-token-id";
-import { useTrackPageViewed } from "app/lib/analytics";
-import { createParam } from "app/navigation/use-param";
+import { CommentsModal } from "app/components/comments-modal";
+import { useHeaderHeight } from "app/lib/react-navigation/elements";
 
-type Query = {
-  tokenId: string;
-  contractAddress: string;
-  chainName: string;
-};
-
-const { useParam } = createParam<Query>();
-
-function CommentsModal() {
-  useTrackPageViewed({ name: "Comments" });
-  const [tokenId] = useParam("tokenId");
-  const [contractAddress] = useParam("contractAddress");
-  const [chainName] = useParam("chainName");
-  const { data } = useNFTDetailByTokenId({
-    chainName: chainName as string,
-    tokenId: tokenId as string,
-    contractAddress: contractAddress as string,
-  });
-
+export const CommentsScreen = () => {
+  const headerHeight = useHeaderHeight();
   return (
-    <ErrorBoundary>
-      <Suspense
-        fallback={<CommentsStatus isLoading={true} error={undefined} />}
-      >
-        {data?.data?.item && <Comments nft={data?.data.item} />}
-      </Suspense>
-    </ErrorBoundary>
-  );
-}
+    <>
+      {Platform.OS !== "android" && <View style={{ height: headerHeight }} />}
 
-export const CommentsScreen = withModalScreen(CommentsModal, {
-  title: "Comments",
-  matchingPathname: "/nft/[chainName]/[contractAddress]/[tokenId]/comments",
-  matchingQueryParam: "commentsModal",
-  snapPoints: ["98%"],
-});
+      <CommentsModal />
+    </>
+  );
+};

--- a/packages/app/screens/comments.web.tsx
+++ b/packages/app/screens/comments.web.tsx
@@ -1,0 +1,10 @@
+import { withModalScreen } from "@showtime-xyz/universal.modal-screen";
+
+import { CommentsModal } from "app/components/comments-modal";
+
+export const CommentsScreen = withModalScreen(CommentsModal, {
+  title: "Comments",
+  matchingPathname: "/nft/[chainName]/[contractAddress]/[tokenId]/comments",
+  matchingQueryParam: "commentsModal",
+  snapPoints: ["98%"],
+});

--- a/packages/app/screens/followers.tsx
+++ b/packages/app/screens/followers.tsx
@@ -1,11 +1,18 @@
-import { withModalScreen } from "@showtime-xyz/universal.modal-screen";
+import { Platform } from "react-native";
+
+import { View } from "@showtime-xyz/universal.view";
 
 import { FollowerModal } from "app/components/follow-modal";
+import { useHeaderHeight } from "app/lib/react-navigation/elements";
 
-export const FollowersScreen = withModalScreen(FollowerModal, {
-  title: "Followers",
-  matchingPathname: "/profile/followers",
-  matchingQueryParam: "followersModal",
-  enableContentPanningGesture: false,
-  snapPoints: ["90%"],
-});
+export const FollowersScreen = () => {
+  const headerHeight = useHeaderHeight();
+
+  return (
+    <>
+      {Platform.OS !== "android" && <View style={{ height: headerHeight }} />}
+
+      <FollowerModal />
+    </>
+  );
+};

--- a/packages/app/screens/followers.web.tsx
+++ b/packages/app/screens/followers.web.tsx
@@ -1,0 +1,11 @@
+import { withModalScreen } from "@showtime-xyz/universal.modal-screen";
+
+import { FollowerModal } from "app/components/follow-modal";
+
+export const FollowersScreen = withModalScreen(FollowerModal, {
+  title: "Followers",
+  matchingPathname: "/profile/followers",
+  matchingQueryParam: "followersModal",
+  enableContentPanningGesture: false,
+  snapPoints: ["90%"],
+});

--- a/packages/app/screens/following.tsx
+++ b/packages/app/screens/following.tsx
@@ -1,11 +1,18 @@
-import { withModalScreen } from "@showtime-xyz/universal.modal-screen";
+import { Platform } from "react-native";
+
+import { View } from "@showtime-xyz/universal.view";
 
 import { FollowingModal } from "app/components/follow-modal";
+import { useHeaderHeight } from "app/lib/react-navigation/elements";
 
-export const FollowingScreen = withModalScreen(FollowingModal, {
-  title: "Following",
-  matchingPathname: "/profile/following",
-  matchingQueryParam: "followingModal",
-  enableContentPanningGesture: false,
-  snapPoints: ["90%"],
-});
+export const FollowingScreen = () => {
+  const headerHeight = useHeaderHeight();
+
+  return (
+    <>
+      {Platform.OS !== "android" && <View style={{ height: headerHeight }} />}
+
+      <FollowingModal />
+    </>
+  );
+};

--- a/packages/app/screens/following.web.tsx
+++ b/packages/app/screens/following.web.tsx
@@ -1,0 +1,11 @@
+import { withModalScreen } from "@showtime-xyz/universal.modal-screen";
+
+import { FollowingModal } from "app/components/follow-modal";
+
+export const FollowingScreen = withModalScreen(FollowingModal, {
+  title: "Following",
+  matchingPathname: "/profile/following",
+  matchingQueryParam: "followingModal",
+  enableContentPanningGesture: false,
+  snapPoints: ["90%"],
+});

--- a/packages/app/screens/likers.tsx
+++ b/packages/app/screens/likers.tsx
@@ -1,11 +1,17 @@
-import { withModalScreen } from "@showtime-xyz/universal.modal-screen";
+import { Platform } from "react-native";
+
+import { View } from "@showtime-xyz/universal.view";
 
 import { LikersModal } from "app/components/likers-modal";
+import { useHeaderHeight } from "app/lib/react-navigation/elements";
 
-export const LikersScreen = withModalScreen(LikersModal, {
-  title: "Likers",
-  matchingPathname: "/collectors/[nftId]",
-  matchingQueryParam: "likersModal",
-  enableContentPanningGesture: false,
-  snapPoints: ["90%"],
-});
+export const LikersScreen = () => {
+  const headerHeight = useHeaderHeight();
+  return (
+    <>
+      {Platform.OS !== "android" && <View style={{ height: headerHeight }} />}
+
+      <LikersModal />
+    </>
+  );
+};

--- a/packages/app/screens/likers.web.tsx
+++ b/packages/app/screens/likers.web.tsx
@@ -1,0 +1,11 @@
+import { withModalScreen } from "@showtime-xyz/universal.modal-screen";
+
+import { LikersModal } from "app/components/likers-modal";
+
+export const LikersScreen = withModalScreen(LikersModal, {
+  title: "Likers",
+  matchingPathname: "/collectors/[nftId]",
+  matchingQueryParam: "likersModal",
+  enableContentPanningGesture: false,
+  snapPoints: ["90%"],
+});


### PR DESCRIPTION
# Why
Modal is not very suitable for UI where we have user lists as discussed here - https://showtime-rq88331.slack.com/archives/C02PXGK3V8D/p1670920369295469
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- Replace modal with regular screens on native
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
Test followers, following, collectors and comments screens on all platforms.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
