### PR TITLE
fix: pop drop select route on native

### DIFF
--- a/packages/app/components/drop/drop-select.tsx
+++ b/packages/app/components/drop/drop-select.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Linking } from "react-native";
+import { Linking, Platform } from "react-native";
 
 import { Button } from "@showtime-xyz/universal.button";
 import { Globe, Lock } from "@showtime-xyz/universal.icon";
@@ -31,7 +31,10 @@ export const DropSelect = () => {
             icon={
               <Gift color={isDark ? "black" : "white"} height={16} width={16} />
             }
-            onPress={() => router.push("/drop/free")}
+            onPress={() => {
+              router.pop();
+              router.push("/drop/free");
+            }}
           />
         </View>
         <View tw="m-4 w-full px-4 lg:w-[360px]">
@@ -48,13 +51,16 @@ export const DropSelect = () => {
             ctaLabel={
               canCreateMusicDrop ? "Create Music Drop" : "Request Access"
             }
-            onPress={() =>
-              canCreateMusicDrop
-                ? router.push("/drop/music")
-                : Linking.openURL(
-                    "https://showtimexyz.typeform.com/to/pXQVhkZo"
-                  )
-            }
+            onPress={() => {
+              if (Platform.OS !== "web") {
+                router.pop();
+              }
+              if (canCreateMusicDrop) {
+                router.push("/drop/music");
+              } else {
+                Linking.openURL("https://showtimexyz.typeform.com/to/pXQVhkZo");
+              }
+            }}
           />
         </View>
         <View tw="m-4 w-full px-4 lg:w-[360px]">
@@ -69,7 +75,12 @@ export const DropSelect = () => {
             }
             description="Connect with fans who show up to your events. This drop lets people mark themselves at your event location."
             ctaLabel="Create Event Drop"
-            onPress={() => router.push("/drop/event")}
+            onPress={() => {
+              if (Platform.OS !== "web") {
+                router.pop();
+              }
+              router.push("/drop/event");
+            }}
           />
         </View>
         <View tw="m-4 w-full px-4 lg:w-[360px]">
@@ -80,7 +91,12 @@ export const DropSelect = () => {
             }
             description="A collectible for your biggest fans of your choice. Don't give up your password so easily!"
             ctaLabel="Create Private Drop"
-            onPress={() => router.push("/drop/private")}
+            onPress={() => {
+              if (Platform.OS !== "web") {
+                router.pop();
+              }
+              router.push("/drop/private");
+            }}
           />
         </View>
       </View>

--- a/packages/app/components/drop/drop-select.tsx
+++ b/packages/app/components/drop/drop-select.tsx
@@ -32,7 +32,9 @@ export const DropSelect = () => {
               <Gift color={isDark ? "black" : "white"} height={16} width={16} />
             }
             onPress={() => {
-              router.pop();
+              if (Platform.OS !== "web") {
+                router.pop();
+              }
               router.push("/drop/free");
             }}
           />


### PR DESCRIPTION
# Why
On Native, we need to pop the drop select route or else it stays mounted after drop success and also it's breaking some flow for new user primary wallet select
