### PR TITLE
fix: comments recycling

### DIFF
--- a/packages/app/components/comments/comment-row.tsx
+++ b/packages/app/components/comments/comment-row.tsx
@@ -67,9 +67,7 @@ function CommentRowComponent({
   const repliesCount = comment.replies?.length ?? 0;
   const replies = useMemo(
     () =>
-      repliesCount > 0
-        ? comment.replies!.slice(0, displayedRepliesCount).reverse()
-        : [],
+      repliesCount > 0 ? comment.replies!.slice(0, displayedRepliesCount) : [],
     [comment.replies, repliesCount, displayedRepliesCount]
   );
   const isMyComment = useMemo(

--- a/packages/app/components/comments/comment-row.tsx
+++ b/packages/app/components/comments/comment-row.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo, useState } from "react";
+import { memo, useCallback, useMemo, useState, useRef } from "react";
 import { Platform } from "react-native";
 
 import { useIsDarkMode } from "@showtime-xyz/universal.hooks";
@@ -39,9 +39,21 @@ function CommentRowComponent({
    */
   useIsDarkMode();
   //#region state
+  const lastItemId = useRef<number>(comment.comment_id);
   const [likeCount, setLikeCount] = useState(comment.like_count);
   const [displayedRepliesCount, setDisplayedRepliesCount] =
     useState(REPLIES_PER_BATCH);
+
+  // This part here is important for FlashList, since state gets recycled
+  // we need to reset the state when the comment changes
+  // I had to remove `key` from CommentRow (Parent) and here, on View,
+  // because it was breaking recycling
+  // https://shopify.github.io/flash-list/docs/recycling/
+  if (comment.comment_id !== lastItemId.current) {
+    lastItemId.current = comment.comment_id;
+    setLikeCount(comment.like_count);
+    setDisplayedRepliesCount(REPLIES_PER_BATCH);
+  }
   //#endregion
 
   //#region hooks
@@ -55,7 +67,9 @@ function CommentRowComponent({
   const repliesCount = comment.replies?.length ?? 0;
   const replies = useMemo(
     () =>
-      repliesCount > 0 ? comment.replies!.slice(0, displayedRepliesCount) : [],
+      repliesCount > 0
+        ? comment.replies!.slice(0, displayedRepliesCount).reverse()
+        : [],
     [comment.replies, repliesCount, displayedRepliesCount]
   );
   const isMyComment = useMemo(
@@ -137,7 +151,7 @@ function CommentRowComponent({
   }, []);
   //#endregion
   return (
-    <View tw="px-4" key={comment.comment_id}>
+    <View tw="px-4">
       <MessageRow
         address={comment.address}
         username={comment.username}
@@ -164,8 +178,10 @@ function CommentRowComponent({
       />
       {!isReply
         ? replies.map((reply, index) => (
+            // only index as key when using map with FlashList
+            // https://shopify.github.io/flash-list/docs/fundamentals/performant-components#remove-key-prop
             <CommentRowComponent
-              key={`comment-reply-${reply.comment_id}`}
+              key={index}
               comment={reply}
               isLastReply={index === (replies.length ?? 0) - 1}
               likeComment={likeComment}

--- a/packages/app/components/comments/index.tsx
+++ b/packages/app/components/comments/index.tsx
@@ -120,7 +120,6 @@ export function Comments({ nft }: { nft: NFT }) {
   const renderItem = useCallback(
     ({ item }: ListRenderItemInfo<CommentType>) => (
       <CommentRow
-        key={`comment-row-${item.comment_id}`}
         comment={item}
         likeComment={likeComment}
         unlikeComment={unlikeComment}


### PR DESCRIPTION
# Why

The comments are powered by FlashList. The real benefit from FlashList vs FlatList is that we can take advantage of recycling. In order to fully leverage recycling, we need to take care of some rules.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

1) No `key` prop down the whole tree. Using `key` forces a re-render and breaks recycling (more blanks) An exception to this rule is when using `.map` like we do for the replies. While still not preferred, but unavoidable. But instead of tying the data to an id, we need to use the index as key.

https://shopify.github.io/flash-list/docs/fundamentals/performant-components#remove-key-prop

2) Removing `key` comes with a cost in terms of state-recycling. When children leverage `useState`, the values will be recycled. We need to store a ref and actually detect the change and reset it back to the initial value.

https://shopify.github.io/flash-list/docs/recycling/

Even though this change causes two `useState` per prop change, it's still a lot faster. The best would be not relying on state at all and instead consuming from a "live" global state. (or even combining the calls to one object or `useReducer`. But these are micro optimizations we could talk about at a later stage.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

| Before (many blanks)  | After (no blanks) |
| ------------- | ------------- |
|  <video src="https://user-images.githubusercontent.com/504909/214960296-a6b85f48-5518-4a03-a244-5268ac03f96b.mp4"></video> | <video src="https://user-images.githubusercontent.com/504909/214960370-82479c80-81ef-408c-8249-ec8b036d3500.mp4"></video> |

