### PR TITLE
fix: tooltip and card ellipsis

### DIFF
--- a/packages/app/components/card/rows/title.tsx
+++ b/packages/app/components/card/rows/title.tsx
@@ -1,6 +1,7 @@
 import { useState, useLayoutEffect, useRef } from "react";
 import { Platform } from "react-native";
 
+import { useIsDarkMode } from "@showtime-xyz/universal.hooks";
 import { Text } from "@showtime-xyz/universal.text";
 import { View } from "@showtime-xyz/universal.view";
 
@@ -13,6 +14,9 @@ type Props = {
 };
 
 export function Title({ title, disableTooltip = false }: Props) {
+  const isDark = useIsDarkMode();
+  title =
+    "wpeowekpfokwefpowkefpowkefpo weifuhweifu hweifuwhefiuwehfiweufhwieufhweifuwekf";
   const [isUseTooltip, setIsOverflow] = useState(
     Platform.OS === "web" && !disableTooltip
   );
@@ -39,14 +43,14 @@ export function Title({ title, disableTooltip = false }: Props) {
         <Tooltip.Root>
           <Tooltip.Trigger>
             <Text
-              tw="text-lg !leading-8 text-black dark:text-white"
+              tw="inline-block overflow-ellipsis whitespace-nowrap text-lg !leading-8 text-black dark:text-white"
               numberOfLines={1}
             >
               {title}
             </Text>
           </Tooltip.Trigger>
           <Tooltip.Content side="bottom">
-            <Tooltip.Text text={title} />
+            <Tooltip.Text text={title} textColor={isDark ? "#000" : "#fff"} />
           </Tooltip.Content>
         </Tooltip.Root>
       ) : (

--- a/packages/app/components/card/rows/title.tsx
+++ b/packages/app/components/card/rows/title.tsx
@@ -15,8 +15,6 @@ type Props = {
 
 export function Title({ title, disableTooltip = false }: Props) {
   const isDark = useIsDarkMode();
-  title =
-    "wpeowekpfokwefpowkefpowkefpo weifuhweifu hweifuwhefiuwehfiweufhwieufhweifuwekf";
   const [isUseTooltip, setIsOverflow] = useState(
     Platform.OS === "web" && !disableTooltip
   );


### PR DESCRIPTION
# Why

Long titles were breaking on cards. Tooltip text color was not respecting theme.
https://showtime-rq88331.slack.com/archives/C02PXGK3V8D/p1676115603228729

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Fixed them

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
