### PR TITLE
fix: notification time darkmode

### DIFF
--- a/packages/app/components/notifications/notification-item.tsx
+++ b/packages/app/components/notifications/notification-item.tsx
@@ -115,7 +115,7 @@ const NotificationDescription = memo(
           <NFTSDisplayName nfts={notification.nfts} />
         </Text>
         {Boolean(formatDistance) && (
-          <Text tw="text-13">{`${formatDistance}`}</Text>
+          <Text tw="text-13 dark:text-white">{`${formatDistance}`}</Text>
         )}
       </View>
     );


### PR DESCRIPTION
# Why

Notification create date was invisible in dark mode.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Added text-white for dark mode.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->


<img width="479" alt="Bildschirm­foto 2023-02-13 um 22 03 54" src="https://user-images.githubusercontent.com/504909/218574324-27876de5-04e3-4719-8b03-cf5086ea6495.png">
<img width="484" alt="Bildschirm­foto 2023-02-13 um 22 01 24" src="https://user-images.githubusercontent.com/504909/218574334-6cea0186-dbff-49d1-a015-503aeb923fde.png">
