### PR TITLE
feat: remove Discord icon on footer

### DIFF
--- a/packages/app/hooks/use-footer.ts
+++ b/packages/app/hooks/use-footer.ts
@@ -1,10 +1,4 @@
-import {
-  Discord,
-  Instagram,
-  Twitter,
-  Mail,
-  Github,
-} from "@showtime-xyz/universal.icon";
+import { Instagram, Twitter, Mail, Github } from "@showtime-xyz/universal.icon";
 
 const links = [
   {
@@ -37,11 +31,7 @@ const social = [
     link: "https://www.instagram.com/Showtime_xyz",
     title: "Instagram",
   },
-  {
-    icon: Discord,
-    link: "/discord",
-    title: "Discord",
-  },
+
   {
     icon: Mail,
     link: "mailto:help@showtime.xyz",


### PR DESCRIPTION
# Why

just remove the Discord icon on the desktop footer, because our discord is closed.


