### PR TITLE
fix: wrong comment count

### DIFF
--- a/packages/app/components/feed-item/details.tsx
+++ b/packages/app/components/feed-item/details.tsx
@@ -50,7 +50,7 @@ export const NFTDetails = ({ nft, edition, detail }: NFTDetailsProps) => {
         <View tw="flex-row">
           <Like nft={nft} />
           <View tw="w-6" />
-          <CommentButton nft={nft} count={detail?.comment_count} />
+          <CommentButton nft={nft} />
           <View tw="w-6" />
           <GiftButton nft={nft} />
         </View>

--- a/packages/app/components/feed-item/details.tsx
+++ b/packages/app/components/feed-item/details.tsx
@@ -50,7 +50,7 @@ export const NFTDetails = ({ nft, edition, detail }: NFTDetailsProps) => {
         <View tw="flex-row">
           <Like nft={nft} />
           <View tw="w-6" />
-          <CommentButton nft={nft} />
+          <CommentButton nft={nft} count={detail?.comment_count} />
           <View tw="w-6" />
           <GiftButton nft={nft} />
         </View>

--- a/packages/app/components/feed/comment-button.tsx
+++ b/packages/app/components/feed/comment-button.tsx
@@ -11,10 +11,9 @@ import { formatNumber } from "app/utilities";
 
 interface CommentButtonProps {
   nft?: NFT;
-  count?: number;
 }
 
-export function CommentButton({ nft, count }: CommentButtonProps) {
+export function CommentButton({ nft }: CommentButtonProps) {
   const router = useRouter();
   const { iconColor } = useSocialColor();
   //const { commentsCount } = useComments(nft?.nft_id ?? -Infinity);
@@ -51,7 +50,9 @@ export function CommentButton({ nft, count }: CommentButtonProps) {
   return (
     <SocialButton
       onPress={handleOnPress}
-      text={count && count > 0 ? ` ${formatNumber(count)}` : ""}
+      text={
+        nft?.comment_count > 0 ? ` ${formatNumber(nft?.comment_count)}` : ""
+      }
     >
       <Message height={24} width={24} color={iconColor} />
     </SocialButton>

--- a/packages/app/components/feed/comment-button.tsx
+++ b/packages/app/components/feed/comment-button.tsx
@@ -5,19 +5,19 @@ import { Message } from "@showtime-xyz/universal.icon";
 import { useRouter } from "@showtime-xyz/universal.router";
 
 import { SocialButton } from "app/components/social-button";
-import { useComments } from "app/hooks/api/use-comments";
 import { useSocialColor } from "app/hooks/use-social-color";
 import { NFT } from "app/types";
 import { formatNumber } from "app/utilities";
 
 interface CommentButtonProps {
   nft?: NFT;
+  count?: number;
 }
 
-export function CommentButton({ nft }: CommentButtonProps) {
+export function CommentButton({ nft, count }: CommentButtonProps) {
   const router = useRouter();
   const { iconColor } = useSocialColor();
-  const { commentsCount } = useComments(nft?.nft_id ?? -Infinity);
+  //const { commentsCount } = useComments(nft?.nft_id ?? -Infinity);
 
   const handleOnPress = useCallback(() => {
     const as = `/nft/${nft?.chain_name}/${nft?.contract_address}/${nft?.token_id}/comments`;
@@ -51,7 +51,7 @@ export function CommentButton({ nft }: CommentButtonProps) {
   return (
     <SocialButton
       onPress={handleOnPress}
-      text={commentsCount > 0 ? ` ${formatNumber(commentsCount)}` : ""}
+      text={count && count > 0 ? ` ${formatNumber(count)}` : ""}
     >
       <Message height={24} width={24} color={iconColor} />
     </SocialButton>


### PR DESCRIPTION
# Why
The comment count of FeedItem was totally wrong

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
The comment count on the FeedItem was calculated based on the length of the returned data from `useComments`.
1) This caused an API roundtrip for no reason and was a complete wrong number (just first page, no replies included)
2) The `nft` object on FeedItem already has the right value from the API (`nft.comment_count`).

The only change now is that the count does not instantly update when a new comment is added. I think that's okay, I'm not sure if this is a crucial feature @intergalacticspacehighway @alantoa. 

If we require an instant reflection of the amount, we might have to mutate nft every time a new comment is posted. Should we spend time on this or just use the real, cached value?


<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
