### PR TITLE
fix: correctly handle HTTP status 401

### DIFF
--- a/packages/app/providers/swr-provider.web.tsx
+++ b/packages/app/providers/swr-provider.web.tsx
@@ -61,6 +61,19 @@ export const SWRProvider = ({
           const maxRetryCount = config.errorRetryCount;
           const currentRetryCount = opts.retryCount;
 
+          if (error.response?.status === 401) {
+            // we only want to refresh tokens once and then bail out if it fails on 401
+            // this is to prevent infinite loops. Actually, we should logout the user but AuthProvider is not available here
+            if (currentRetryCount > 1) {
+              return;
+            }
+            try {
+              await refreshTokens();
+            } catch (err) {
+              return;
+            }
+          }
+
           // Exponential backoff
           const timeout =
             ~~(
@@ -73,10 +86,6 @@ export const SWRProvider = ({
             currentRetryCount > maxRetryCount
           ) {
             return;
-          }
-
-          if (error.status === 401) {
-            await refreshTokens();
           }
 
           setTimeout(revalidate, timeout, opts);


### PR DESCRIPTION
# Why

401 issues are currently not working, because the `error.status` is undefined (due to our use of Axios). The status data from Axios resides in the `error.response` property.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

I fixed the check and moved the code a bit. I also added a bail out if the refreshToken failed once. I am still not completely satisfied with this solution, as I am seeing up to eight refreshToken requests on the Home page once we encounter a 401 (because all 401s result in at least one retry). This is still an improvement, as before (when it wasn't even executing), it would have attempted it many, many more times before eventually bailing out.

For now, this issue has been resolved, but the proper way to handle it would be to instantly log out the user if the first refreshToken results in another 401. I tried, but the AuthProvider is not available, so we need to export a generic logout function that is not related to the AuthProvider. This should prevent further 401 API spam, as once we fail to refresh the user, we should log them out.

This is at least a temporary solution to reduce the number of retries in the API.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
