### PR TITLE
fix: clamp-text not updating

### DIFF
--- a/packages/design-system/clamp-text/use-clamp-text.tsx
+++ b/packages/design-system/clamp-text/use-clamp-text.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, ReactNode, useEffect } from "react";
+import { useState, useRef, useCallback, ReactNode } from "react";
 import { NativeSyntheticEvent, TextLayoutEventData } from "react-native";
 
 import { ClampTextProps } from "./clamp-text";
@@ -28,23 +28,22 @@ export const useClampText = ({
   const [showLess, setShowLess] = useState(false);
   const collapseText = useRef("");
   const isLayouted = useRef(false);
-  const currentText = useRef<string | Iterable<ReactNode> | null>(null);
+  const currentText = useRef<string | Iterable<ReactNode> | null>(
+    typeof text === "string" ? text.replace(/[\r\n]/g, " ") : text
+  );
 
   // reset state when text changed so that the text can be re-clamped
   // this is useful when the text is updated by a parent component
   // and the text is not the same as the previous one
   // because it did not change once the profile was updated
-  useEffect(() => {
-    // only reset state when the text is changed
-    if (currentText.current !== text) {
-      const newText =
-        typeof text === "string" ? text.replace(/[\r\n]/g, " ") : text;
-      setShowMore(false);
-      setShowLess(false);
-      setInnerText(newText);
-      currentText.current = newText;
-    }
-  }, [text]);
+  if (currentText.current !== text) {
+    const newText =
+      typeof text === "string" ? text.replace(/[\r\n]/g, " ") : text;
+    setShowMore(false);
+    setShowLess(false);
+    setInnerText(newText);
+    currentText.current = newText;
+  }
 
   const onTextLayout = (e: NativeSyntheticEvent<TextLayoutEventData>) => {
     if (e.nativeEvent.lines.length <= rows || isLayouted.current) return;

--- a/packages/design-system/clamp-text/use-clamp-text.tsx
+++ b/packages/design-system/clamp-text/use-clamp-text.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, ReactNode } from "react";
+import { useState, useRef, useCallback, ReactNode, useEffect } from "react";
 import { NativeSyntheticEvent, TextLayoutEventData } from "react-native";
 
 import { ClampTextProps } from "./clamp-text";
@@ -21,13 +21,30 @@ export const useClampText = ({
   ellipsis = "...",
   expandButtonWidth = 10,
 }: ClampTextParams) => {
-  const [innerText, setInnerText] = useState(
-    typeof text === "string" ? text.replace(/[\r\n]/g, " ") : text
-  );
+  const [innerText, setInnerText] = useState<
+    string | Iterable<ReactNode> | null
+  >(() => (typeof text === "string" ? text.replace(/[\r\n]/g, " ") : text));
   const [showMore, setShowMore] = useState(false);
   const [showLess, setShowLess] = useState(false);
   const collapseText = useRef("");
   const isLayouted = useRef(false);
+  const currentText = useRef<string | Iterable<ReactNode> | null>(null);
+
+  // reset state when text changed so that the text can be re-clamped
+  // this is useful when the text is updated by a parent component
+  // and the text is not the same as the previous one
+  // because it did not change once the profile was updated
+  useEffect(() => {
+    // only reset state when the text is changed
+    if (currentText.current !== text) {
+      const newText =
+        typeof text === "string" ? text.replace(/[\r\n]/g, " ") : text;
+      setShowMore(false);
+      setShowLess(false);
+      setInnerText(newText);
+      currentText.current = newText;
+    }
+  }, [text]);
 
   const onTextLayout = (e: NativeSyntheticEvent<TextLayoutEventData>) => {
     if (e.nativeEvent.lines.length <= rows || isLayouted.current) return;


### PR DESCRIPTION
# Why

When updating the bio on iOS or Android, the text does not change and a restart of the app is required to see the changes.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

This was a challenging issue to resolve. Initially, I thought the problem was due to memoizing in the Tab-View component, but it turned out to be related to how state was managed in the use-clamp-text function. A simple solution would have been to add a key to the ClampText component, but since it is widely used and also in recycling lists, I had to find a more comprehensive solution.

I solved the issue by comparing the text with a stored reference. Whenever the text changes, I update the state and reset the clamping process. This solution is stable with recycling and should not result in any additional overhead.

## Help

**@alantoa could you please update the universal design system? I had to make changes. If you don't mind, please co-author this PR to publish the changes.**

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

| Before  | After |
| ------------- | ------------- |
| <video src="https://user-images.githubusercontent.com/504909/218285230-26feeeda-63cb-4a25-aa7b-42de36bc169a.mp4"></video> | <video alt="" src="https://user-images.githubusercontent.com/504909/218285229-6c6f33f9-62cb-4dda-97a7-2ff35c6ca7ba.mp4"></video> |

