### PR TITLE
feat: optimize linkify

### DIFF
--- a/packages/app/lib/linkify.tsx
+++ b/packages/app/lib/linkify.tsx
@@ -27,7 +27,7 @@ export const linkifyDescription = (text?: string, tw?: TW) => {
     replacedText,
     /(https?:\/\/\S+|www\.\S+)\b/g,
     (match, i) => {
-      if (match.startsWith("www")) {
+      if (match.startsWith("www.")) {
         match = "https://" + match;
       }
 

--- a/packages/app/lib/linkify.tsx
+++ b/packages/app/lib/linkify.tsx
@@ -25,17 +25,25 @@ export const linkifyDescription = (text?: string, tw?: TW) => {
   // Match URLs
   replacedText = reactStringReplace(
     replacedText,
-    /(https?:\/\/\S+)/g,
-    (match, i) => (
-      <TextLink
-        href={match}
-        key={match + i}
-        target="_blank"
-        tw={tw ?? "text-13 font-bold text-gray-900 dark:text-gray-100"}
-      >
-        {match}
-      </TextLink>
-    )
+    /(https?:\/\/\S+|www\.\S+)\b/g,
+    (match, i) => {
+      if (match.startsWith("www")) {
+        match = "https://" + match;
+      }
+
+      const urlText = match.replace("https://", "").replace("http://", "");
+
+      return (
+        <TextLink
+          href={match}
+          key={match + i}
+          target="_blank"
+          tw={tw ?? "text-13 font-bold text-gray-900 dark:text-gray-100"}
+        >
+          {urlText}
+        </TextLink>
+      );
+    }
   );
 
   return replacedText;


### PR DESCRIPTION
# Why

Our linkify function had several flaws. It included punctuation at the end of the URL in the final match and did not support URLs without a protocol, such as [www.google.de](http://www.google.de/).

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

I optimized the regular expression to exclude trailing punctuation. Additionally, I added checks for "[www](http://www/)." and prepended "https://" to it. I chose not to add "http" because all websites should use "https" now. I also removed the protocol from the printed URL to save space and make it look better, while still retaining the protocol in the URL itself.

After trying 30 different regular expressions, I settled on a straightforward and simple solution based on the previous one, which provided good results.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img alt="" src="https://user-images.githubusercontent.com/504909/218288717-224044d3-83af-4ae3-856a-b1d040f0d7e7.png" width="400" />

