### PR TITLE
fix: bail out of retry logic in swr if status 400, 403 or 404

### DIFF
--- a/packages/app/hooks/api-hooks.ts
+++ b/packages/app/hooks/api-hooks.ts
@@ -116,7 +116,18 @@ export const useUserProfile = ({ address }: { address?: string | null }) => {
   const queryKey = address ? USER_PROFILE_KEY + address : null;
   const { data, error, isLoading } = useSWR<{
     data?: UserProfile;
-  }>(queryKey, fetcher);
+  }>(queryKey, fetcher, {
+    onErrorRetry: (error, key, _config, revalidate, { retryCount }) => {
+      // Never retry on 404 or 404.
+      if (error.status === 404 || error.status === 403) return;
+
+      // Only retry up to 5 times.
+      if (retryCount >= 5) return;
+
+      // Retry after 5 seconds.
+      setTimeout(() => revalidate({ retryCount }), 5000);
+    },
+  });
   const { mutate } = useSWRConfig();
 
   const { data: myInfoData } = useMyInfo();

--- a/packages/app/hooks/api-hooks.ts
+++ b/packages/app/hooks/api-hooks.ts
@@ -119,7 +119,8 @@ export const useUserProfile = ({ address }: { address?: string | null }) => {
   }>(queryKey, fetcher, {
     onErrorRetry: (error, key, _config, revalidate, { retryCount }) => {
       // Never retry on 403 or 404.
-      if (error.status === 404 || error.status === 403) return;
+      if (error.response.status === 404 || error.response.status === 403)
+        return;
 
       // Only retry up to 5 times.
       if (retryCount >= 5) return;

--- a/packages/app/hooks/api-hooks.ts
+++ b/packages/app/hooks/api-hooks.ts
@@ -118,7 +118,7 @@ export const useUserProfile = ({ address }: { address?: string | null }) => {
     data?: UserProfile;
   }>(queryKey, fetcher, {
     onErrorRetry: (error, key, _config, revalidate, { retryCount }) => {
-      // Never retry on 404 or 404.
+      // Never retry on 403 or 404.
       if (error.status === 404 || error.status === 403) return;
 
       // Only retry up to 5 times.

--- a/packages/app/hooks/api-hooks.ts
+++ b/packages/app/hooks/api-hooks.ts
@@ -116,19 +116,7 @@ export const useUserProfile = ({ address }: { address?: string | null }) => {
   const queryKey = address ? USER_PROFILE_KEY + address : null;
   const { data, error, isLoading } = useSWR<{
     data?: UserProfile;
-  }>(queryKey, fetcher, {
-    onErrorRetry: (error, key, _config, revalidate, { retryCount }) => {
-      // Never retry on 403 or 404.
-      if (error.response.status === 404 || error.response.status === 403)
-        return;
-
-      // Only retry up to 5 times.
-      if (retryCount >= 5) return;
-
-      // Retry after 5 seconds.
-      setTimeout(() => revalidate({ retryCount }), 5000);
-    },
-  });
+  }>(queryKey, fetcher);
   const { mutate } = useSWRConfig();
 
   const { data: myInfoData } = useMyInfo();

--- a/packages/app/providers/swr-provider.tsx
+++ b/packages/app/providers/swr-provider.tsx
@@ -61,6 +61,11 @@ export const SWRProvider = ({
           revalidate: Revalidator,
           opts: Required<RevalidatorOptions>
         ) => {
+          // bail out immediately if the error is unrecoverable
+          if (error.status === 403 || error.status === 404) {
+            return;
+          }
+
           const maxRetryCount = config.errorRetryCount;
           const currentRetryCount = opts.retryCount;
 
@@ -75,10 +80,6 @@ export const SWRProvider = ({
             !isUndefined(maxRetryCount) &&
             currentRetryCount > maxRetryCount
           ) {
-            return;
-          }
-
-          if (error.status === 404) {
             return;
           }
 

--- a/packages/app/providers/swr-provider.tsx
+++ b/packages/app/providers/swr-provider.tsx
@@ -1,10 +1,11 @@
 import { AppState, AppStateStatus } from "react-native";
 
 import NetInfo from "@react-native-community/netinfo";
+import type { AxiosError } from "axios";
 import { MMKV } from "react-native-mmkv";
 import type { Revalidator, RevalidatorOptions } from "swr";
 import { SWRConfig } from "swr";
-import type { PublicConfiguration } from "swr/dist/types";
+import type { PublicConfiguration } from "swr/_internal";
 
 import { useToast } from "@showtime-xyz/universal.toast";
 
@@ -53,16 +54,18 @@ export const SWRProvider = ({
           }
         },
         onErrorRetry: async (
-          error: {
-            status: number;
-          },
+          error: AxiosError,
           key: string,
           config: Readonly<PublicConfiguration>,
           revalidate: Revalidator,
           opts: Required<RevalidatorOptions>
         ) => {
           // bail out immediately if the error is unrecoverable
-          if (error.status === 403 || error.status === 404) {
+          if (
+            error.response?.status === 400 ||
+            error.response?.status === 403 ||
+            error.response?.status === 404
+          ) {
             return;
           }
 

--- a/packages/app/providers/swr-provider.web.tsx
+++ b/packages/app/providers/swr-provider.web.tsx
@@ -50,6 +50,11 @@ export const SWRProvider = ({
           revalidate: Revalidator,
           opts: Required<RevalidatorOptions>
         ) => {
+          // bail out immediately if the error is unrecoverable
+          if (error.status === 403 || error.status === 404) {
+            return;
+          }
+
           const maxRetryCount = config.errorRetryCount;
           const currentRetryCount = opts.retryCount;
 
@@ -64,10 +69,6 @@ export const SWRProvider = ({
             !isUndefined(maxRetryCount) &&
             currentRetryCount > maxRetryCount
           ) {
-            return;
-          }
-
-          if (error.status === 404) {
             return;
           }
 

--- a/packages/app/providers/swr-provider.web.tsx
+++ b/packages/app/providers/swr-provider.web.tsx
@@ -1,3 +1,4 @@
+import type { AxiosError } from "axios";
 import type { Revalidator, RevalidatorOptions } from "swr";
 import { SWRConfig } from "swr";
 import type { SWRConfiguration } from "swr";
@@ -42,16 +43,18 @@ export const SWRProvider = ({
           }
         },
         onErrorRetry: async (
-          error: {
-            status: number;
-          },
+          error: AxiosError,
           key: string,
           config: Readonly<SWRConfiguration>,
           revalidate: Revalidator,
           opts: Required<RevalidatorOptions>
         ) => {
           // bail out immediately if the error is unrecoverable
-          if (error.status === 403 || error.status === 404) {
+          if (
+            error.response?.status === 400 ||
+            error.response?.status === 403 ||
+            error.response?.status === 404
+          ) {
             return;
           }
 


### PR DESCRIPTION
# Why

Our Feed and data is cached. If we ban profiles, they might still be in the Feed cache. This causes hundreds of retries by useSWRs defaults, spamming our API and eating up client resources.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

While I think we should adapt a global SWRConfig strategy (even though we have exponential backoff baked in), for now I've gone with the route to only adjust this single useSWR. There is no need to retry to grab a profile with a 404 or 403 forever or hundreds of times. Therefore I have added this exception, until we decide how to proceed globally.

In my findings, a single banned profile was causing 80 XHR requests in less than 5 minutes on the home feed. This should fix this.

If you guys agree, we could ignore my PR and just add the exception to swr-provider.tsx and swr-prodiver.web.tsx and generally ignore retries for 403

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
