### PR TITLE
fix: sanitize comments and comment input

### DIFF
--- a/packages/app/components/messages/message-box.tsx
+++ b/packages/app/components/messages/message-box.tsx
@@ -88,10 +88,11 @@ export const MessageBox = forwardRef<MessageBoxMethods, MessageBoxProps>(
             placeholderTextColor={isDark ? colors.gray[400] : colors.gray[500]}
             multiline={true}
             keyboardType="twitter"
-            tw="web:max-h-40 rounded-[32px] bg-gray-100 py-3 pr-3 pl-[44px] text-sm text-black dark:bg-gray-900 dark:text-white"
+            tw="web:max-h-40 max-h-32 rounded-[32px] bg-gray-100 py-3 pr-3 pl-[44px] text-sm text-black dark:bg-gray-900 dark:text-white"
             onChangeText={handleTextChange}
             onFocus={onFocus}
             onBlur={onBlur}
+            maxLength={500}
           />
           <Avatar
             alt="Avatar"

--- a/packages/app/components/messages/message-row.tsx
+++ b/packages/app/components/messages/message-row.tsx
@@ -14,7 +14,11 @@ import { View } from "@showtime-xyz/universal.view";
 import { AvatarHoverCard } from "app/components/card/avatar-hover-card";
 import { linkifyDescription } from "app/lib/linkify";
 import { Link } from "app/navigation/link";
-import { convertUTCDateToLocalDate, formatAddressShort } from "app/utilities";
+import {
+  cleanUserTextInput,
+  convertUTCDateToLocalDate,
+  formatAddressShort,
+} from "app/utilities";
 
 interface MessageRowProps {
   /**
@@ -171,10 +175,10 @@ export function MessageRow({
   const contentWithTags = useMemo(() => {
     return onTagPress
       ? linkifyDescription(
-          content,
+          cleanUserTextInput(content),
           "font-bold text-xs text-gray-900 dark:text-gray-100"
         )
-      : content;
+      : cleanUserTextInput(content);
   }, [content, onTagPress]);
 
   const userNameText = useMemo(() => {

--- a/packages/app/components/messages/message-row.tsx
+++ b/packages/app/components/messages/message-row.tsx
@@ -18,6 +18,7 @@ import {
   cleanUserTextInput,
   convertUTCDateToLocalDate,
   formatAddressShort,
+  limitLineBreaks,
 } from "app/utilities";
 
 interface MessageRowProps {
@@ -175,10 +176,10 @@ export function MessageRow({
   const contentWithTags = useMemo(() => {
     return onTagPress
       ? linkifyDescription(
-          cleanUserTextInput(content),
+          limitLineBreaks(cleanUserTextInput(content)),
           "font-bold text-xs text-gray-900 dark:text-gray-100"
         )
-      : cleanUserTextInput(content);
+      : limitLineBreaks(cleanUserTextInput(content));
   }, [content, onTagPress]);
 
   const userNameText = useMemo(() => {

--- a/packages/app/utilities.ts
+++ b/packages/app/utilities.ts
@@ -660,3 +660,15 @@ export const contentFitToresizeMode = (resizeMode: ImageResizeMode) => {
       return ResizeMode.STRETCH;
   }
 };
+
+export const cleanUserTextInput = (text: string) => {
+  return (
+    text
+      // normalize line breaks
+      .replace(/\r\n|\r|\n/g, "\n")
+      // remove extra line breaks (more than 1)
+      .replace(/(\n){2,}/g, "\n")
+      // remove leading and trailing line breaks and whitespace
+      .trim()
+  );
+};

--- a/packages/app/utilities.ts
+++ b/packages/app/utilities.ts
@@ -667,8 +667,21 @@ export const cleanUserTextInput = (text: string) => {
       // normalize line breaks
       .replace(/\r\n|\r|\n/g, "\n")
       // remove extra line breaks (more than 1)
-      .replace(/(\n){2,}/g, "\n")
+      .replace(/(\n){3,}/g, "\n")
       // remove leading and trailing line breaks and whitespace
       .trim()
   );
+};
+
+export const limitLineBreaks = (
+  text: string,
+  maxLineBreaks: number = 5,
+  separator: string = " "
+) => {
+  return text
+    .split("\n")
+    .slice(0, maxLineBreaks)
+    .concat(text.split("\n").slice(maxLineBreaks).join(separator).trim())
+    .join("\n")
+    .trim();
 };


### PR DESCRIPTION
# Why

The comments section had some flaws. One could spam infinite line-breaks and whitespaces before and after a comment. This could cause really terrible comment inputs and white-spaces.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

I think I’ve come up with something smart to allow line breaks, but limit them to a maximum of two consecutive line breaks. The overall number of line breaks in the entire text is limited to 5. This neat algorithm will prevent excessive line breaks in comments, while still allowing for limited paragraph breaks. Additionally, the maximum text output is limited to 500 characters. If you need longer text, let me know.

Furthermore the TextInput on native was growing unlimited.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

| Input before  | Input after |
| ------------- | ------------- |
| ![simulator_screenshot_649B188A-E0E1-424F-909B-60EA61A83E48](https://user-images.githubusercontent.com/504909/218339452-31b6ba5d-550f-47ed-bc53-18374f6e42a3.png)  | ![Simulator Screen Shot - iPhone 14 Pro Max - 2023-02-12 at 22 52 06](https://user-images.githubusercontent.com/504909/218339484-6f4de31f-b00d-4ea8-b021-a05b39fce31d.png) |


| Before | After |
| ------------- | ------------- |
| ![Simulator Screen Shot - iPhone 14 Pro Max - 2023-02-12 at 22 55 13](https://user-images.githubusercontent.com/504909/218339602-1154ea3a-3568-4752-a2aa-0bfeed59dec0.png) | ![Simulator Screen Shot - iPhone 14 Pro Max - 2023-02-12 at 22 55 40](https://user-images.githubusercontent.com/504909/218339608-4d5330a4-4438-431f-baad-96f9fc7bad37.png) |










