### PR TITLE
fix: modal screen presentation

### DIFF
--- a/packages/app/navigation/root-stack-navigator.tsx
+++ b/packages/app/navigation/root-stack-navigator.tsx
@@ -129,8 +129,7 @@ export function RootStackNavigator() {
         screenOptions={{
           headerShown: false,
           animation: Platform.OS === "ios" ? "default" : "none",
-          presentation:
-            Platform.OS === "ios" ? "formSheet" : "transparentModal",
+          presentation: Platform.OS === "ios" ? "modal" : "transparentModal",
         }}
       >
         <Stack.Screen name="login" component={LoginScreen} />


### PR DESCRIPTION
# Why

since the `formSheet` has an [issue](https://github.com/software-mansion/react-native-screens/issues/1686#issuecomment-1399217550) on `react-native-screen v3.19.0`, so let's replace it with `modal` first. 

# Test Plan

## Before  


https://user-images.githubusercontent.com/37520667/216956829-ad728abb-6bbe-4a4d-8c4c-4d21c9eba2bc.mp4




## After  

https://user-images.githubusercontent.com/37520667/216956594-715282d4-3065-4964-aab2-f925610f5f0f.mp4


