### PR TITLE
fix: comments & expo-updates

### DIFF
--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -167,7 +167,7 @@
     "expo-splash-screen": "~0.17.5",
     "expo-status-bar": "~1.4.2",
     "expo-system-ui": "~2.0.1",
-    "expo-updates": "~0.15.4",
+    "expo-updates": "~0.15.6",
     "expo-web-browser": "~12.0.0",
     "https-browserify": "~1.0.0",
     "inherits": "^2.0.1",

--- a/apps/storybook-react-native/package.json
+++ b/apps/storybook-react-native/package.json
@@ -55,7 +55,7 @@
     "expo-splash-screen": "~0.17.5",
     "expo-status-bar": "~1.4.2",
     "expo-system-ui": "~2.0.1",
-    "expo-updates": "~0.15.4",
+    "expo-updates": "~0.15.6",
     "expo-web-browser": "~12.0.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/packages/app/hooks/use-expo-update.tsx
+++ b/packages/app/hooks/use-expo-update.tsx
@@ -57,9 +57,9 @@ export function useExpoUpdate() {
   );
 
   useEffect(() => {
-    const now = new Date();
-    const currentHours = now.getHours();
-    checkUpdate(currentHours > 3 && currentHours < 5);
+    // const now = new Date();
+    // const currentHours = now.getHours();
+    checkUpdate(true);
     // if (isForeground) {
     //   if (__DEV__) return;
     //   if (Platform.OS !== "ios") return;

--- a/packages/app/lib/linkify.tsx
+++ b/packages/app/lib/linkify.tsx
@@ -1,22 +1,23 @@
 import reactStringReplace from "react-string-replace";
-import { Link } from "solito/link";
 
-import { Text } from "@showtime-xyz/universal.text";
-import { View } from "@showtime-xyz/universal.view";
+import { TextLink } from "app/navigation/link";
 
 // This function replaces mention tags (@showtime) and URL (http://) with Link components
-export const linkifyDescription = (text?: string, rest?: Props) => {
+export const linkifyDescription = (text?: string) => {
   if (!text) {
     return null;
   }
   // Match @-mentions
   let replacedText = reactStringReplace(text, /@(\w+)/g, (match, i) => {
     return (
-      <Link key={match + i} href={`/@${match}`} target="_blank">
-        <Text tw="text-13 font-bold text-gray-900 dark:text-gray-100">
-          @{match}
-        </Text>
-      </Link>
+      <TextLink
+        href={`/@${match}`}
+        key={match + i}
+        target="_blank"
+        tw="text-13 font-bold text-gray-900 dark:text-gray-100"
+      >
+        @{match}
+      </TextLink>
     );
   });
   // Match URLs
@@ -24,13 +25,14 @@ export const linkifyDescription = (text?: string, rest?: Props) => {
     replacedText,
     /(https?:\/\/\S+)/g,
     (match, i) => (
-      <Link key={match + i} href={match} target="_blank">
-        <View tw="flex-row">
-          <Text tw="text-13 wrap flex-shrink-1 font-bold text-gray-900 dark:text-gray-100">
-            {match}
-          </Text>
-        </View>
-      </Link>
+      <TextLink
+        href={match}
+        key={match + i}
+        target="_blank"
+        tw="text-13 font-bold text-gray-900 dark:text-gray-100"
+      >
+        {match}
+      </TextLink>
     )
   );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4300,16 +4300,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@expo/code-signing-certificates@npm:0.0.2":
-  version: 0.0.2
-  resolution: "@expo/code-signing-certificates@npm:0.0.2"
-  dependencies:
-    node-forge: ^1.2.1
-    nullthrows: ^1.1.1
-  checksum: 4ccbdab505e32ce70c01ead08541d651f5585ada55f579f56abaa241445a9571e14198bdc60cc0f6b78814da69b10802a73384e99193385f742762d8541f1ad3
-  languageName: node
-  linkType: hard
-
 "@expo/code-signing-certificates@npm:0.0.5":
   version: 0.0.5
   resolution: "@expo/code-signing-certificates@npm:0.0.5"
@@ -8868,7 +8858,7 @@ __metadata:
     expo-splash-screen: ~0.17.5
     expo-status-bar: ~1.4.2
     expo-system-ui: ~2.0.1
-    expo-updates: ~0.15.4
+    expo-updates: ~0.15.6
     expo-web-browser: ~12.0.0
     https-browserify: ~1.0.0
     inherits: ^2.0.1
@@ -9062,7 +9052,7 @@ __metadata:
     expo-splash-screen: ~0.17.5
     expo-status-bar: ~1.4.2
     expo-system-ui: ~2.0.1
-    expo-updates: ~0.15.4
+    expo-updates: ~0.15.6
     expo-web-browser: ~12.0.0
     react: 18.2.0
     react-dom: 18.2.0
@@ -20349,11 +20339,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expo-updates@npm:~0.15.4":
-  version: 0.15.4
-  resolution: "expo-updates@npm:0.15.4"
+"expo-updates@npm:~0.15.6":
+  version: 0.15.6
+  resolution: "expo-updates@npm:0.15.6"
   dependencies:
-    "@expo/code-signing-certificates": 0.0.2
+    "@expo/code-signing-certificates": 0.0.5
     "@expo/config": ~7.0.2
     "@expo/config-plugins": ~5.0.3
     "@expo/metro-config": ~0.5.0
@@ -20369,7 +20359,7 @@ __metadata:
     expo: "*"
   bin:
     expo-updates: bin/cli.js
-  checksum: eee386232d7739883bd116ee3491c30d784b8591d3ef87d840ff61b8f360092911137dc45caf9f14db5b556fb79624784e184e327c121f0daec55f24d41911a1
+  checksum: 8f9dcdc0b1f096cd20d43242af6df96239a4617c33951ea1453a6b160fc11ce5153c667bcecf89151aae90332bbf8fc93e4d2dbae5a194bf124ecc4f04251541
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Why

- link components display was overwritten on comments. 
- from feedback,  remove the snackbar on expo updates, let's try updates directly.



# How

- use `LinkText` components instead of the old link component.

# Test Plan 

if has a links component in the comments, check if it looks good! 

## Before 

![CleanShot 2022-12-20 at 16 22 51](https://user-images.githubusercontent.com/37520667/208618356-80815a60-7c06-4a3a-9969-8ecedf341d4f.png)


## After 
![CleanShot 2022-12-20 at 16 22 01](https://user-images.githubusercontent.com/37520667/208618209-740dbc9c-3028-40d9-9837-5164b31f52b2.png)



