### PR TITLE
fix: phone number alignment cross platform

### DIFF
--- a/packages/app/components/login/phone-number-picker.tsx
+++ b/packages/app/components/login/phone-number-picker.tsx
@@ -81,13 +81,18 @@ export const PhoneNumberPicker = (props: PhoneNumberPickerProp) => {
             marginTop: Platform.select({
               android: -4,
               default: 0,
+              web: 4,
             }),
-            marginRight: 1,
+            fontSize: Platform.select({
+              default: 18,
+              android: 14,
+              web: 20,
+            }),
           }}
         >
           {selectedCountry?.emoji}
         </Text>
-        <Text tw="text-base font-semibold text-gray-600 dark:text-gray-400">
+        <Text tw="web:pl-2 pl-1 pr-1 text-base font-semibold text-gray-600 dark:text-gray-400">
           {selectedCountry?.dial_code}{" "}
         </Text>
       </PressableScale>


### PR DESCRIPTION
# Why

Phone input was misaligned across platforms.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Adjusted values across devices

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
<img width="458" alt="Bildschirm­foto 2023-02-07 um 12 25 13" src="https://user-images.githubusercontent.com/504909/217232395-33cebcee-f893-49a2-a1c9-cff889b363e6.png">
<img width="452" alt="Bildschirm­foto 2023-02-07 um 12 25 17" src="https://user-images.githubusercontent.com/504909/217232399-9df42afc-566f-4dfc-9fba-8204c73d077b.png">

