### PR TITLE
feat: allow updates in design-system with bit watch

### DIFF
--- a/apps/next/next.config.js
+++ b/apps/next/next.config.js
@@ -180,6 +180,15 @@ const nextConfig = {
       })
     );
 
+    // this little neat function will allow us to use `bit watch` in dev and change the code from design system without
+    // restarting next or clearing the next cache
+    config.snapshot = {
+      ...(config.snapshot ?? {}),
+      // Add all node_modules but @showtime-xyz module to managedPaths
+      // Allows for hot refresh of changes to @showtime-xyz module
+      managedPaths: [/^(.+?[\\/]node_modules[\\/])(?!@showtime-xyz)/],
+    };
+
     return config;
   },
   typescript: {


### PR DESCRIPTION
# Why

Updating anything in the design system while imported from @showtime-xyz/universal requires clearing the cache with .next and restarting the server on the web

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Thanks to this [awesome comment](https://github.com/vercel/next.js/discussions/33929#discussioncomment-2710035), we can finally run `bit watch` and just update and get instant results. @Robert-Schirmer made my day!

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
