### PR TITLE
Add a rule to enforce a max drop title length of 255

### DIFF
--- a/packages/app/components/drop/drop-event.tsx
+++ b/packages/app/components/drop/drop-event.tsx
@@ -76,7 +76,7 @@ const durationOptions = [
 
 const dropValidationSchema = yup.object({
   file: yup.mixed().required("Media is required"),
-  title: yup.string().required(),
+  title: yup.string().required().max(255),
   description: yup.string().max(280).required(),
   editionSize: yup
     .number()

--- a/packages/app/components/drop/drop-free.tsx
+++ b/packages/app/components/drop/drop-free.tsx
@@ -72,7 +72,7 @@ const durationOptions = [
 
 const dropValidationSchema = yup.object({
   file: yup.mixed().required("Media is required"),
-  title: yup.string().required(),
+  title: yup.string().required().max(255),
   description: yup.string().max(280).required(),
   editionSize: yup
     .number()

--- a/packages/app/components/drop/drop-music.tsx
+++ b/packages/app/components/drop/drop-music.tsx
@@ -85,7 +85,7 @@ const durationOptions = [
 
 const dropValidationSchema = yup.object({
   file: yup.mixed().required("Media is required"),
-  title: yup.string().required(),
+  title: yup.string().required().max(255),
   description: yup.string().max(280).required(),
   editionSize: yup
     .number()

--- a/packages/app/components/drop/drop-private.tsx
+++ b/packages/app/components/drop/drop-private.tsx
@@ -74,7 +74,7 @@ const durationOptions = [
 
 const dropValidationSchema = yup.object({
   file: yup.mixed().required("Media is required"),
-  title: yup.string().required(),
+  title: yup.string().required().max(255),
   description: yup.string().max(280).required(),
   editionSize: yup
     .number()


### PR DESCRIPTION
# Why

We were receiving titles that were too long and this was breaking the indexer.

More context in the ticket: https://linear.app/showtime/issue/SHOW2-1445/validate-drop-name-is-less-than-255-characters

# How

Chain `max` at the end of the title validator

# Test Plan

In staging
