### PR TITLE
feat: add spotify in profile social

### DIFF
--- a/packages/app/components/profile/profile-social.tsx
+++ b/packages/app/components/profile/profile-social.tsx
@@ -81,6 +81,7 @@ export const ProfileSocial = memo<ProfileSocialProps>(function ProfileSocial({
       <View tw="mt-2 flex-row items-center justify-end sm:mt-0">
         {spotifyUrl && (
           <PressableScale
+            style={{ marginRight: 16 }}
             onPress={() => onPressLink(spotifyUrl)}
             accessibilityLabel="Spotify"
             accessibilityRole="link"
@@ -94,7 +95,6 @@ export const ProfileSocial = memo<ProfileSocialProps>(function ProfileSocial({
         )}
         {twitter?.user_input && (
           <PressableScale
-            style={{ marginLeft: 16 }}
             onPress={() =>
               onPressLink(
                 `https://${twitter?.type__prefix}${twitter?.user_input}`

--- a/packages/app/components/profile/profile-social.tsx
+++ b/packages/app/components/profile/profile-social.tsx
@@ -36,13 +36,9 @@ export const ProfileSocial = memo<ProfileSocialProps>(function ProfileSocial({
     () => profile?.links?.find((item) => item.type__name === "Instagram"),
     [profile?.links]
   );
-  const spotify = useMemo(
-    () =>
-      profile?.spotify_artist_id
-        ? `https://open.spotify.com/artist/${profile?.spotify_artist_id}`
-        : null,
-    [profile?.spotify_artist_id]
-  );
+  const spotifyUrl = profile?.spotify_artist_id
+    ? `https://open.spotify.com/artist/${profile?.spotify_artist_id}`
+    : null;
   const websiteLink = useMemo(
     () => getDomainName(profile?.website_url),
     [profile?.website_url]
@@ -83,9 +79,9 @@ export const ProfileSocial = memo<ProfileSocialProps>(function ProfileSocial({
       </Hidden>
 
       <View tw="mt-2 flex-row items-center justify-end sm:mt-0">
-        {spotify && (
+        {spotifyUrl && (
           <PressableScale
-            onPress={() => onPressLink(spotify)}
+            onPress={() => onPressLink(spotifyUrl)}
             accessibilityLabel="Spotify"
             accessibilityRole="link"
           >

--- a/packages/app/components/profile/profile-social.tsx
+++ b/packages/app/components/profile/profile-social.tsx
@@ -7,6 +7,7 @@ import {
   Twitter,
   Link as LinkIcon,
   Instagram,
+  Spotify,
 } from "@showtime-xyz/universal.icon";
 import { PressableScale } from "@showtime-xyz/universal.pressable-scale";
 import { colors } from "@showtime-xyz/universal.tailwind";
@@ -35,6 +36,13 @@ export const ProfileSocial = memo<ProfileSocialProps>(function ProfileSocial({
     () => profile?.links?.find((item) => item.type__name === "Instagram"),
     [profile?.links]
   );
+  const spotify = useMemo(
+    () =>
+      profile?.spotify_artist_id
+        ? `https://open.spotify.com/artist/${profile?.spotify_artist_id}`
+        : null,
+    [profile?.spotify_artist_id]
+  );
   const websiteLink = useMemo(
     () => getDomainName(profile?.website_url),
     [profile?.website_url]
@@ -45,7 +53,7 @@ export const ProfileSocial = memo<ProfileSocialProps>(function ProfileSocial({
   }, []);
 
   return (
-    <View tw="justify-center sm:flex-row">
+    <View tw="items-center justify-center sm:flex-row">
       {profile?.website_url && websiteLink && (
         <PressableScale
           onPress={() => onPressLink(formatLink(profile.website_url))}
@@ -75,8 +83,22 @@ export const ProfileSocial = memo<ProfileSocialProps>(function ProfileSocial({
       </Hidden>
 
       <View tw="mt-2 flex-row items-center justify-end sm:mt-0">
+        {spotify && (
+          <PressableScale
+            onPress={() => onPressLink(spotify)}
+            accessibilityLabel="Spotify"
+            accessibilityRole="link"
+          >
+            <Spotify
+              width={20}
+              height={20}
+              color={isDark ? "#FFF" : colors.gray[900]}
+            />
+          </PressableScale>
+        )}
         {twitter?.user_input && (
           <PressableScale
+            style={{ marginLeft: 16 }}
             onPress={() =>
               onPressLink(
                 `https://${twitter?.type__prefix}${twitter?.user_input}`

--- a/packages/app/types.ts
+++ b/packages/app/types.ts
@@ -115,6 +115,7 @@ export interface Profile {
   links: Link[];
   primary_wallet?: WalletAddressesV2;
   has_verified_phone_number: boolean;
+  spotify_artist_id?: string;
 }
 
 type FollowType = {


### PR DESCRIPTION
# Why
- To show Spotify link when user has an artist account with Spotify
- It has a small blocker - https://linear.app/showtime/issue/SHOW2-1462/profile-add-spotify-icon-linking-to-spotify-artist-profile

<img width="782" alt="Screenshot 2023-02-01 at 4 11 56 PM" src="https://user-images.githubusercontent.com/23293248/216021079-420db6b0-bdde-4d77-89d3-8581c19112c6.png">

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
Show Spotify link when user has Spotify artist id
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Check Responsive UI
- Check link appears for Spotify artist accounts.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
