### PR TITLE
fix: notification time and UI

### DIFF
--- a/packages/app/components/notifications/index.tsx
+++ b/packages/app/components/notifications/index.tsx
@@ -49,7 +49,7 @@ export const Notifications = ({
   hideHeader = false,
   web_height = undefined,
 }: NotificationsProps) => {
-  const { data, fetchMore, refresh, isRefreshing, isLoadingMore } =
+  const { data, fetchMore, refresh, isRefreshing, isLoadingMore, isLoading } =
     useNotifications();
   const { refetchMyInfo } = useMyInfo();
   const isDark = useIsDarkMode();
@@ -88,17 +88,6 @@ export const Notifications = ({
     []
   );
 
-  const ListEmptyComponent = useCallback(
-    () => (
-      <View tw="items-center justify-center">
-        <Text tw="p-20 text-gray-900 dark:text-gray-100">
-          No new notifications
-        </Text>
-      </View>
-    ),
-    []
-  );
-
   useEffect(() => {
     (async function resetNotificationLastOpenedTime() {
       await axios({
@@ -109,6 +98,16 @@ export const Notifications = ({
       refetchMyInfo();
     })();
   }, [refetchMyInfo]);
+
+  if (!isLoading && data.length === 0) {
+    return (
+      <View tw="flex-1 items-center justify-center">
+        <Text tw="font-medium text-gray-900 dark:text-gray-100">
+          You have no notifications yet
+        </Text>
+      </View>
+    );
+  }
 
   return (
     <>
@@ -162,7 +161,6 @@ export const Notifications = ({
         refreshing={isRefreshing}
         onRefresh={refresh}
         ListFooterComponent={ListFooterComponent}
-        ListEmptyComponent={ListEmptyComponent}
         ref={listRef}
         estimatedItemSize={56}
       />

--- a/packages/app/components/notifications/notification-item.tsx
+++ b/packages/app/components/notifications/notification-item.tsx
@@ -105,18 +105,18 @@ const NotificationDescription = memo(
     );
 
     return (
-      <View tw="flex-1">
+      <View tw="flex-1 flex-row justify-between">
         <Text
-          tw="text-13 max-w-[69vw] text-gray-600 dark:text-gray-400"
+          tw="text-13 web:max-w-[80%] mr-4 max-w-[70vw] text-gray-600 dark:text-gray-400"
           ellipsizeMode="tail"
         >
           <Actors actors={notification.actors} setUsers={setUsers} />
           {NOTIFICATION_TYPE_COPY.get(notification.type_name)}
           <NFTSDisplayName nfts={notification.nfts} />
-          {Boolean(formatDistance) && (
-            <Text tw="text-13">{` · ${formatDistance}`}</Text>
-          )}
         </Text>
+        {Boolean(formatDistance) && (
+          <Text tw="text-13">{`${formatDistance}`}</Text>
+        )}
       </View>
     );
   }

--- a/packages/app/utilities.ts
+++ b/packages/app/utilities.ts
@@ -640,8 +640,17 @@ export const getFormatDistanceStrictToWeek = (time?: string) => {
   const currentDate = new Date();
   const givenDate = new Date(time);
   const diffTime = currentDate.getTime() - givenDate.getTime();
+  const diffMinutes = diffTime / (1000 * 60);
   const diffDays = diffTime / (1000 * 60 * 60 * 24);
   const diffHours = diffTime / (1000 * 60 * 60);
+
+  if (diffMinutes < 1) {
+    return `now`;
+  }
+
+  if (diffMinutes >= 1 && diffMinutes < 60) {
+    return `${Math.round(diffMinutes)}m`;
+  }
 
   if (diffDays < 1) {
     return `${Math.round(diffHours)}h`;


### PR DESCRIPTION
# Why

Times under 1h have been shown as 0h.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Changed logic a bit. Notifications under < 1m are shown are "now", from 1-59 they are shown as 30m, 50m etc.
From 1h > its shown as we already now it. Also spoke to Alex and we decided to give the UI a little update and dont break the times into a new line.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

https://showtime-rq88331.slack.com/archives/C02Q0EY6RMH/p1676040789678999
