### PR TITLE
fix: remove nft title and desc escaping

### DIFF
--- a/packages/app/hooks/use-drop-nft.ts
+++ b/packages/app/hooks/use-drop-nft.ts
@@ -196,17 +196,11 @@ export const useDropNFT = () => {
         return;
       }
 
-      const escapedTitle = JSON.stringify(params.title).slice(1, -1);
-      const escapedDescription = JSON.stringify(params.description).slice(
-        1,
-        -1
-      );
-
       Logger.log("ipfs hash ", {
         ipfsHash,
         params,
-        escapedTitle,
-        escapedDescription,
+        title: params.title,
+        description: params.description,
       });
 
       const isPasswordGated = params.password;
@@ -236,8 +230,8 @@ export const useDropNFT = () => {
         : {};
 
       let requestData: DropRequestData = {
-        name: escapedTitle,
-        description: escapedDescription,
+        name: params.title,
+        description: params.description,
         image_url: "ipfs://" + ipfsHash,
         edition_size: params.editionSize,
         royalty_bps: params.royalty * 100,


### PR DESCRIPTION
# Why

We need to remove an old hack, since it will be handled from contract.
https://showtime-rq88331.slack.com/archives/C02PXGK3V8D/p1676305085989649

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Reverted  https://github.com/showtime-xyz/showtime-frontend/pull/1260
We need to wait before we merge, because @jorgeavaldez needs to address this in the backend first.

https://linear.app/showtime/issue/SHOW2-1527/when-fetching-edition-details-properly-handle-unescaped-strings-in

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
