### PR TITLE
fix: avoid soft input breaking on iOS

### DIFF
--- a/packages/app/components/settings/setting-edit-nickname-moda.tsx
+++ b/packages/app/components/settings/setting-edit-nickname-moda.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState, useRef } from "react";
 
+import { AvoidSoftInput } from "react-native-avoid-softinput";
+
 import { Button } from "@showtime-xyz/universal.button";
 import { Fieldset } from "@showtime-xyz/universal.fieldset";
 import { Modal } from "@showtime-xyz/universal.modal";
@@ -21,10 +23,16 @@ export const EditNicknameModal = ({
   const initialValueSet = useRef(false);
 
   useEffect(() => {
+    AvoidSoftInput.setEnabled(false);
+
     if (editingWallet?.nickname && !initialValueSet.current) {
       setNickname(editingWallet?.nickname);
       initialValueSet.current = true;
     }
+
+    return function unmount() {
+      AvoidSoftInput.setEnabled(true);
+    };
   }, [editingWallet?.nickname]);
 
   return (


### PR DESCRIPTION
# Why
Edit wallet nickname was breaking due to soft input enabled globally.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Disabled for this particular screen.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
