### PR TITLE
fix: show spotify url on pre-save drop after the release

### DIFF
--- a/packages/app/components/content-type-tooltip.tsx
+++ b/packages/app/components/content-type-tooltip.tsx
@@ -36,7 +36,7 @@ const contentGatingType = {
   },
   music_presave: {
     icon: Spotify,
-    text: "Presave to collect",
+    text: "Pre-Save to collect",
   },
 };
 const TriggerView = isMobileWeb() ? View : PressableHover;
@@ -48,9 +48,20 @@ export const ContentTypeTooltip = ({ edition }: ContentTypeTooltipProps) => {
   if (edition?.spinamp_track_url) {
     return <PlayOnSpinamp url={edition?.spinamp_track_url} />;
   }
-  if (edition?.spotify_track_url) {
+
+  if (
+    edition?.gating_type === "music_presave" &&
+    edition?.spotify_track_url &&
+    edition?.presave_release_date &&
+    new Date() >= new Date(edition?.presave_release_date)
+  ) {
     return <PlayOnSpotify url={edition?.spotify_track_url} />;
   }
+
+  if (edition?.gating_type === "spotify_save" && edition?.spotify_track_url) {
+    return <PlayOnSpotify url={edition?.spotify_track_url} />;
+  }
+
   if (edition?.gating_type && contentGatingType[edition?.gating_type]) {
     const Icon = contentGatingType[edition?.gating_type].icon;
     return (


### PR DESCRIPTION
# Why
- show spotify url on pre-save drop after the release
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
Show the Play button only after the release date of the song.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
