### PR TITLE
hotfix: create screen throws bottomsheet context error

### DIFF
--- a/packages/app/components/explanation.tsx
+++ b/packages/app/components/explanation.tsx
@@ -31,7 +31,7 @@ export const Explanation = ({
 
   return (
     <>
-      <BottomSheetScrollView useNativeModal>
+      <BottomSheetScrollView>
         {coverElement}
         <View tw="flex-1 items-center justify-center py-4">
           <Text tw="px-8 text-center text-3xl text-gray-900 dark:text-white">

--- a/packages/app/components/explanation.tsx
+++ b/packages/app/components/explanation.tsx
@@ -31,7 +31,7 @@ export const Explanation = ({
 
   return (
     <>
-      <BottomSheetScrollView useNativeModal={false}>
+      <BottomSheetScrollView useNativeModal>
         {coverElement}
         <View tw="flex-1 items-center justify-center py-4">
           <Text tw="px-8 text-center text-3xl text-gray-900 dark:text-white">


### PR DESCRIPTION
# Why
We're using native sheet on iOS so I think we'd need the `useNativeModal` true on iOS. 
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->


<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Open create form on iOS
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
