### PR TITLE
e2e: sign up test flow

### DIFF
--- a/.github/workflows/maestro-android.yml
+++ b/.github/workflows/maestro-android.yml
@@ -45,3 +45,5 @@ jobs:
         with:
           api-key: ${{ secrets.MAESTRO_CLOUD_API_KEY }}
           app-file: ${{ env.APK_PATH }}
+          env: |
+            PLATFORM=android

--- a/.github/workflows/maestro-ios.yml
+++ b/.github/workflows/maestro-ios.yml
@@ -44,3 +44,5 @@ jobs:
         with:
           api-key: ${{ secrets.MAESTRO_CLOUD_API_KEY }}
           app-file: ${{ env.APP_DIR_PATH }}
+          env: |
+            PLATFORM=ios

--- a/.maestro/sign-in-with-email.yml
+++ b/.maestro/sign-in-with-email.yml
@@ -1,5 +1,3 @@
-# sign-in-with-email.yaml
-
 appId: io.showtime.development
 ---
 - launchApp

--- a/.maestro/sign-up-with-wallet.yml
+++ b/.maestro/sign-up-with-wallet.yml
@@ -1,0 +1,10 @@
+appId: io.showtime.development
+---
+- runFlow:
+    when:
+      true: ${PLATFORM == 'ios'}
+    file: subflows/sign-up-with-wallet-ios.yml
+- runFlow:
+    when:
+      true: ${PLATFORM == 'android'}
+    file: subflows/sign-up-with-wallet-android.yml

--- a/.maestro/subflows/sign-up-with-wallet-android.yml
+++ b/.maestro/subflows/sign-up-with-wallet-android.yml
@@ -1,0 +1,3 @@
+appId: io.showtime.development
+---
+- launchApp

--- a/.maestro/subflows/sign-up-with-wallet-ios.yml
+++ b/.maestro/subflows/sign-up-with-wallet-ios.yml
@@ -1,19 +1,26 @@
 appId: io.showtime.development
 ---
 - launchApp
+# - tapOn: "Showtime http://192.168.0.241:8081"
 - assertVisible: "Sign In"
 - tapOn: "Sign In"
-- tapOn: "I already have a wallet"
+- tapOn: "Connect Wallet"
 - assertNotVisible: "Sign In"
 - tapOn:
     text: "Pick profile photo"
     index: 1
-- tapOn: "Select Photos…"
+- tapOn:
+    text: "Select Photos…"
+    optional: true
 - tapOn:
     # Selects photo from picker
     point: "16%,22%"
-- tapOn: "Choose"
-- tapOn: "Keep current Selection"
+- tapOn:
+    text: "Choose"
+    optional: true
+- tapOn:
+    text: "Keep current Selection"
+    optional: true
 - tapOn: "Your display name"
 - inputRandomPersonName
 - tapOn: "Your username"

--- a/.maestro/subflows/sign-up-with-wallet-ios.yml
+++ b/.maestro/subflows/sign-up-with-wallet-ios.yml
@@ -1,0 +1,33 @@
+appId: io.showtime.development
+---
+- launchApp
+- assertVisible: "Sign In"
+- tapOn: "Sign In"
+- tapOn: "I already have a wallet"
+- assertNotVisible: "Sign In"
+- tapOn:
+    text: "Pick profile photo"
+    index: 1
+- tapOn: "Select Photos…"
+- tapOn:
+    # Selects photo from picker
+    point: "16%,22%"
+- tapOn: "Choose"
+- tapOn: "Keep current Selection"
+- tapOn: "Your display name"
+- inputRandomPersonName
+- tapOn: "Your username"
+- inputRandomText
+- tapOn:
+    id: "about_me"
+- inputRandomText
+- pressKey: Enter
+- tapOn:
+    id: "website_url"
+- inputText: "www.google.com"
+- pressKey: Enter
+- tapOn:
+    text: "Complete Profile"
+    index: 1
+- assertVisible: "Submitting..."
+- assertNotVisible: "Complete Profile"


### PR DESCRIPTION
# Why
Adds sign up test flow using a new wallet
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- Adds sign up test flow for iOS. Maestro cloud lacks default media in their android emulators. So it's noop on android as our sign up step depends upon media. I have asked their team if they can do something.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Sign up test should pass on maestro cloud.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
