### PR TITLE
Feature/show2 1437 update search bar design

### DIFF
--- a/packages/app/components/header/header-cancel.tsx
+++ b/packages/app/components/header/header-cancel.tsx
@@ -1,0 +1,29 @@
+import { PressableScale } from "@showtime-xyz/universal.pressable-scale";
+import { useRouter } from "@showtime-xyz/universal.router";
+import { Text } from "@showtime-xyz/universal.text";
+
+type HeaderCancelProps = {
+  canGoBack?: boolean;
+  withBackground?: boolean;
+};
+export const HeaderCancel = ({ canGoBack = true }: HeaderCancelProps) => {
+  const router = useRouter();
+  const canGoHome = router.pathname.split("/").length - 1 >= 2;
+
+  return (
+    <PressableScale
+      hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+      onPress={() => {
+        if (canGoBack) {
+          router.pop();
+        } else if (canGoHome) {
+          router.push("/home");
+        } else {
+          router.push("/search");
+        }
+      }}
+    >
+      <Text tw="font-medium text-gray-700 dark:text-white">Cancel</Text>
+    </PressableScale>
+  );
+};

--- a/packages/app/components/header/header-cancel.tsx
+++ b/packages/app/components/header/header-cancel.tsx
@@ -4,7 +4,6 @@ import { Text } from "@showtime-xyz/universal.text";
 
 type HeaderCancelProps = {
   canGoBack?: boolean;
-  withBackground?: boolean;
 };
 export const HeaderCancel = ({ canGoBack = true }: HeaderCancelProps) => {
   const router = useRouter();

--- a/packages/app/components/header/index.ts
+++ b/packages/app/components/header/index.ts
@@ -2,3 +2,4 @@ export * from "./header";
 export * from "./header-center";
 export * from "./header-left";
 export * from "./header-right";
+export * from "./header-cancel";

--- a/packages/app/components/search/index.tsx
+++ b/packages/app/components/search/index.tsx
@@ -18,7 +18,7 @@ import { Text } from "@showtime-xyz/universal.text";
 import { VerificationBadge } from "@showtime-xyz/universal.verification-badge";
 import { View } from "@showtime-xyz/universal.view";
 
-import { HeaderCancel } from "app/components/header";
+import { HeaderLeft } from "app/components/header";
 import { SearchResponseItem, useSearch } from "app/hooks/api/use-search";
 import { Link } from "app/navigation/link";
 import { useHideHeader } from "app/navigation/use-navigation-elements";
@@ -58,19 +58,18 @@ export const Search = () => {
   return (
     <>
       <View
-        tw="flex-row pb-2"
+        tw="flex-row px-4 pb-2"
         style={{
           paddingTop: Platform.select({
             default: Math.max(top, PT_2_UNIT),
             android: Math.max(top, PT_2_UNIT * 4),
           }),
-          paddingHorizontal: Platform.select({
-            default: 12,
-            ios: 16,
-          }),
         }}
       >
         <View tw="flex-1 flex-row items-center">
+          <View tw="mr-4">
+            <HeaderLeft canGoBack />
+          </View>
           <View tw="flex-1">
             <Input
               placeholder="Search for @name or name.eth"
@@ -87,7 +86,6 @@ export const Search = () => {
                   default: 8,
                   android: 6,
                 }),
-                minHeight: 33,
               }}
               leftElement={
                 <View tw="px-2">
@@ -117,9 +115,6 @@ export const Search = () => {
                 ) : undefined
               }
             />
-          </View>
-          <View tw="ml-4">
-            <HeaderCancel />
           </View>
         </View>
       </View>

--- a/packages/app/components/search/index.tsx
+++ b/packages/app/components/search/index.tsx
@@ -11,7 +11,6 @@ import {
 } from "@showtime-xyz/universal.icon";
 import { Image } from "@showtime-xyz/universal.image";
 import { InfiniteScrollList } from "@showtime-xyz/universal.infinite-scroll-list";
-import { Input } from "@showtime-xyz/universal.input";
 import { PressableScale } from "@showtime-xyz/universal.pressable-scale";
 import { Skeleton } from "@showtime-xyz/universal.skeleton";
 import { colors } from "@showtime-xyz/universal.tailwind";
@@ -20,13 +19,21 @@ import { VerificationBadge } from "@showtime-xyz/universal.verification-badge";
 import { View } from "@showtime-xyz/universal.view";
 
 import { SearchResponseItem, useSearch } from "app/hooks/api/use-search";
-import { useHeaderHeight } from "app/lib/react-navigation/elements";
 import { Link } from "app/navigation/link";
+import { useHideHeader } from "app/navigation/use-navigation-elements";
 import { formatAddressShort } from "app/utilities";
 
+import { Input } from "design-system/input";
+import { useSafeAreaInsets } from "design-system/safe-area";
+
+import { HeaderCancel } from "../header";
+
+const PT_2_UNIT = 8;
+
 export const Search = () => {
+  useHideHeader();
   const isDark = useIsDarkMode();
-  const headerHeight = useHeaderHeight();
+  const { top } = useSafeAreaInsets();
   const [term, setTerm] = useState("");
   const { loading, data } = useSearch(term);
   const inputRef = useRef<TextInput>();
@@ -51,42 +58,52 @@ export const Search = () => {
 
   return (
     <>
-      {Platform.OS !== "android" && <View style={{ height: headerHeight }} />}
-      <View tw="px-4 py-2">
-        <Input
-          placeholder="Search for @name or name.eth"
-          value={term}
-          ref={inputRef}
-          autoFocus
-          onChangeText={setTerm}
-          leftElement={
-            <View tw="p-2">
-              <SearchIcon
-                color={isDark ? colors.gray[400] : colors.gray[600]}
-                width={24}
-                height={24}
-              />
-            </View>
-          }
-          rightElement={
-            term.length > 0 ? (
-              <PressableScale
-                style={{ padding: 8 }}
-                onPress={() => {
-                  setTerm("");
-                  inputRef.current?.focus();
-                }}
-                hitSlop={{ top: 10, left: 10, right: 10, bottom: 10 }}
-              >
-                <CloseIcon
-                  color={isDark ? colors.gray[400] : colors.gray[600]}
-                  width={24}
-                  height={24}
-                />
-              </PressableScale>
-            ) : undefined
-          }
-        />
+      <View
+        tw="flex-row px-4 pb-2"
+        style={{ paddingTop: Math.max(top, PT_2_UNIT) }}
+      >
+        <View tw="flex-1 flex-row items-center">
+          <View tw="flex-1">
+            <Input
+              placeholder="Search for @name or name.eth"
+              value={term}
+              ref={inputRef}
+              autoFocus
+              onChangeText={setTerm}
+              inputStyle={{ paddingTop: 8, paddingBottom: 8, minHeight: 33 }}
+              leftElement={
+                <View tw="px-2">
+                  <SearchIcon
+                    color={isDark ? colors.gray[400] : colors.gray[600]}
+                    width={24}
+                    height={24}
+                  />
+                </View>
+              }
+              rightElement={
+                term.length > 0 ? (
+                  <PressableScale
+                    style={{ paddingVertical: 4, paddingHorizontal: 8 }}
+                    onPress={() => {
+                      setTerm("");
+                      inputRef.current?.focus();
+                    }}
+                    hitSlop={{ top: 10, left: 10, right: 10, bottom: 10 }}
+                  >
+                    <CloseIcon
+                      color={isDark ? colors.gray[400] : colors.gray[600]}
+                      width={24}
+                      height={24}
+                    />
+                  </PressableScale>
+                ) : undefined
+              }
+            />
+          </View>
+          <View tw="ml-4">
+            <HeaderCancel />
+          </View>
+        </View>
       </View>
       {data ? (
         <InfiniteScrollList

--- a/packages/app/components/search/index.tsx
+++ b/packages/app/components/search/index.tsx
@@ -18,6 +18,7 @@ import { Text } from "@showtime-xyz/universal.text";
 import { VerificationBadge } from "@showtime-xyz/universal.verification-badge";
 import { View } from "@showtime-xyz/universal.view";
 
+import { HeaderCancel } from "app/components/header";
 import { SearchResponseItem, useSearch } from "app/hooks/api/use-search";
 import { Link } from "app/navigation/link";
 import { useHideHeader } from "app/navigation/use-navigation-elements";
@@ -25,8 +26,6 @@ import { formatAddressShort } from "app/utilities";
 
 import { Input } from "design-system/input";
 import { useSafeAreaInsets } from "design-system/safe-area";
-
-import { HeaderCancel } from "../header";
 
 const PT_2_UNIT = 8;
 

--- a/packages/app/components/search/index.tsx
+++ b/packages/app/components/search/index.tsx
@@ -58,8 +58,17 @@ export const Search = () => {
   return (
     <>
       <View
-        tw="flex-row px-4 pb-2"
-        style={{ paddingTop: Math.max(top, PT_2_UNIT) }}
+        tw="flex-row pb-2"
+        style={{
+          paddingTop: Platform.select({
+            default: Math.max(top, PT_2_UNIT),
+            android: Math.max(top, PT_2_UNIT * 4),
+          }),
+          paddingHorizontal: Platform.select({
+            default: 16,
+            android: 12,
+          }),
+        }}
       >
         <View tw="flex-1 flex-row items-center">
           <View tw="flex-1">
@@ -69,7 +78,17 @@ export const Search = () => {
               ref={inputRef}
               autoFocus
               onChangeText={setTerm}
-              inputStyle={{ paddingTop: 8, paddingBottom: 8, minHeight: 33 }}
+              inputStyle={{
+                paddingTop: Platform.select({
+                  default: 8,
+                  android: 6,
+                }),
+                paddingBottom: Platform.select({
+                  default: 8,
+                  android: 6,
+                }),
+                minHeight: 33,
+              }}
               leftElement={
                 <View tw="px-2">
                   <SearchIcon

--- a/packages/app/components/search/index.tsx
+++ b/packages/app/components/search/index.tsx
@@ -65,8 +65,8 @@ export const Search = () => {
             android: Math.max(top, PT_2_UNIT * 4),
           }),
           paddingHorizontal: Platform.select({
-            default: 16,
-            android: 12,
+            default: 12,
+            ios: 16,
           }),
         }}
       >

--- a/packages/app/navigation/root-stack-navigator.tsx
+++ b/packages/app/navigation/root-stack-navigator.tsx
@@ -61,6 +61,13 @@ export function RootStackNavigator() {
           component={ProfileScreen}
           getId={({ params }) => params?.username}
         />
+        <Stack.Screen
+          name="search"
+          component={SearchScreen}
+          options={{
+            animation: "none",
+          }}
+        />
       </Stack.Group>
 
       {/* Screens accessible in most of the navigators */}
@@ -75,13 +82,6 @@ export function RootStackNavigator() {
           component={NotificationSettingsScreen}
         />
         <Stack.Screen name="blockedList" component={BlockedListScreen} />
-        <Stack.Screen
-          name="search"
-          component={SearchScreen}
-          options={{
-            animation: "none",
-          }}
-        />
         <Stack.Screen
           name="swipeList"
           component={SwipeListScreen}

--- a/packages/design-system/input/index.tsx
+++ b/packages/design-system/input/index.tsx
@@ -114,7 +114,6 @@ export const Input = forwardRef((props: InputProps, ref: any) => {
               },
               default: undefined,
             }),
-            props.inputStyle,
             {
               flexGrow: 1,
               paddingTop: Platform.select({
@@ -129,6 +128,7 @@ export const Input = forwardRef((props: InputProps, ref: any) => {
               paddingRight: rightElement ? 0 : 16,
               fontWeight: "500",
             },
+            props.inputStyle,
           ]}
           placeholderTextColor={
             isDark ? colors.gray["400"] : colors.gray["500"]


### PR DESCRIPTION
# Why
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

Search input should be moved to the header. 


# How

1) Moved Search-Screen to the navigation group with `headerShown` false
2) For Web and Android, used the provided hook to hide the header
3) Made a change to `Input` from universal in order to be able to overwrite paddings. I had to import from `design-system` directly after speaking to @alantoa. He will publish my changes and afterwards we should change the import once again. (no showstopper afaik)
4) Aligned layout to fit native experience (no back button but instead a Cancel text on the right side)
5) In order to prevent a jump and have both search icons (home) aligned at the exact position (on search screen), I had to drastically reduce the height and reduce paddings, which was fine according to @alantoa

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

| Before  | After iOS | After Android |
| ------------- | ------------- | ------------- |
| ![CleanShot 2023-01-13 at 19 32 03](https://user-images.githubusercontent.com/504909/213262681-1d710197-ddd2-4841-946a-04e50fe45c45.png)  | <img src="https://user-images.githubusercontent.com/504909/213261712-9e58602b-16a7-4d8e-afbf-2f5144a6e60d.png" width="550">  |<img alt="Bildschirm­foto 2023-01-18 um 19 46 46" src="https://user-images.githubusercontent.com/504909/213268349-827a3a08-a4a1-4548-82e1-1ff89cf5d68d.png" width="648">|


<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Tested on iOS, Android and web. 
