### PR TITLE
fix: comments on web had no padding top

### DIFF
--- a/packages/app/components/comments/index.tsx
+++ b/packages/app/components/comments/index.tsx
@@ -154,7 +154,7 @@ export function Comments({ nft, webListHeight }: CommentsProps) {
       {isLoading || (dataReversed.length == 0 && error) ? (
         <CommentsStatus isLoading={isLoading} error={error} />
       ) : (
-        <>
+        <View tw="web:pt-4 flex-1">
           <InfiniteScrollList
             data={dataReversed}
             refreshing={isLoading}
@@ -188,7 +188,7 @@ export function Comments({ nft, webListHeight }: CommentsProps) {
               />
             </PlatformInputAccessoryView>
           )}
-        </>
+        </View>
       )}
     </View>
   );


### PR DESCRIPTION
# Why

contentContainerStyle is not supported on web for `InfiniteScrollList`, therefore, my padding was not applied.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Changed Fragment to View and added a web-only pt-4.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

| Before  | After |
| ------------- | ------------- |
| <img width="421" alt="Bildschirm­foto 2023-02-06 um 12 56 03" src="https://user-images.githubusercontent.com/504909/216965969-1ba065b2-b14a-425d-8960-6ac1837f6ade.png">  | <img width="362" alt="Bildschirm­foto 2023-02-06 um 12 56 26" src="https://user-images.githubusercontent.com/504909/216965978-45c8194a-7a94-4b1d-a31d-ee178583d4dc.png">  |





