### PR TITLE
chore: don't commit history files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ apps/expo/service-account-key.json
 
 # ESLint
 lint-results/
+
+# History plugins for VSCode
+.history/


### PR DESCRIPTION
# Why

Some really useful tools like local history write files into a local .history folder (others in .lh/).
This files should not be commited

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Added to history related files to gitignore. 

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
