### PR TITLE
Fix/feed item recycling

### DIFF
--- a/apps/expo/app.config.js
+++ b/apps/expo/app.config.js
@@ -187,8 +187,6 @@ export default {
         "./assets/fonts/Inter-Medium.otf",
         "./assets/fonts/Inter-Regular.otf",
         "./assets/fonts/Inter-SemiBold.otf",
-        "./assets/fonts/SpaceGrotesk-Bold.otf",
-        "./assets/fonts/SpaceGrotesk-Regular.otf",
       ],
     ],
     [

--- a/apps/expo/tailwind.config.js
+++ b/apps/expo/tailwind.config.js
@@ -307,8 +307,6 @@ module.exports = {
         ...colors,
       },
       fontFamily: {
-        space: "SpaceGrotesk-Regular",
-        "space-bold": "SpaceGrotesk-Bold",
         inter: "Inter-Regular",
         "inter-semibold": "Inter-SemiBold",
         "inter-bold": "Inter-Bold",
@@ -325,12 +323,12 @@ module.exports = {
         ".text-base": textSizes["text-base"],
         ".text-lg": {
           ...textSizes["text-lg"],
-          fontFamily: "SpaceGrotesk-Bold",
+          fontFamily: "Inter-Bold",
         },
         ".text-xl": textSizes["text-xl"],
         ".text-2xl": {
           ...textSizes["text-2xl"],
-          fontFamily: "SpaceGrotesk-Bold",
+          fontFamily: "Inter-Bold",
         },
         ".text-3xl": textSizes["text-3xl"],
         ".text-4xl": textSizes["text-4xl"],

--- a/apps/next/src/pages/_app.tsx
+++ b/apps/next/src/pages/_app.tsx
@@ -4,7 +4,7 @@ import "setimmediate";
 
 import { useCallback } from "react";
 
-import { Inter, Space_Grotesk } from "@next/font/google";
+import { Inter } from "@next/font/google";
 import "@rainbow-me/rainbowkit/styles.css";
 import { AppProps } from "next/app";
 import Head from "next/head";
@@ -204,15 +204,9 @@ const inter = Inter({
   display: "swap",
 });
 
-const spaceGrotesk = Space_Grotesk({
-  weight: "700",
-  variable: "--font-space-grotesk",
-  display: "swap",
-});
-
 const Container = withColorScheme(
   ({ children }: { children: React.ReactChild }) => {
-    const fonts = [inter.variable, spaceGrotesk.variable].join(" ");
+    const fonts = [inter.variable].join(" ");
 
     const onResize = useCallback(() => {
       if (isMobileWeb()) {

--- a/apps/next/tailwind.config.js
+++ b/apps/next/tailwind.config.js
@@ -329,8 +329,6 @@ module.exports = {
         copy: "copy",
       },
       fontFamily: {
-        space: "var(--font-space-grotesk)",
-        "space-bold": "var(--font-space-grotesk)",
         inter: "var(--font-inter)",
         "inter-semibold": "var(--font-inter)",
         "inter-bold": "var(--font-inter)",
@@ -374,12 +372,12 @@ module.exports = {
         ".text-base": textSizes["text-base"],
         ".text-lg": {
           ...textSizes["text-lg"],
-          fontFamily: "var(--font-space-grotesk)",
+          fontWeight: "bold",
         },
         ".text-xl": textSizes["text-xl"],
         ".text-2xl": {
           ...textSizes["text-2xl"],
-          fontFamily: "var(--font-space-grotesk)",
+          fontWeight: "bold",
         },
         ".text-3xl": textSizes["text-3xl"],
         ".text-4xl": textSizes["text-4xl"],

--- a/apps/storybook-react-native/.storybook/preview.js
+++ b/apps/storybook-react-native/.storybook/preview.js
@@ -17,8 +17,6 @@ const FontsLoader = ({ children }) => {
     Inter: require("../assets/fonts/Inter-Regular.otf"),
     "Inter-Regular": require("../assets/fonts/Inter-Regular.otf"),
     "Inter-SemiBold": require("../assets/fonts/Inter-SemiBold.otf"),
-    "SpaceGrotesk-Regular": require("../assets/fonts/SpaceGrotesk-Regular.otf"),
-    "SpaceGrotesk-Bold": require("../assets/fonts/SpaceGrotesk-Bold.otf"),
   });
 
   if (!fontsLoaded) return null;

--- a/apps/storybook-react/styles/globals.css
+++ b/apps/storybook-react/styles/globals.css
@@ -77,26 +77,6 @@
   }
 }
 
-/* SpaceGrotesk Regular */
-@font-face {
-  font-family: "SpaceGrotesk Regular";
-  src: url("/fonts/woff/SpaceGrotesk-Regular-subset.zopfli.woff") format("woff"),
-    url("/fonts/woff2/SpaceGrotesk-Regular-subset.woff2") format("woff2");
-  font-weight: 500;
-  font-style: normal;
-  font-display: swap;
-}
-
-/* SpaceGrotesk Bold */
-@font-face {
-  font-family: "SpaceGrotesk Bold";
-  src: url("/fonts/woff/SpaceGrotesk-Bold-subset.zopfli.woff") format("woff"),
-    url("/fonts/woff2/SpaceGrotesk-Bold-subset.woff2") format("woff2");
-  font-weight: 700;
-  font-style: bold;
-  font-display: swap;
-}
-
 body {
   font-family: Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
     Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;

--- a/apps/storybook-react/tailwind.config.js
+++ b/apps/storybook-react/tailwind.config.js
@@ -331,8 +331,6 @@ module.exports = {
         copy: "copy",
       },
       fontFamily: {
-        space: fontFamily("SpaceGrotesk-Regular"),
-        "space-bold": fontFamily("SpaceGrotesk-Bold"),
         inter: fontFamily("Inter-Regular"),
         "inter-semibold": fontFamily("Inter-SemiBold"),
         "inter-bold": fontFamily("Inter-Bold"),
@@ -376,12 +374,12 @@ module.exports = {
         ".text-base": textSizes["text-base"],
         ".text-lg": {
           ...textSizes["text-lg"],
-          fontFamily: fontFamily("SpaceGrotesk-Bold"),
+          fontFamily: fontFamily("Inter-Bold"),
         },
         ".text-xl": textSizes["text-xl"],
         ".text-2xl": {
           ...textSizes["text-2xl"],
-          fontFamily: fontFamily("SpaceGrotesk-Bold"),
+          fontFamily: fontFamily("Inter-Bold"),
         },
         ".text-3xl": textSizes["text-3xl"],
         ".text-4xl": textSizes["text-4xl"],

--- a/packages/app/components/card/avatar-hover-card.web.tsx
+++ b/packages/app/components/card/avatar-hover-card.web.tsx
@@ -137,7 +137,7 @@ export function AvatarHoverCard({
                 ) : (
                   <View tw="mt-4">
                     <Text
-                      tw="font-space-bold text-xl font-extrabold text-gray-900 dark:text-white"
+                      tw="text-xl font-extrabold text-gray-900 dark:text-white"
                       numberOfLines={2}
                     >
                       {profileData?.profile.name}

--- a/packages/app/components/card/rows/title.tsx
+++ b/packages/app/components/card/rows/title.tsx
@@ -39,7 +39,7 @@ export function Title({ title, disableTooltip = false }: Props) {
         <Tooltip.Root>
           <Tooltip.Trigger>
             <Text
-              tw="font-space-bold text-lg !leading-8 text-black dark:text-white"
+              tw="text-lg !leading-8 text-black dark:text-white"
               numberOfLines={1}
             >
               {title}
@@ -51,7 +51,7 @@ export function Title({ title, disableTooltip = false }: Props) {
         </Tooltip.Root>
       ) : (
         <Text
-          tw="font-space-bold text-lg !leading-8 text-black dark:text-white"
+          tw="text-lg !leading-8 text-black dark:text-white"
           numberOfLines={1}
         >
           {title}

--- a/packages/app/components/details.tsx
+++ b/packages/app/components/details.tsx
@@ -9,7 +9,7 @@ function Details({ nft }: { nft?: NFT }) {
   return (
     <>
       <View tw="m-4">
-        <Text tw="font-space-bold text-lg font-medium text-black dark:text-white">
+        <Text tw="text-lg font-medium text-black dark:text-white">
           {nft?.token_name}
         </Text>
         {nft?.token_description && (

--- a/packages/app/components/feed-item/details.tsx
+++ b/packages/app/components/feed-item/details.tsx
@@ -38,7 +38,7 @@ export const NFTDetails = ({ nft, edition, detail }: NFTDetailsProps) => {
       <View tw="flex-row items-center justify-between">
         <Creator nft={nft} shouldShowCreatorIndicator={false} />
       </View>
-      <Text tw="font-space-bold text-lg dark:text-white" numberOfLines={3}>
+      <Text tw="text-lg dark:text-white" numberOfLines={3}>
         {nft.token_name}
       </Text>
       <Description

--- a/packages/app/components/feed-item/feed-item.md.tsx
+++ b/packages/app/components/feed-item/feed-item.md.tsx
@@ -298,7 +298,7 @@ export const FeedItemMD = memo<FeedItemProps>(function FeedItemMD({
             </View>
             <LikedBy nft={nft} tw="mt-4" />
             <View tw="my-4 mr-4 flex-row justify-between">
-              <Text tw="font-space-bold text-lg text-black dark:text-white md:text-2xl">
+              <Text tw="text-lg text-black dark:text-white md:text-2xl">
                 {nft.token_name}
               </Text>
             </View>

--- a/packages/app/components/feed-item/feed-item.tsx
+++ b/packages/app/components/feed-item/feed-item.tsx
@@ -65,6 +65,8 @@ export const FeedItem = memo<FeedItemProps>(function FeedItem({
   itemHeight,
   setMomentumScrollCallback,
 }) {
+  const lastItemId = useRef(nft.nft_id);
+  const detailViewRef = useRef<Reanimated.View>(null);
   const headerHeight = useHeaderHeight();
   const headerHeightRef = useRef(headerHeight);
   const { data: detailData } = useNFTDetailByTokenId({
@@ -79,6 +81,22 @@ export const FeedItem = memo<FeedItemProps>(function FeedItem({
   const { data: edition } = useCreatorCollectionDetail(
     nft.creator_airdrop_edition_address
   );
+
+  const isLayouted = useSharedValue(0);
+  const opacity = useSharedValue(1);
+
+  // This part here is important for FlashList, since state gets recycled
+  // we need to reset the state when the comment changes
+  // I had to remove `key` from LikeContextProvider
+  // because it was breaking recycling
+  // https://shopify.github.io/flash-list/docs/recycling/
+  if (nft.nft_id !== lastItemId.current) {
+    lastItemId.current = nft.nft_id;
+    // since we are recycling, onLayout will not be called again, therefore we need to measure the height manually
+    detailViewRef.current?.measure((a, b, width, height, px, py) => {
+      setDetailHeight(height);
+    });
+  }
 
   const blurredBackgroundStyles = useBlurredBackgroundStyles(95);
   const maxContentHeight = windowHeight - bottomHeight;
@@ -118,8 +136,6 @@ export const FeedItem = memo<FeedItemProps>(function FeedItem({
       return 0;
     }
   });
-  const isLayouted = useSharedValue(0);
-  const opacity = useSharedValue(1);
 
   const detailStyle = useAnimatedStyle(() => {
     return {
@@ -174,7 +190,7 @@ export const FeedItem = memo<FeedItemProps>(function FeedItem({
   }, [setMomentumScrollCallback, showHeader]);
 
   return (
-    <LikeContextProvider nft={nft} key={nft.nft_id}>
+    <LikeContextProvider nft={nft}>
       <View tw="w-full" style={{ height: itemHeight, overflow: "hidden" }}>
         <View>
           {nft.blurhash ? (
@@ -220,6 +236,7 @@ export const FeedItem = memo<FeedItemProps>(function FeedItem({
           </Animated.View>
         </FeedItemTapGesture>
         <Reanimated.View
+          ref={detailViewRef}
           style={[
             detailStyle,
             {

--- a/packages/app/components/feed.tsx
+++ b/packages/app/components/feed.tsx
@@ -102,7 +102,7 @@ const FeedList = () => {
 //         }}
 //       >
 //         <Animated.View style={animatedStyleFirstTab}>
-//           <Text tw="font-space-bold text-lg font-bold text-black dark:text-white">
+//           <Text tw="text-lg font-bold text-black dark:text-white">
 //             Following
 //           </Text>
 //         </Animated.View>
@@ -121,7 +121,7 @@ const FeedList = () => {
 //         }}
 //       >
 //         <Animated.View style={animatedStyleSecondTab}>
-//           <Text tw="font-space-bold text-lg font-bold text-black dark:text-white">
+//           <Text tw="text-lg font-bold text-black dark:text-white">
 //             For You
 //           </Text>
 //         </Animated.View>

--- a/packages/app/components/feed/feed.md.tsx
+++ b/packages/app/components/feed/feed.md.tsx
@@ -231,13 +231,11 @@ const SuggestedUsers = () => {
   return (
     <>
       <View tw="h-16 justify-center">
-        <Text tw="font-space-bold text-2xl text-black dark:text-white">
-          Home
-        </Text>
+        <Text tw="text-2xl text-black dark:text-white">Home</Text>
       </View>
 
       <View tw="dark:shadow-dark shadow-light mt-8 rounded-2xl bg-white dark:bg-black">
-        <Text tw="font-space-bold p-4 text-lg dark:text-white">Suggested</Text>
+        <Text tw="p-4 text-lg dark:text-white">Suggested</Text>
         {loading ? (
           <View tw="m-4">
             <Skeleton colorMode={colorScheme as any} width={100} height={20} />
@@ -263,12 +261,10 @@ const SuggestedUsers = () => {
       </View>
 
       <View tw="dark:shadow-dark shadow-light mt-8 rounded-2xl bg-white dark:bg-black">
-        <Text tw="font-space-bold p-4 text-lg dark:text-white">
-          Get the app
-        </Text>
+        <Text tw="p-4 text-lg dark:text-white">Get the app</Text>
         <View tw="flex flex-row items-center justify-between py-4 px-2">
           <TextLink
-            tw="font-space-bold text-base dark:text-white"
+            tw="text-base font-bold dark:text-white"
             href="https://apps.apple.com/us/app/showtime-nft-social-network/id1606611688"
             target="_blank"
           >
@@ -284,7 +280,7 @@ const SuggestedUsers = () => {
             />
           </TextLink>
           <TextLink
-            tw="font-space-bold text-base dark:text-white"
+            tw="text-base font-bold dark:text-white"
             href="https://play.google.com/store/apps/details?id=io.showtime"
             target="_blank"
           >

--- a/packages/app/components/login/phone-number-picker.tsx
+++ b/packages/app/components/login/phone-number-picker.tsx
@@ -223,7 +223,7 @@ export function Header({ title, close, onSearchSubmit, twCenter = "" }: Props) {
         ) : (
           <Text
             onPress={onPressTitle}
-            tw="font-space-bold px-4 py-3.5 text-lg font-bold dark:text-white"
+            tw="px-4 py-3.5 text-lg font-bold dark:text-white"
           >
             {title}
           </Text>

--- a/packages/app/components/notifications/index.tsx
+++ b/packages/app/components/notifications/index.tsx
@@ -29,7 +29,7 @@ const Header = () => {
 
   return Platform.OS === "web" ? (
     <View tw="w-full flex-row justify-center px-4 py-4">
-      <Text tw="font-space-bold text-lg font-extrabold text-gray-900 dark:text-white md:text-2xl">
+      <Text tw="text-lg font-extrabold text-gray-900 dark:text-white md:text-2xl">
         Notifications
       </Text>
     </View>

--- a/packages/app/components/profile/profile-top.tsx
+++ b/packages/app/components/profile/profile-top.tsx
@@ -335,7 +335,7 @@ export const ProfileTop = ({
             <View tw="flex-row items-start justify-between">
               <View tw="flex-1">
                 <Text
-                  tw="font-space-bold max-w-45 text-2xl font-extrabold text-gray-900 dark:text-white"
+                  tw="max-w-45 text-2xl font-extrabold text-gray-900 dark:text-white"
                   numberOfLines={2}
                 >
                   {name}

--- a/packages/app/components/qr-code/qr-code-modal.tsx
+++ b/packages/app/components/qr-code/qr-code-modal.tsx
@@ -366,7 +366,7 @@ export const QRCodeModal = (props?: QRCodeModalProps) => {
                       </View>
 
                       <Text
-                        tw="font-space-bold text-lg text-black dark:text-white"
+                        tw="text-lg text-black dark:text-white"
                         numberOfLines={2}
                       >
                         {nft.token_name}

--- a/packages/app/components/settings/privacy-and-security.tsx
+++ b/packages/app/components/settings/privacy-and-security.tsx
@@ -15,7 +15,7 @@ export const PrivacyAndSecuritySettings = () => {
     <ScrollView tw="w-full bg-white dark:bg-black md:bg-transparent">
       {Platform.OS !== "android" && <View style={{ height: headerHeight }} />}
       <View tw="mx-auto mt-4 w-full max-w-screen-lg px-4 md:mt-8">
-        <Text tw="font-space-bold text-2xl font-extrabold text-gray-900 dark:text-white">
+        <Text tw="text-2xl font-extrabold text-gray-900 dark:text-white">
           Privacy & Security
         </Text>
         <View tw="h-8" />

--- a/packages/app/components/settings/setting-header.tsx
+++ b/packages/app/components/settings/setting-header.tsx
@@ -14,7 +14,7 @@ export const SettingHeaderSection = ({ title = "" }) => {
   return (
     <View tw="dark:shadow-dark shadow-light items-center bg-white dark:bg-black md:mb-8">
       <View tw="w-full max-w-screen-2xl flex-row justify-between bg-white py-4 px-4 dark:bg-black">
-        <Text tw="font-space-bold text-2xl font-extrabold text-gray-900 dark:text-white">
+        <Text tw="text-2xl font-extrabold text-gray-900 dark:text-white">
           {title}
         </Text>
       </View>
@@ -39,11 +39,11 @@ export const SettingsHeader = ({
       <View tw="dark:shadow-dark shadow-light items-center bg-white dark:bg-black">
         <View tw="w-full max-w-screen-2xl">
           <View tw="w-full flex-row justify-between self-center px-4 py-4">
-            <Text tw="font-space-bold self-center text-2xl font-extrabold text-gray-900 dark:text-white">
+            <Text tw="self-center text-2xl font-extrabold text-gray-900 dark:text-white">
               Settings
             </Text>
             {!isWeb ? (
-              <Text tw="font-space-bold text-2xl font-extrabold text-gray-100 dark:text-gray-900">
+              <Text tw="text-2xl font-extrabold text-gray-100 dark:text-gray-900">
                 v{Constants?.manifest?.version ?? packageJson?.version}
               </Text>
             ) : null}

--- a/packages/app/components/settings/setting.md.tsx
+++ b/packages/app/components/settings/setting.md.tsx
@@ -42,9 +42,7 @@ export const SettingsMd = () => {
         >
           <Sticky top={112} enabled>
             <View>
-              <Text tw="font-space-bold text-2xl text-black dark:text-white">
-                Settings
-              </Text>
+              <Text tw="text-2xl text-black dark:text-white">Settings</Text>
               <TabBarVertical
                 onPress={(i) => {
                   setIndex(i);

--- a/packages/app/components/transfer.tsx
+++ b/packages/app/components/transfer.tsx
@@ -148,7 +148,7 @@ function Transfer({ nft }: { nft?: NFT }) {
         <Text tw="text-4xl">🎉</Text>
         <View>
           <View tw="my-8">
-            <Text tw="font-space-bold text-center text-lg text-black dark:text-white">
+            <Text tw="text-center text-lg font-bold text-black dark:text-white">
               Your NFT has been transferred
             </Text>
           </View>
@@ -165,7 +165,7 @@ function Transfer({ nft }: { nft?: NFT }) {
           <View tw="flex-row items-center pb-4">
             <Media item={nft} tw="h-[80px] w-[80px] rounded-2xl" />
             <View tw="flex-1 px-[16px]">
-              <Text tw="font-space-bold pb-4 text-lg font-bold text-black dark:text-white">
+              <Text tw="pb-4 text-lg font-bold text-black dark:text-white">
                 {nft?.token_name}
               </Text>
               <View tw="flex-row items-center">

--- a/packages/app/components/trending/trending.tsx
+++ b/packages/app/components/trending/trending.tsx
@@ -39,7 +39,7 @@ export const Trending = () => {
       <>
         {Platform.OS !== "android" && <View style={{ height: headerHeight }} />}
         <View tw="flex-row justify-between bg-white py-2 px-4 dark:bg-black">
-          <Text tw="font-space-bold text-2xl font-extrabold text-gray-900 dark:text-white">
+          <Text tw="text-2xl font-extrabold text-gray-900 dark:text-white">
             Trending
           </Text>
         </View>

--- a/packages/app/components/trending/trending.web.tsx
+++ b/packages/app/components/trending/trending.web.tsx
@@ -44,7 +44,7 @@ const Header = () => {
   return (
     <View tw="mx-auto w-full max-w-screen-xl">
       <View tw="w-full flex-row justify-center self-center px-4 py-4 md:justify-between md:pb-8">
-        <Text tw="font-space-bold self-center text-lg font-extrabold text-gray-900 dark:text-white md:text-2xl">
+        <Text tw="self-center text-lg font-extrabold text-gray-900 dark:text-white md:text-2xl">
           Trending
         </Text>
       </View>

--- a/packages/app/context/like-context.tsx
+++ b/packages/app/context/like-context.tsx
@@ -4,6 +4,7 @@ import React, {
   useContext,
   useMemo,
   useState,
+  useRef,
 } from "react";
 
 import { Haptics } from "@showtime-xyz/universal.haptics";
@@ -28,6 +29,7 @@ export const LikeContextProvider = ({
   nft: NFT;
   children: any;
 }) => {
+  const lastItemId = useRef(nft.nft_id);
   const { isLiked, like, unlike } = useMyInfo();
   const { isAuthenticated } = useUser();
 
@@ -36,6 +38,16 @@ export const LikeContextProvider = ({
   const [likeCount, setLikeCount] = useState(
     typeof nft.like_count === "number" ? nft.like_count : 0
   );
+
+  // This part here is important for FlashList, since state gets recycled
+  // we need to reset the state when the comment changes
+  // I had to remove `key` from CommentRow (Parent) and here, on View,
+  // because it was breaking recycling
+  // https://shopify.github.io/flash-list/docs/recycling/
+  if (nft.nft_id !== lastItemId.current) {
+    lastItemId.current = nft.nft_id;
+    setLikeCount(typeof nft.like_count === "number" ? nft.like_count : 0);
+  }
 
   const likeImpl = useCallback(async () => {
     Haptics.impactAsync();

--- a/packages/app/screens/marketplace.tsx
+++ b/packages/app/screens/marketplace.tsx
@@ -14,7 +14,7 @@ const MarketplaceScreen = withColorScheme(() => {
       <View tw={`bg-black`} style={{ height: headerHeight }} />
 
       <View tw="p-4">
-        <Text tw="font-space-bold text-2xl font-extrabold text-black dark:text-white">
+        <Text tw="text-2xl font-extrabold text-black dark:text-white">
           Discover
         </Text>
         <View tw="h-6" />

--- a/packages/design-system/modal/modal.header.tsx
+++ b/packages/design-system/modal/modal.header.tsx
@@ -29,9 +29,7 @@ function ModalHeaderComponent({
         </Button>
       )}
 
-      <Text tw={[MODAL_HEADER_TITLE_TW, "font-space-bold text-lg"]}>
-        {title}
-      </Text>
+      <Text tw={[MODAL_HEADER_TITLE_TW, "text-lg"]}>{title}</Text>
 
       {EndContentComponent ? (
         <EndContentComponent />

--- a/packages/design-system/text/text.stories.tsx
+++ b/packages/design-system/text/text.stories.tsx
@@ -58,19 +58,13 @@ export const TextBaseCapsize: React.VFC<{}> = () => (
 );
 
 export const TextLG: React.VFC<{}> = () => (
-  <Text tw="font-space-bold text-lg text-black dark:text-white">
-    Hello World!
-  </Text>
+  <Text tw="text-lg text-black dark:text-white">Hello World!</Text>
 );
 
 export const TextLGCapsize: React.VFC<{}> = () => (
   <View tw="bg-black">
-    <Text tw="font-space-bold text-lg text-black dark:text-white">
-      Hello World!
-    </Text>
-    <Text tw="font-space-bold text-lg text-black dark:text-white">
-      Hello World!
-    </Text>
+    <Text tw="text-lg text-black dark:text-white">Hello World!</Text>
+    <Text tw="text-lg text-black dark:text-white">Hello World!</Text>
   </View>
 );
 
@@ -85,16 +79,12 @@ export const TextXLCapsize: React.VFC<{}> = () => (
 );
 
 export const Text2XL: React.VFC<{}> = () => (
-  <Text tw="font-space-bold text-2xl text-black dark:text-white">
-    Hello World!
-  </Text>
+  <Text tw="text-2xl text-black dark:text-white">Hello World!</Text>
 );
 
 export const Text2XLCapsize: React.VFC<{}> = () => (
   <View tw="bg-black">
-    <Text tw="font-space-bold text-2xl text-black dark:text-white">
-      Hello World!
-    </Text>
+    <Text tw="text-2xl text-black dark:text-white">Hello World!</Text>
   </View>
 );
 

--- a/packages/design-system/typography/typography.js
+++ b/packages/design-system/typography/typography.js
@@ -72,16 +72,6 @@ const fontMetricsInter = {
   xHeight: 1536,
 };
 
-const fontMetricsSpaceGrotesk = {
-  familyName: "Space Grotesk",
-  capHeight: 700,
-  ascent: 984,
-  descent: -292,
-  lineGap: 20,
-  unitsPerEm: 1000,
-  xHeight: 486,
-};
-
 const textSizes = {
   "text-xs": createTextSize({
     fontSize: 12,
@@ -126,7 +116,7 @@ const textSizes = {
       android: 0.2,
       ios: 0,
     },
-    fontMetrics: fontMetricsSpaceGrotesk,
+    fontMetrics: fontMetricsInter,
   }),
   "text-xl": createTextSize({
     fontSize: 20,
@@ -144,7 +134,7 @@ const textSizes = {
       android: -0.3,
       ios: -0.3,
     },
-    fontMetrics: fontMetricsSpaceGrotesk,
+    fontMetrics: fontMetricsInter,
   }),
   "text-3xl": createTextSize({
     fontSize: 30,

--- a/packages/design-system/typography/typography.native.js
+++ b/packages/design-system/typography/typography.native.js
@@ -72,16 +72,6 @@ const fontMetricsInter = {
   xHeight: 1536,
 };
 
-const fontMetricsSpaceGrotesk = {
-  familyName: "Space Grotesk",
-  capHeight: 700,
-  ascent: 984,
-  descent: -292,
-  lineGap: 0,
-  unitsPerEm: 1000,
-  xHeight: 486,
-};
-
 const textSizes = {
   "text-xs": createTextSize({
     fontSize: 12,
@@ -126,7 +116,7 @@ const textSizes = {
       android: 0.2,
       ios: 0,
     },
-    fontMetrics: fontMetricsSpaceGrotesk,
+    fontMetrics: fontMetricsInter,
   }),
   "text-xl": createTextSize({
     fontSize: 20,
@@ -144,7 +134,7 @@ const textSizes = {
       android: -0.3,
       ios: -0.3,
     },
-    fontMetrics: fontMetricsSpaceGrotesk,
+    fontMetrics: fontMetricsInter,
   }),
   "text-3xl": createTextSize({
     fontSize: 30,

--- a/packages/design-system/typography/yolo.tsx
+++ b/packages/design-system/typography/yolo.tsx
@@ -43,16 +43,6 @@ const fontMetricsInter = {
   xHeight: 1536,
 };
 
-const fontMetricsSpaceGrotesk = {
-  familyName: "Space Grotesk",
-  capHeight: 700,
-  ascent: 984,
-  descent: -292,
-  lineGap: 20,
-  unitsPerEm: 1000,
-  xHeight: 486,
-};
-
 const createTextSize = ({
   fontSize,
   lineHeight: leading,
@@ -147,7 +137,7 @@ export const textSizes = {
       android: 0.2,
       ios: 0,
     },
-    fontMetrics: fontMetricsSpaceGrotesk,
+    fontMetrics: fontMetricsInter,
   }),
   "text-xl": createTextSize({
     fontSize: 20,
@@ -167,7 +157,7 @@ export const textSizes = {
       android: -0.3,
       ios: -0.3,
     },
-    fontMetrics: fontMetricsSpaceGrotesk,
+    fontMetrics: fontMetricsInter,
   }),
   "text-3xl": createTextSize({
     fontSize: 30,


### PR DESCRIPTION
# Why

FlashLists recycling was breaking because we used `key` on LikeContextProvider

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Added proper recycling back with a ref. Unfortunately, we're relying on `onLayout` (we should think how to get rid of this) which won't trigger again when recycled. So I need to re-measure the view. Even though we're doing two useState calls (and a measuring) here, we still take advantage of a lot of recycling which leads into better JS-FPS perf on fast scrolls.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
