### PR TITLE
fix: listemptycomponent breaking tabs

### DIFF
--- a/packages/app/components/comments/index.tsx
+++ b/packages/app/components/comments/index.tsx
@@ -153,10 +153,11 @@ export function Comments({ nft, webListHeight }: CommentsProps) {
   const listEmptyComponent = useCallback(
     () =>
       !isLoading && !error && !dataReversed.length ? (
-        <View tw="absolute -mt-10 h-full w-full flex-1 items-center justify-center">
+        <View tw="absolute h-full w-full flex-1 items-center justify-center">
           <EmptyPlaceholder
             text="Be the first to add a comment!"
             title="💬 No comments yet..."
+            tw="-mt-20"
           />
         </View>
       ) : null,
@@ -172,7 +173,6 @@ export function Comments({ nft, webListHeight }: CommentsProps) {
         <CommentsStatus isLoading={isLoading} error={error} />
       ) : (
         <View tw="web:pt-4 flex-1">
-          {listEmptyComponent()}
           <InfiniteScrollList
             data={dataReversed}
             refreshing={isLoading}
@@ -188,6 +188,7 @@ export function Comments({ nft, webListHeight }: CommentsProps) {
             contentContainerStyle={styles.contentContainer}
             {...modalListProps}
           />
+          {listEmptyComponent()}
           {isAuthenticated && (
             <PlatformInputAccessoryView
               {...Platform.select({

--- a/packages/app/components/comments/index.tsx
+++ b/packages/app/components/comments/index.tsx
@@ -153,7 +153,7 @@ export function Comments({ nft, webListHeight }: CommentsProps) {
   const listEmptyComponent = useCallback(
     () =>
       !isLoading && !error && !dataReversed.length ? (
-        <View tw="pointer-events-none absolute -mt-10 h-full w-full flex-1 items-center justify-center">
+        <View tw="absolute -mt-10 h-full w-full flex-1 items-center justify-center">
           <EmptyPlaceholder
             text="Be the first to add a comment!"
             title="💬 No comments yet..."

--- a/packages/app/components/comments/index.tsx
+++ b/packages/app/components/comments/index.tsx
@@ -153,7 +153,7 @@ export function Comments({ nft, webListHeight }: CommentsProps) {
   const listEmptyComponent = useCallback(
     () =>
       !isLoading && !error && !dataReversed.length ? (
-        <View tw="absolute -mt-10 h-full w-full flex-1 items-center justify-center">
+        <View tw="pointer-events-none absolute -mt-10 h-full w-full flex-1 items-center justify-center">
           <EmptyPlaceholder
             text="Be the first to add a comment!"
             title="💬 No comments yet..."

--- a/packages/design-system/tab-view/tab-bar-single.tsx
+++ b/packages/design-system/tab-view/tab-bar-single.tsx
@@ -41,10 +41,7 @@ export const TabBarSingle = memo<IndependentTabBarProps>(
 
     return (
       <View
-        tw={[
-          "no-scrollbar z-[1] flex-row overflow-x-auto overflow-y-hidden",
-          tw,
-        ]}
+        tw={["no-scrollbar flex-row overflow-x-auto overflow-y-hidden", tw]}
       >
         {routes.map((item, index) => (
           <PressableHover

--- a/packages/design-system/tab-view/tab-bar-single.tsx
+++ b/packages/design-system/tab-view/tab-bar-single.tsx
@@ -41,7 +41,10 @@ export const TabBarSingle = memo<IndependentTabBarProps>(
 
     return (
       <View
-        tw={["no-scrollbar flex-row overflow-x-auto overflow-y-hidden", tw]}
+        tw={[
+          "no-scrollbar z-[1] flex-row overflow-x-auto overflow-y-hidden",
+          tw,
+        ]}
       >
         {routes.map((item, index) => (
           <PressableHover


### PR DESCRIPTION
# Why

-mt-10 caused list empty component in comments overlap the tabs, making it non clickable.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Removed pointer events.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="418" alt="Bildschirm­foto 2023-02-13 um 17 33 52" src="https://user-images.githubusercontent.com/504909/218516787-4d63ff5a-7a67-4000-842a-af4f33d0a154.png">
