### PR TITLE
fix: tailwind intelliSense on vscode

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,3 @@
+/** @type {import('tailwindcss').Config} */
+// this file just for Tailwind CSS IntelliSense, so don't need add any config to this.
+module.exports = {};


### PR DESCRIPTION
# Why

just add a tailwind config to support tailwind css intelliSense on vscode.

