### PR TITLE
fix: recycling for FeedItem

### DIFF
--- a/packages/app/components/feed-item/feed-item.tsx
+++ b/packages/app/components/feed-item/feed-item.tsx
@@ -86,7 +86,7 @@ export const FeedItem = memo<FeedItemProps>(function FeedItem({
   const opacity = useSharedValue(1);
 
   // This part here is important for FlashList, since state gets recycled
-  // we need to reset the state when the comment changes
+  // we need to reset the state when the nft-id changes
   // I had to remove `key` from LikeContextProvider
   // because it was breaking recycling
   // https://shopify.github.io/flash-list/docs/recycling/

--- a/packages/app/components/feed-item/feed-item.tsx
+++ b/packages/app/components/feed-item/feed-item.tsx
@@ -65,6 +65,8 @@ export const FeedItem = memo<FeedItemProps>(function FeedItem({
   itemHeight,
   setMomentumScrollCallback,
 }) {
+  const lastItemId = useRef(nft.nft_id);
+  const detailViewRef = useRef<Reanimated.View>(null);
   const headerHeight = useHeaderHeight();
   const headerHeightRef = useRef(headerHeight);
   const { data: detailData } = useNFTDetailByTokenId({
@@ -79,6 +81,22 @@ export const FeedItem = memo<FeedItemProps>(function FeedItem({
   const { data: edition } = useCreatorCollectionDetail(
     nft.creator_airdrop_edition_address
   );
+
+  const isLayouted = useSharedValue(0);
+  const opacity = useSharedValue(1);
+
+  // This part here is important for FlashList, since state gets recycled
+  // we need to reset the state when the comment changes
+  // I had to remove `key` from LikeContextProvider
+  // because it was breaking recycling
+  // https://shopify.github.io/flash-list/docs/recycling/
+  if (nft.nft_id !== lastItemId.current) {
+    lastItemId.current = nft.nft_id;
+    // since we are recycling, onLayout will not be called again, therefore we need to measure the height manually
+    detailViewRef.current?.measure((a, b, width, height, px, py) => {
+      setDetailHeight(height);
+    });
+  }
 
   const blurredBackgroundStyles = useBlurredBackgroundStyles(95);
   const maxContentHeight = windowHeight - bottomHeight;
@@ -118,8 +136,6 @@ export const FeedItem = memo<FeedItemProps>(function FeedItem({
       return 0;
     }
   });
-  const isLayouted = useSharedValue(0);
-  const opacity = useSharedValue(1);
 
   const detailStyle = useAnimatedStyle(() => {
     return {
@@ -174,7 +190,7 @@ export const FeedItem = memo<FeedItemProps>(function FeedItem({
   }, [setMomentumScrollCallback, showHeader]);
 
   return (
-    <LikeContextProvider nft={nft} key={nft.nft_id}>
+    <LikeContextProvider nft={nft}>
       <View tw="w-full" style={{ height: itemHeight, overflow: "hidden" }}>
         <View>
           {nft.blurhash ? (
@@ -220,6 +236,7 @@ export const FeedItem = memo<FeedItemProps>(function FeedItem({
           </Animated.View>
         </FeedItemTapGesture>
         <Reanimated.View
+          ref={detailViewRef}
           style={[
             detailStyle,
             {

--- a/packages/app/context/like-context.tsx
+++ b/packages/app/context/like-context.tsx
@@ -40,9 +40,7 @@ export const LikeContextProvider = ({
   );
 
   // This part here is important for FlashList, since state gets recycled
-  // we need to reset the state when the comment changes
-  // I had to remove `key` from CommentRow (Parent) and here, on View,
-  // because it was breaking recycling
+  // we need to reset the state when the nft-id changes
   // https://shopify.github.io/flash-list/docs/recycling/
   if (nft.nft_id !== lastItemId.current) {
     lastItemId.current = nft.nft_id;

--- a/packages/app/context/like-context.tsx
+++ b/packages/app/context/like-context.tsx
@@ -4,6 +4,7 @@ import React, {
   useContext,
   useMemo,
   useState,
+  useRef,
 } from "react";
 
 import { Haptics } from "@showtime-xyz/universal.haptics";
@@ -28,6 +29,7 @@ export const LikeContextProvider = ({
   nft: NFT;
   children: any;
 }) => {
+  const lastItemId = useRef(nft.nft_id);
   const { isLiked, like, unlike } = useMyInfo();
   const { isAuthenticated } = useUser();
 
@@ -36,6 +38,16 @@ export const LikeContextProvider = ({
   const [likeCount, setLikeCount] = useState(
     typeof nft.like_count === "number" ? nft.like_count : 0
   );
+
+  // This part here is important for FlashList, since state gets recycled
+  // we need to reset the state when the comment changes
+  // I had to remove `key` from CommentRow (Parent) and here, on View,
+  // because it was breaking recycling
+  // https://shopify.github.io/flash-list/docs/recycling/
+  if (nft.nft_id !== lastItemId.current) {
+    lastItemId.current = nft.nft_id;
+    setLikeCount(typeof nft.like_count === "number" ? nft.like_count : 0);
+  }
 
   const likeImpl = useCallback(async () => {
     Haptics.impactAsync();


### PR DESCRIPTION
# Why

FlashLists recycling was breaking because we used `key` on LikeContextProvider

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Added proper recycling back with a ref. Unfortunately, we're relying on `onLayout` (we should think how to get rid of this) which won't trigger again when recycled. So I need to re-measure the view. Even though we're doing two useState calls (and a measuring) here, we still take advantage of a lot of recycling which leads into better JS-FPS perf on fast scrolls.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
