### PR TITLE
fix: cumulative layout shifts caused by cards

### DIFF
--- a/packages/app/components/card/card.tsx
+++ b/packages/app/components/card/card.tsx
@@ -6,6 +6,7 @@ import {
   ViewStyle,
 } from "react-native";
 
+import { ResizeMode } from "expo-av";
 import { Link, LinkProps } from "solito/link";
 
 import {
@@ -187,7 +188,7 @@ const CardLargeScreen = ({
                 width: sizeStyle?.width ?? cardMaxWidth,
                 height: sizeStyle?.height ?? cardMaxWidth,
               }}
-              resizeMode="cover"
+              resizeMode={ResizeMode.COVER}
             />
             {numColumns === 1 && nft?.mime_type?.includes("video") ? (
               <View tw="z-9 absolute bottom-5 right-5">

--- a/packages/app/components/feed-item/claimed-by.tsx
+++ b/packages/app/components/feed-item/claimed-by.tsx
@@ -16,7 +16,7 @@ type NFTDetailsProps = {
 export const ClaimedBy = ({ nft, claimersList, tw = "" }: NFTDetailsProps) => {
   const router = useRouter();
   if (!claimersList || claimersList?.length <= 1) {
-    return null;
+    return <View tw="native:mb-4 web:h-5 ml-2 h-9" collapsable />;
   }
   const slicedClaimersList = claimersList?.slice(1, 4);
   const firstClaimer = claimersList[1];

--- a/packages/app/components/feed-item/feed-item.tsx
+++ b/packages/app/components/feed-item/feed-item.tsx
@@ -93,7 +93,7 @@ export const FeedItem = memo<FeedItemProps>(function FeedItem({
   if (nft.nft_id !== lastItemId.current) {
     lastItemId.current = nft.nft_id;
     // since we are recycling, onLayout will not be called again, therefore we need to measure the height manually
-    detailViewRef.current?.measure((a, b, width, height, px, py) => {
+    detailViewRef.current?.measure((a, b, width, height) => {
       setDetailHeight(height);
     });
   }

--- a/packages/app/components/feed-item/feed-item.web.tsx
+++ b/packages/app/components/feed-item/feed-item.web.tsx
@@ -6,6 +6,8 @@ import {
   ViewStyle,
 } from "react-native";
 
+import { ResizeMode } from "expo-av";
+
 import { View } from "@showtime-xyz/universal.view";
 
 import { FeedItemTapGesture } from "app/components/feed/feed-item-tap-gesture";
@@ -96,7 +98,7 @@ export const FeedItem = memo<FeedItemProps>(function FeedItem({
                 height: mediaHeight,
                 width: windowWidth,
               }}
-              resizeMode="cover"
+              resizeMode={ResizeMode.COVER}
             />
           </FeedItemTapGesture>
         </View>


### PR DESCRIPTION
# Why

The cards on Home and Trending are causing a lot of CLS due to the "ClaimedBy" component.
Currently, we have two endpoints for NFTs: the NFT endpoint and the NFT-detail endpoint. The NFT-detail endpoint provides information about how many people have collected a specific NFT.

However, the detail endpoint is called asynchronously after a card (either the feed or trending card) has been rendered. Based on the value of this key, we decide whether to render the “claimed-by” component or not. I have temporarily fixed this issue with a simple “hack” (rendering an empty view with the final layout). This solution works well because I haven’t seen any unowned NFTs, but it could result in a gap if an NFT was not collected yet. (not looking bad though)

Knowing this information beforehand would prevent the cumulative layout shift in both cases.
I have asked for this information, in more detail [here on slack](https://showtime-rq88331.slack.com/archives/C02QD3J7DJM/p1676130946348719)
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
Preserving the expected height upfront, until the async request is done. Works pretty well.
Also fixed some types. Drastically reduced CLS and it looks way better when scrolling through lists. 

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
