### PR TITLE
deps: update react-native-screen

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -53,7 +53,7 @@
     },
     "clamp-text": {
         "scope": "showtime.universal",
-        "version": "0.0.40",
+        "version": "0.0.41",
         "mainFile": "index.ts",
         "rootDir": "packages/design-system/clamp-text"
     },

--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -201,7 +201,7 @@
     "react-native-reanimated": "~2.14.4",
     "react-native-reanimated-carousel": "^3.1.5",
     "react-native-safe-area-context": "4.5.0",
-    "react-native-screens": "3.18.0",
+    "react-native-screens": "^3.20.0",
     "react-native-share": "8.0.0",
     "react-native-spotify-remote": "file:../../react-native-spotify-remote.tgz",
     "react-native-svg": "13.8.0",

--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -78,7 +78,7 @@
     "@showtime-xyz/universal.button": "^0.0.85",
     "@showtime-xyz/universal.checkbox": "^0.0.73",
     "@showtime-xyz/universal.chip": "^0.0.16",
-    "@showtime-xyz/universal.clamp-text": "^0.0.40",
+    "@showtime-xyz/universal.clamp-text": "^0.0.41",
     "@showtime-xyz/universal.collapsible-tab-view": "^0.0.56",
     "@showtime-xyz/universal.color-scheme": "^0.0.46",
     "@showtime-xyz/universal.country-code-picker": "^0.0.98",

--- a/apps/storybook-react-native/package.json
+++ b/apps/storybook-react-native/package.json
@@ -71,7 +71,7 @@
     "react-native-randombytes": "^3.6.1",
     "react-native-reanimated": "~2.14.4",
     "react-native-safe-area-context": "4.5.0",
-    "react-native-screens": "3.19.0",
+    "react-native-screens": "3.20.0",
     "react-native-svg": "13.8.0",
     "react-native-web": "0.18.9",
     "three": "^0.142.0"

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "eth-block-tracker": "4.4.3",
     "next": "^13.1.1",
     "react-native-spotify-remote": "file:./react-native-spotify-remote.tgz",
-    "react-native-screens": "3.19.0",
+    "react-native-screens": "3.20.0",
     "react-native-mmkv": "2.5.1"
   },
   "react-native": {

--- a/packages/app/navigation/root-stack-navigator.tsx
+++ b/packages/app/navigation/root-stack-navigator.tsx
@@ -129,7 +129,8 @@ export function RootStackNavigator() {
         screenOptions={{
           headerShown: false,
           animation: Platform.OS === "ios" ? "default" : "none",
-          presentation: Platform.OS === "ios" ? "modal" : "transparentModal",
+          presentation:
+            Platform.OS === "ios" ? "formSheet" : "transparentModal",
         }}
       >
         <Stack.Screen name="login" component={LoginScreen} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -9167,7 +9167,7 @@ __metadata:
     react-native-reanimated: ~2.14.4
     react-native-reanimated-carousel: ^3.1.5
     react-native-safe-area-context: 4.5.0
-    react-native-screens: 3.18.0
+    react-native-screens: ^3.20.0
     react-native-share: 8.0.0
     react-native-spotify-remote: "file:../../react-native-spotify-remote.tgz"
     react-native-svg: 13.8.0
@@ -9335,7 +9335,7 @@ __metadata:
     react-native-randombytes: ^3.6.1
     react-native-reanimated: ~2.14.4
     react-native-safe-area-context: 4.5.0
-    react-native-screens: 3.19.0
+    react-native-screens: 3.20.0
     react-native-svg: 13.8.0
     react-native-web: 0.18.9
     three: ^0.142.0
@@ -33042,16 +33042,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-screens@npm:3.19.0":
-  version: 3.19.0
-  resolution: "react-native-screens@npm:3.19.0"
+"react-native-screens@npm:3.20.0":
+  version: 3.20.0
+  resolution: "react-native-screens@npm:3.20.0"
   dependencies:
     react-freeze: ^1.0.0
     warn-once: ^0.1.0
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 3a0116bf0628a735bdb87d7e4648f4bbac278152599a2bdd973e4dec92f87cb2c805dd7adb844d01236c7c92bab017ea8de59bea44d9f58397fddb6f9f3077c5
+  checksum: 94ab21378ee82765d329ccb8c92f5ca7cb15df916496fac7ce9a03c45e22579715000dae9c16f0a7d734a8fc1c2d0569fd82ecb71119a0b56046b5ea7533e7c2
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8257,9 +8257,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@showtime-xyz/universal.clamp-text@npm:^0.0.40":
-  version: 0.0.40
-  resolution: "@showtime-xyz/universal.clamp-text@npm:0.0.40"
+"@showtime-xyz/universal.clamp-text@npm:^0.0.41":
+  version: 0.0.41
+  resolution: "@showtime-xyz/universal.clamp-text@npm:0.0.41"
   dependencies:
     "@showtime-xyz/universal.text": 0.0.57
     "@storybook/react": 6.5.16
@@ -8268,7 +8268,7 @@ __metadata:
     react-dom: ^16.8.0 || ^17.0.0
     react-native: ^0.64.1
     react-native-web: ^0.16.0
-  checksum: e36a1b1e2bd196bc4ee00358c711c6d0eb11c0842239eee43cebe53863522feb0f6321aa07a4e9d6fc313b6c5d981fed6f9c73c5369eacbd224775779310908c
+  checksum: d2dade2a5fda1596c45cfbfc849dd61b09b21dafeb3fd9eeaef9e3ac86188d1d4b2e5f3a9254480d87dbc0ef405fbc69473bccc9891039545492af1173540ce9
   languageName: node
   linkType: hard
 
@@ -9023,7 +9023,7 @@ __metadata:
     "@showtime-xyz/universal.button": ^0.0.85
     "@showtime-xyz/universal.checkbox": ^0.0.73
     "@showtime-xyz/universal.chip": ^0.0.16
-    "@showtime-xyz/universal.clamp-text": ^0.0.40
+    "@showtime-xyz/universal.clamp-text": ^0.0.41
     "@showtime-xyz/universal.collapsible-tab-view": ^0.0.56
     "@showtime-xyz/universal.color-scheme": ^0.0.46
     "@showtime-xyz/universal.country-code-picker": ^0.0.98


### PR DESCRIPTION
# Why
since react-native-screen `v3.20.0` was released and the `formSheet` prop got [fixed](https://github.com/software-mansion/react-native-screens/issues/1686#issuecomment-1427582416) we should update it! 

# Test Video

https://user-images.githubusercontent.com/37520667/218464149-95bb61a5-d856-42d4-a0a4-447fef29bd88.mp4

