### PR TITLE
feat: allow drop creators to delete all comments

### DIFF
--- a/packages/app/components/comments/comment-row.tsx
+++ b/packages/app/components/comments/comment-row.tsx
@@ -18,6 +18,7 @@ interface CommentRowProps {
   unlikeComment: (id: number) => Promise<boolean>;
   deleteComment: (id: number) => Promise<void>;
   reply?: (comment: CommentType) => void;
+  creatorId?: number;
 }
 
 const REPLIES_PER_BATCH = 2;
@@ -29,6 +30,7 @@ function CommentRowComponent({
   unlikeComment,
   deleteComment,
   reply,
+  creatorId,
 }: CommentRowProps) {
   /**
    * we used memo, so needs to add this hooks to here,
@@ -60,24 +62,34 @@ function CommentRowComponent({
   //#endregion
 
   //#region variables
+  const isDropCreator = useMemo(
+    () => creatorId === user?.data.profile.profile_id,
+    [creatorId, user?.data.profile.profile_id]
+  );
+
   const repliesCount = comment.replies?.length ?? 0;
+
   const replies = useMemo(
     () =>
       repliesCount > 0 ? comment.replies!.slice(0, displayedRepliesCount) : [],
     [comment.replies, repliesCount, displayedRepliesCount]
   );
+
   const isMyComment = useMemo(
     () => user?.data.profile.profile_id === comment.commenter_profile_id,
     [user, comment.commenter_profile_id]
   );
+
   const isRepliedByMe = useMemo(
     () => user?.data.comments.includes(comment.comment_id),
     [user, comment.comment_id]
   );
+
   const isLikedByMe = useMemo(
     () => user?.data.likes_comment.includes(comment.comment_id),
     [user, comment.comment_id]
   );
+
   const isReply = comment.parent_id !== null && comment.parent_id !== undefined;
   //#endregion
 
@@ -158,7 +170,9 @@ function CommentRowComponent({
         createdAt={comment.added}
         position={isLastReply ? "last" : undefined}
         onLikePress={handleOnLikePress}
-        onDeletePress={isMyComment ? handleOnDeletePress : undefined}
+        onDeletePress={
+          isMyComment || isDropCreator ? handleOnDeletePress : undefined
+        }
         onReplyPress={handleOnReplyPress}
         onTagPress={handleOnUserPress}
         onUserPress={handleOnUserPress}

--- a/packages/app/components/comments/index.tsx
+++ b/packages/app/components/comments/index.tsx
@@ -138,9 +138,16 @@ export function Comments({ nft, webListHeight }: CommentsProps) {
         unlikeComment={unlikeComment}
         deleteComment={handleOnDeleteComment}
         reply={handleOnReply}
+        creatorId={nft.creator_id}
       />
     ),
-    [likeComment, unlikeComment, handleOnDeleteComment, handleOnReply]
+    [
+      likeComment,
+      unlikeComment,
+      handleOnDeleteComment,
+      handleOnReply,
+      nft.creator_id,
+    ]
   );
 
   const listEmptyComponent = useCallback(


### PR DESCRIPTION
# Why

A drop creator should be able to delete all comments

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Added a check of the current drop is made by logged in user, if yes, allow swipe to delete on all of them

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
