### PR TITLE
feat: add new notification types

### DIFF
--- a/packages/app/components/notifications/nfts-display-name.tsx
+++ b/packages/app/components/notifications/nfts-display-name.tsx
@@ -52,3 +52,13 @@ export const NFTSDisplayName = ({ nfts }: NotificationDescriptionProps) => {
     </>
   );
 };
+
+export const NFTSDisplayNameText = ({ nfts }: NotificationDescriptionProps) => {
+  if (!nfts || nfts?.length === 0) return null;
+  const nft = nfts[0];
+  return (
+    <Text tw="text-13 font-bold text-black dark:text-white">
+      {nft.display_name}
+    </Text>
+  );
+};

--- a/packages/app/components/notifications/notification-item.tsx
+++ b/packages/app/components/notifications/notification-item.tsx
@@ -8,6 +8,7 @@ import {
   MessageFilled,
   PlusFilled,
   GiftSolid,
+  Spotify,
 } from "@showtime-xyz/universal.icon";
 import { colors } from "@showtime-xyz/universal.tailwind";
 import { Text } from "@showtime-xyz/universal.text";
@@ -19,7 +20,8 @@ import { Actor, NotificationType } from "app/hooks/use-notifications";
 import { useUser } from "app/hooks/use-user";
 import { getFormatDistanceStrictToWeek } from "app/utilities";
 
-import { NFTSDisplayName } from "./nfts-display-name";
+import { NFTSDisplayName, NFTSDisplayNameText } from "./nfts-display-name";
+import { UpdateSpotifyDetails } from "./update-spotify-details";
 
 export type NotificationItemProp = {
   notification: NotificationType;
@@ -39,6 +41,11 @@ const NOTIFICATION_TYPE_COPY = new Map([
   ["CLAIMED_CREATOR_AIRDROP_FROM_FOLLOWING", "collected "],
   ["CREATED_EDITION_SOLD_OUT", "Your drop sold out: "],
   ["CREATED_EDITION_EXPIRED", "Your drop expired: "],
+  [
+    "MISSING_MUSIC_RELEASE_METADATA",
+    "Spotify song link to notify your fans the song is out. ",
+  ],
+  ["RELEASE_SAVED_TO_SPOTIFY", "is out! Check it out now."],
 ]);
 
 export const NotificationItem = memo(
@@ -104,6 +111,42 @@ const NotificationDescription = memo(
       notification.to_timestamp
     );
 
+    if (notification.type_name === "MISSING_MUSIC_RELEASE_METADATA") {
+      return (
+        <UpdateSpotifyDetails nfts={notification.nfts}>
+          <View tw="flex-1 flex-row justify-between">
+            <Text
+              tw="text-13 web:max-w-[80%] mr-4 max-w-[70vw] self-center text-gray-600 dark:text-gray-400"
+              ellipsizeMode="tail"
+            >
+              Tap here to enter <NFTSDisplayNameText nfts={notification.nfts} />{" "}
+              {NOTIFICATION_TYPE_COPY.get(notification.type_name)}
+            </Text>
+            {Boolean(formatDistance) && (
+              <Text tw="text-13 dark:text-white">{`${formatDistance}`}</Text>
+            )}
+          </View>
+        </UpdateSpotifyDetails>
+      );
+    }
+
+    if (notification.type_name === "RELEASE_SAVED_TO_SPOTIFY") {
+      return (
+        <View tw="flex-1 flex-row justify-between">
+          <Text
+            tw="text-13 web:max-w-[80%] mr-4 max-w-[70vw] self-center text-gray-600 dark:text-gray-400"
+            ellipsizeMode="tail"
+          >
+            <NFTSDisplayName nfts={notification.nfts} />{" "}
+            {NOTIFICATION_TYPE_COPY.get("RELEASE_SAVED_TO_SPOTIFY")}
+          </Text>
+          {Boolean(formatDistance) && (
+            <Text tw="text-13 dark:text-white">{`${formatDistance}`}</Text>
+          )}
+        </View>
+      );
+    }
+
     return (
       <View tw="flex-1 flex-row justify-between">
         <Text
@@ -115,7 +158,7 @@ const NotificationDescription = memo(
           <NFTSDisplayName nfts={notification.nfts} />
         </Text>
         {Boolean(formatDistance) && (
-          <Text tw="text-13">{`${formatDistance}`}</Text>
+          <Text tw="text-13 dark:text-white">{`${formatDistance}`}</Text>
         )}
       </View>
     );
@@ -156,6 +199,10 @@ export const getNotificationIcon = (type_name: string) => {
       return <GiftSolid width={20} height={20} color={colors.rose[500]} />;
     case "CREATED_EDITION_EXPIRED":
       return <GiftSolid width={20} height={20} color={colors.gray[500]} />;
+    case "MISSING_MUSIC_RELEASE_METADATA":
+    case "RELEASE_SAVED_TO_SPOTIFY":
+      return <Spotify width={20} height={20} color={"#1DB954"} />;
+
     default:
       return undefined;
   }

--- a/packages/app/components/notifications/update-spotify-details.tsx
+++ b/packages/app/components/notifications/update-spotify-details.tsx
@@ -1,0 +1,22 @@
+import { NotificationNFT } from "app/hooks/use-notifications";
+import { Link } from "app/navigation/link";
+
+type NotificationDescriptionProps = {
+  nfts: NotificationNFT[];
+  children: React.ReactNode;
+};
+
+export const UpdateSpotifyDetails = ({
+  nfts,
+  children,
+}: NotificationDescriptionProps) => {
+  if (!nfts || nfts?.length === 0) return null;
+
+  const nft = nfts[0];
+
+  return (
+    <Link href={"/drop/update/" + nft.contract_address} tw={"flex-1"}>
+      {children}
+    </Link>
+  );
+};


### PR DESCRIPTION
# Why

We have two new notification types. Added those to the notification.
https://showtime-rq88331.slack.com/archives/C02QD3J7DJM/p1675987736390959

Supersedes #1858

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Added new notification types (one to update metadata when spotify link is missing and the other when a song was released.
@alantoa @intergalacticspacehighway I think we also need to add new Notification settings. Could someone please take care of that? Not sure if we actually have those already. 

ID 13 = MISSING_MUSIC_RELEASE_METADATA
ID 14 = RELEASE_SAVED_TO_SPOTIFY

I had to change the NotificationItem, because these ones are new and need special handling.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="403" alt="Bildschirm_foto 2023-02-14 um 02 15 46" src="https://user-images.githubusercontent.com/504909/218613794-353edbf3-5094-44f9-b2f1-8ef4b361309a.png">

<img width="430" alt="Bildschirm­foto 2023-02-14 um 02 23 23" src="https://user-images.githubusercontent.com/504909/218613818-58dd3014-49a9-4d62-ba7d-e0978bc41266.png">


