### PR TITLE
fix: tracking screens/page correctly

### DIFF
--- a/packages/app/lib/analytics.ts
+++ b/packages/app/lib/analytics.ts
@@ -1,18 +1,24 @@
 import { useEffect } from "react";
+import { Platform } from "react-native";
 
 import { useRudder } from "app/lib/rudderstack";
 
 type PageViewedProps = {
   name: string;
-  type?: string;
+  properties?: Record<string, any>;
 };
 
 // Page Viewed
-export function useTrackPageViewed({ name, type }: PageViewedProps) {
+export function useTrackPageViewed({ name, properties }: PageViewedProps) {
   const { rudder } = useRudder();
 
   useEffect(() => {
-    rudder?.track("Page Viewed", { name, type });
+    if (Platform.OS === "web") {
+      // @ts-expect-error rudderstack-native-sdk does not have a page method but its there in our rudderstack-provider.web.tsx
+      rudder?.page(name, { ...properties });
+    } else {
+      rudder?.screen(name, { ...properties });
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [rudder]);
 }

--- a/packages/app/lib/analytics.ts
+++ b/packages/app/lib/analytics.ts
@@ -15,9 +15,9 @@ export function useTrackPageViewed({ name, properties }: PageViewedProps) {
   useEffect(() => {
     if (Platform.OS === "web") {
       // @ts-expect-error rudderstack-native-sdk does not have a page method but its there in our rudderstack-provider.web.tsx
-      rudder?.page(name, { ...properties });
+      rudder?.page(name, properties);
     } else {
-      rudder?.screen(name, { ...properties });
+      rudder?.screen(name, properties);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [rudder]);


### PR DESCRIPTION
# Why

We have been tracking pages (web) and screens (app) wrong. We used a custom track event instead of using the right tools

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Added a check for web and app and call `page` or `screen`. I had to ignore the types for `page` because of how we import the rudderClient, but it works.


<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
