### PR TITLE
feat: add collapsible to GH actions

### DIFF
--- a/.github/workflows/expo-preview.yml
+++ b/.github/workflows/expo-preview.yml
@@ -97,8 +97,14 @@ jobs:
 
             This pull request preview deployment is now available.
 
-            ✅ Preview: <a href="${{ steps.publish-url.outputs.url }}">${{ steps.publish-url.outputs.url }}</a>
+            <details>
+              <summary>Open Details</summary>
 
-            <a href="${{ steps.publish-url.outputs.url }}"><img src="https://api.qrserver.com/v1/create-qr-code/?size=512x512&data=${{ steps.publish-url.outputs.url }}" height="512px" width="512px" /></a>
 
-            Comment ID: ${{ steps.existing-comment.outputs.comment-id }}
+              ✅ Preview: <a href="${{ steps.publish-url.outputs.url }}">${{ steps.publish-url.outputs.url }}</a>
+
+              <a href="${{ steps.publish-url.outputs.url }}"><img src="https://api.qrserver.com/v1/create-qr-code/?size=512x512&data=${{ steps.publish-url.outputs.url }}" height="256px" width="256px" /></a>
+
+              Comment ID: ${{ steps.existing-comment.outputs.comment-id }}
+            </details>
+

--- a/.github/workflows/expo-storybook-preview.yml
+++ b/.github/workflows/expo-storybook-preview.yml
@@ -97,8 +97,14 @@ jobs:
 
             This pull request preview deployment is now available.
 
-            ✅ Preview: <a href="${{ steps.publish-url.outputs.url }}">${{ steps.publish-url.outputs.url }}</a>
+            <details>
+              <summary>Open Details</summary>
 
-            <a href="${{ steps.publish-url.outputs.url }}"><img src="https://api.qrserver.com/v1/create-qr-code/?size=512x512&data=${{ steps.publish-url.outputs.url }}" height="512px" width="512px" /></a>
 
-            Comment ID: ${{ steps.existing-comment.outputs.comment-id }}
+              ✅ Preview: <a href="${{ steps.publish-url.outputs.url }}">${{ steps.publish-url.outputs.url }}</a>
+
+              <a href="${{ steps.publish-url.outputs.url }}"><img src="https://api.qrserver.com/v1/create-qr-code/?size=512x512&data=${{ steps.publish-url.outputs.url }}" height="256px" width="256px" /></a>
+
+              Comment ID: ${{ steps.existing-comment.outputs.comment-id }}
+            </details>
+


### PR DESCRIPTION
# Why

Currently, the text messages generated by our actions are huge and distracting a bit from reading the comments.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Hide the QR codes behind collapsibles and make them a bit smaller

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
