### PR TITLE
fix: long text in bio break HoverCard overflow

### DIFF
--- a/packages/app/components/card/avatar-hover-card.web.tsx
+++ b/packages/app/components/card/avatar-hover-card.web.tsx
@@ -78,6 +78,7 @@ export function AvatarHoverCard({
             >
               {profileData?.profile.cover_url && (
                 <Image
+                  alt="Profile Image"
                   source={{
                     uri: getFullSizeCover(profileData?.profile.cover_url),
                   }}
@@ -165,8 +166,8 @@ export function AvatarHoverCard({
                       <View tw="mt-4 items-baseline">
                         <ClampText
                           text={bioWithMentions}
-                          maxLines={3}
-                          tw="text-sm text-gray-900 dark:text-white"
+                          maxLines={2}
+                          tw="max-w-full break-all text-sm text-gray-900 dark:text-white"
                         />
                       </View>
                     ) : null}

--- a/packages/app/components/card/avatar-hover-card.web.tsx
+++ b/packages/app/components/card/avatar-hover-card.web.tsx
@@ -166,7 +166,7 @@ export function AvatarHoverCard({
                       <View tw="mt-4 items-baseline">
                         <ClampText
                           text={bioWithMentions}
-                          maxLines={2}
+                          maxLines={3}
                           tw="max-w-full break-all text-sm text-gray-900 dark:text-white"
                         />
                       </View>


### PR DESCRIPTION
# Why

Long text in bio would break overflow in AvatarHoverCard.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Added a word-break strategy.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
