### PR TITLE
fix: android build failure (revert mmkv to 2.5.1)

### DIFF
--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -193,7 +193,7 @@
     "react-native-ios-context-menu": "^1.15.1",
     "react-native-level-fs": "^3.0.0",
     "react-native-localhost": "^1.0.0",
-    "react-native-mmkv": "2.6.1",
+    "react-native-mmkv": "2.5.1",
     "react-native-os": "^1.0.1",
     "react-native-pager-view": "6.0.1",
     "react-native-popper": "^0.3.2",

--- a/apps/storybook-react-native/package.json
+++ b/apps/storybook-react-native/package.json
@@ -64,7 +64,7 @@
     "react-native-fast-image": "8.6.3",
     "react-native-gesture-handler": "~2.9.0",
     "react-native-ios-context-menu": "^1.15.1",
-    "react-native-mmkv": "2.6.1",
+    "react-native-mmkv": "2.5.1",
     "react-native-pager-view": "6.0.1",
     "react-native-quick-base64": "^2.0.2",
     "react-native-random-values-jsi-helper": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
     "zeego": "canary",
     "react-native-spotify-remote": "file:./react-native-spotify-remote.tgz",
     "react-native-screens": "3.19.0",
-    "@showtime-xyz/universal.color-scheme": "^0.0.43"
+    "@showtime-xyz/universal.color-scheme": "^0.0.43",
+    "react-native-mmkv": "2.5.1"
   },
   "react-native": {
     "zlib": "browserify-zlib",

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -64,7 +64,7 @@
         "expo-status-bar": "1.4.2",
         "expo-system-ui": "2.0.1",
         "react-native-fast-image": "8.6.3",
-        "react-native-mmkv": "2.6.1",
+        "react-native-mmkv": "2.5.1",
         "react-native-safe-area-context": "4.5.0",
         "react-native-screens": "3.19.0",
         "react-native-svg": "13.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9504,7 +9504,7 @@ __metadata:
     react-native-ios-context-menu: ^1.15.1
     react-native-level-fs: ^3.0.0
     react-native-localhost: ^1.0.0
-    react-native-mmkv: 2.6.1
+    react-native-mmkv: 2.5.1
     react-native-os: ^1.0.1
     react-native-pager-view: 6.0.1
     react-native-popper: ^0.3.2
@@ -9676,7 +9676,7 @@ __metadata:
     react-native-fast-image: 8.6.3
     react-native-gesture-handler: ~2.9.0
     react-native-ios-context-menu: ^1.15.1
-    react-native-mmkv: 2.6.1
+    react-native-mmkv: 2.5.1
     react-native-pager-view: 6.0.1
     react-native-quick-base64: ^2.0.2
     react-native-random-values-jsi-helper: ^1.0.4
@@ -33199,23 +33199,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-mmkv@npm:2.4.3":
-  version: 2.4.3
-  resolution: "react-native-mmkv@npm:2.4.3"
+"react-native-mmkv@npm:2.5.1":
+  version: 2.5.1
+  resolution: "react-native-mmkv@npm:2.5.1"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: d01cda411babfaabd6389c26d0ea403b36b5203d82b8a4fe4800317d4192aaa805fcafedd5945692c7893c6c95b01e1d57e8871a76dcd92ab594ed9c84c5faa3
-  languageName: node
-  linkType: hard
-
-"react-native-mmkv@npm:2.6.1":
-  version: 2.6.1
-  resolution: "react-native-mmkv@npm:2.6.1"
-  peerDependencies:
-    react: "*"
-    react-native: ">=0.71.0"
-  checksum: c73959d10e102a08bbde6a8dd041840a680faa8ef411125431afe63fdce38bf5f58cbd3985f8ef63832b8f5c0279ca39d7cd4a2ca1bde172a23eb74e644af5e0
+  checksum: 6f0cf484e71d8069c9b3cdb57b76eafaca40aa75f359beb6959c77d0ef66d0481d4459b1ffa94640170ce4744e337fefb38b8ccf6e1a3c3663561ede5f7a2c20
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Why
Android build is failing
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
Revert mmkv to 2.5.1 as we're still on 0.70 RN

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
Test if android build fixes on waldo. Worked locally
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
