### PR TITLE
fix: form draft persistence and file saving support

### DIFF
--- a/packages/app/components/drop/drop-event.tsx
+++ b/packages/app/components/drop/drop-event.tsx
@@ -313,6 +313,8 @@ export const DropEvent = () => {
                       errorText={errors.title?.message}
                       value={value}
                       onChangeText={onChange}
+                      numberOfLines={2}
+                      multiline
                     />
                   );
                 }}

--- a/packages/app/components/drop/drop-event.tsx
+++ b/packages/app/components/drop/drop-event.tsx
@@ -40,7 +40,6 @@ import { DropFileZone } from "app/lib/drop-file-zone";
 import { FilePickerResolveValue, useFilePicker } from "app/lib/file-picker";
 import { useBottomTabBarHeight } from "app/lib/react-navigation/bottom-tabs";
 import { useHeaderHeight } from "app/lib/react-navigation/elements";
-import { useRudder } from "app/lib/rudderstack";
 import { yup } from "app/lib/yup";
 import { formatAddressShort } from "app/utilities";
 
@@ -71,10 +70,8 @@ const DROP_FORM_DATA_KEY = "drop_form_local_data_event";
 
 export const DropEvent = () => {
   const isDark = useIsDarkMode();
-  const { rudder } = useRudder();
   const { data: userProfile } = useMyInfo();
   const maxEditionSize = userProfile?.data?.profile.verified ? 100000 : 50;
-  const defaultEditionSize = defaultValues.editionSize;
   const dropValidationSchema = useMemo(
     () =>
       yup.object({
@@ -90,7 +87,7 @@ export const DropEvent = () => {
             maxEditionSize,
             `You can drop ${maxEditionSize} editions at most`
           )
-          .default(defaultEditionSize),
+          .default(defaultValues.editionSize),
         royalty: yup
           .number()
           .required()
@@ -106,7 +103,7 @@ export const DropEvent = () => {
         googleMapsUrl: yup.string().url(),
         radius: yup.number().min(0.01).max(10),
       }),
-    [defaultEditionSize, maxEditionSize]
+    [maxEditionSize]
   );
   const {
     control,
@@ -120,10 +117,6 @@ export const DropEvent = () => {
     resolver: yupResolver(dropValidationSchema),
     mode: "onBlur",
     reValidateMode: "onChange",
-    defaultValues: {
-      ...defaultValues,
-      editionSize: defaultEditionSize,
-    },
   });
 
   const bottomBarHeight = useBottomTabBarHeight();
@@ -140,13 +133,7 @@ export const DropEvent = () => {
   const { clearStorage } = usePersistForm(DROP_FORM_DATA_KEY, {
     watch,
     setValue,
-    /**
-     * Todo: use Context to draft file data, because use localStoge max size generally <= 5mb, so exclude `file` field first
-     */
-    exclude: Platform.select({
-      web: ["file"],
-      default: [],
-    }),
+    defaultValues,
   });
 
   const onSubmit = (values: UseDropNFT) => {

--- a/packages/app/components/drop/drop-event.tsx
+++ b/packages/app/components/drop/drop-event.tsx
@@ -250,7 +250,7 @@ export const DropEvent = () => {
                               file={value}
                               width={windowWidth >= 768 ? 256 : 120}
                               height={windowWidth >= 768 ? 256 : 120}
-                              style={{ borderRadius: 16 }}
+                              tw="rounded-2xl"
                             />
                             <View tw="absolute h-full w-full items-center justify-center">
                               <View tw="flex-row items-center shadow-lg">

--- a/packages/app/components/drop/drop-free.tsx
+++ b/packages/app/components/drop/drop-free.tsx
@@ -225,7 +225,7 @@ export const DropFree = () => {
                               file={value}
                               width={windowWidth >= 768 ? 256 : 120}
                               height={windowWidth >= 768 ? 256 : 120}
-                              style={{ borderRadius: 16 }}
+                              tw="rounded-2xl"
                             />
                             <View tw="absolute h-full w-full items-center justify-center">
                               <View tw="flex-row items-center shadow-lg">

--- a/packages/app/components/drop/drop-free.tsx
+++ b/packages/app/components/drop/drop-free.tsx
@@ -136,25 +136,7 @@ export const DropFree = () => {
     dropNFT(values, clearStorage);
   };
 
-  // useEffect(() => {
-  //   if (transactionId) {
-  //     pollTransaction(transactionId)
-  //   }
-  // }, [transactionId])
-
-  // useEffect(() => {
-  //   if (state.transactionId) {
-  //     setTransactionId(transactionId)
-  //   }
-  // }, [state.transactionId])
-
   const pickFile = useFilePicker();
-
-  // if (state.transactionHash) {
-  //   return <View>
-  //     <Text>Loading</Text>
-  //   </View>
-  // }
 
   const selectedDuration = watch("duration");
 

--- a/packages/app/components/drop/drop-free.tsx
+++ b/packages/app/components/drop/drop-free.tsx
@@ -18,7 +18,6 @@ import { ErrorText, Fieldset } from "@showtime-xyz/universal.fieldset";
 import { useIsDarkMode } from "@showtime-xyz/universal.hooks";
 import { FlipIcon, Image as ImageIcon } from "@showtime-xyz/universal.icon";
 import { Pressable } from "@showtime-xyz/universal.pressable";
-import { useRouter } from "@showtime-xyz/universal.router";
 import { ScrollView } from "@showtime-xyz/universal.scroll-view";
 import { Text } from "@showtime-xyz/universal.text";
 import { View } from "@showtime-xyz/universal.view";
@@ -31,16 +30,13 @@ import { Preview } from "app/components/preview";
 import { QRCodeModal } from "app/components/qr-code";
 import { useMyInfo } from "app/hooks/api-hooks";
 import { MAX_FILE_SIZE, UseDropNFT, useDropNFT } from "app/hooks/use-drop-nft";
-import { useModalScreenViewStyle } from "app/hooks/use-modal-screen-view-style";
 import { usePersistForm } from "app/hooks/use-persist-form";
 import { useRedirectToCreateDrop } from "app/hooks/use-redirect-to-create-drop";
-import { useShare } from "app/hooks/use-share";
 import { useUser } from "app/hooks/use-user";
 import { DropFileZone } from "app/lib/drop-file-zone";
 import { FilePickerResolveValue, useFilePicker } from "app/lib/file-picker";
 import { useBottomTabBarHeight } from "app/lib/react-navigation/bottom-tabs";
 import { useHeaderHeight } from "app/lib/react-navigation/elements";
-import { useRudder } from "app/lib/rudderstack";
 import { yup } from "app/lib/yup";
 import { formatAddressShort } from "app/utilities";
 
@@ -68,10 +64,8 @@ const defaultValues = {
 };
 export const DropFree = () => {
   const isDark = useIsDarkMode();
-  const { rudder } = useRudder();
   const { data: userProfile } = useMyInfo();
   const maxEditionSize = userProfile?.data?.profile.verified ? 100000 : 50;
-  const defaultEditionSize = defaultValues.editionSize;
   const dropValidationSchema = useMemo(
     () =>
       yup.object({
@@ -87,7 +81,7 @@ export const DropFree = () => {
             maxEditionSize,
             `You can drop ${maxEditionSize} editions at most`
           )
-          .default(defaultEditionSize),
+          .default(defaultValues.editionSize),
         royalty: yup
           .number()
           .required()
@@ -103,7 +97,7 @@ export const DropFree = () => {
         googleMapsUrl: yup.string().url(),
         radius: yup.number().min(0.01).max(10),
       }),
-    [maxEditionSize, defaultEditionSize]
+    [maxEditionSize]
   );
 
   const {
@@ -118,10 +112,6 @@ export const DropFree = () => {
     resolver: yupResolver(dropValidationSchema),
     mode: "onBlur",
     reValidateMode: "onChange",
-    defaultValues: {
-      ...defaultValues,
-      editionSize: defaultEditionSize,
-    },
   });
 
   const bottomBarHeight = useBottomTabBarHeight();
@@ -139,13 +129,7 @@ export const DropFree = () => {
   const { clearStorage } = usePersistForm(DROP_FORM_DATA_KEY, {
     watch,
     setValue,
-    /**
-     * Todo: use Context to draft file data, because use localStoge max size generally <= 5mb, so exclude `file` field first
-     */
-    exclude: Platform.select({
-      web: ["file"],
-      default: [],
-    }),
+    defaultValues,
   });
 
   const onSubmit = (values: UseDropNFT) => {
@@ -165,9 +149,6 @@ export const DropFree = () => {
   // }, [state.transactionId])
 
   const pickFile = useFilePicker();
-  const share = useShare();
-  const router = useRouter();
-  const modalScreenViewStyle = useModalScreenViewStyle({ mode: "margin" });
 
   // if (state.transactionHash) {
   //   return <View>

--- a/packages/app/components/drop/drop-free.tsx
+++ b/packages/app/components/drop/drop-free.tsx
@@ -288,6 +288,8 @@ export const DropFree = () => {
                       errorText={errors.title?.message}
                       value={value}
                       onChangeText={onChange}
+                      numberOfLines={2}
+                      multiline
                     />
                   );
                 }}

--- a/packages/app/components/drop/drop-music.tsx
+++ b/packages/app/components/drop/drop-music.tsx
@@ -349,6 +349,8 @@ export const DropMusic = () => {
                       errorText={errors.title?.message}
                       value={value}
                       onChangeText={onChange}
+                      numberOfLines={2}
+                      multiline
                     />
                   );
                 }}

--- a/packages/app/components/drop/drop-music.tsx
+++ b/packages/app/components/drop/drop-music.tsx
@@ -130,7 +130,6 @@ export const DropMusic = () => {
     resolver: yupResolver(dropValidationSchema),
     mode: "onBlur",
     reValidateMode: "onChange",
-    defaultValues: defaultValues,
   });
 
   const bottomBarHeight = useBottomTabBarHeight();
@@ -154,13 +153,7 @@ export const DropMusic = () => {
   const { clearStorage } = usePersistForm(DROP_FORM_DATA_KEY, {
     watch,
     setValue,
-    /**
-     * Todo: use Context to draft file data, because use localStoge max size generally <= 5mb, so exclude `file` field first
-     */
-    exclude: Platform.select({
-      web: ["file"],
-      default: [],
-    }),
+    defaultValues,
   });
 
   const onSubmit = async (values: UseDropNFT) => {

--- a/packages/app/components/drop/drop-music.tsx
+++ b/packages/app/components/drop/drop-music.tsx
@@ -286,7 +286,7 @@ export const DropMusic = () => {
                               file={value}
                               width={windowWidth >= 768 ? 256 : 120}
                               height={windowWidth >= 768 ? 256 : 120}
-                              style={{ borderRadius: 16 }}
+                              tw="rounded-2xl"
                             />
                             <View tw="absolute h-full w-full items-center justify-center">
                               <View tw="flex-row items-center shadow-lg">

--- a/packages/app/components/drop/drop-private.tsx
+++ b/packages/app/components/drop/drop-private.tsx
@@ -250,7 +250,7 @@ export const DropPrivate = () => {
                               file={value}
                               width={windowWidth >= 768 ? 256 : 120}
                               height={windowWidth >= 768 ? 256 : 120}
-                              style={{ borderRadius: 16 }}
+                              tw="rounded-2xl"
                             />
                             <View tw="absolute h-full w-full items-center justify-center">
                               <View tw="flex-row items-center shadow-lg">

--- a/packages/app/components/drop/drop-private.tsx
+++ b/packages/app/components/drop/drop-private.tsx
@@ -313,6 +313,8 @@ export const DropPrivate = () => {
                       errorText={errors.title?.message}
                       value={value}
                       onChangeText={onChange}
+                      numberOfLines={2}
+                      multiline
                     />
                   );
                 }}

--- a/packages/app/components/drop/drop-private.tsx
+++ b/packages/app/components/drop/drop-private.tsx
@@ -40,7 +40,6 @@ import { DropFileZone } from "app/lib/drop-file-zone";
 import { FilePickerResolveValue, useFilePicker } from "app/lib/file-picker";
 import { useBottomTabBarHeight } from "app/lib/react-navigation/bottom-tabs";
 import { useHeaderHeight } from "app/lib/react-navigation/elements";
-import { useRudder } from "app/lib/rudderstack";
 import { yup } from "app/lib/yup";
 import { formatAddressShort } from "app/utilities";
 
@@ -71,10 +70,8 @@ const DROP_FORM_DATA_KEY = "drop_form_local_data_private";
 
 export const DropPrivate = () => {
   const isDark = useIsDarkMode();
-  const { rudder } = useRudder();
   const { data: userProfile } = useMyInfo();
   const maxEditionSize = userProfile?.data?.profile.verified ? 100000 : 50;
-  const defaultEditionSize = defaultValues.editionSize;
   const dropValidationSchema = useMemo(
     () =>
       yup.object({
@@ -90,7 +87,7 @@ export const DropPrivate = () => {
             maxEditionSize,
             `You can drop ${maxEditionSize} editions at most`
           )
-          .default(defaultEditionSize),
+          .default(defaultValues.editionSize),
         royalty: yup
           .number()
           .required()
@@ -106,7 +103,7 @@ export const DropPrivate = () => {
         googleMapsUrl: yup.string().url(),
         radius: yup.number().min(0.01).max(10),
       }),
-    [maxEditionSize, defaultEditionSize]
+    [maxEditionSize]
   );
   const {
     control,
@@ -120,10 +117,6 @@ export const DropPrivate = () => {
     resolver: yupResolver(dropValidationSchema),
     mode: "onBlur",
     reValidateMode: "onChange",
-    defaultValues: {
-      ...defaultValues,
-      editionSize: defaultEditionSize,
-    },
   });
 
   const bottomBarHeight = useBottomTabBarHeight();
@@ -140,13 +133,7 @@ export const DropPrivate = () => {
   const { clearStorage } = usePersistForm(DROP_FORM_DATA_KEY, {
     watch,
     setValue,
-    /**
-     * Todo: use Context to draft file data, because use localStoge max size generally <= 5mb, so exclude `file` field first
-     */
-    exclude: Platform.select({
-      web: ["file"],
-      default: [],
-    }),
+    defaultValues,
   });
 
   const onSubmit = (values: UseDropNFT) => {

--- a/packages/app/components/preview/index.tsx
+++ b/packages/app/components/preview/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, memo } from "react";
 import { Platform } from "react-native";
 
 import { Video } from "expo-av";
@@ -23,7 +23,7 @@ type PreviewProps = {
 
 const StyledVideo = styled(Video);
 
-export const Preview = ({
+export const Preview = memo(function Preview({
   tw = "",
   style,
   type,
@@ -31,7 +31,7 @@ export const Preview = ({
   resizeMode = "cover",
   width,
   height,
-}: PreviewProps) => {
+}: PreviewProps) {
   const uri = getLocalFileURI(file);
 
   const fileType = useMemo(() => {
@@ -89,7 +89,7 @@ export const Preview = ({
   }
 
   return null;
-};
+});
 
 export const getLocalFileURI = (file?: string | File) => {
   if (!file) return null;

--- a/packages/app/hooks/use-persist-form.ts
+++ b/packages/app/hooks/use-persist-form.ts
@@ -37,13 +37,15 @@ export const usePersistForm = (
   }: FormPersistConfig
 ) => {
   const watchedValues = watch();
-
-  const clearStorage = () => store.delete(name);
-
   const fileStorage = useMemo(
     () => new FileStorage("persist_db", name),
     [name]
   );
+
+  const clearStorage = () => {
+    store.delete(name);
+    fileStorage.clearStorage();
+  };
 
   useEffect(() => {
     const str = store.getString(name);

--- a/packages/app/hooks/use-persist-form.ts
+++ b/packages/app/hooks/use-persist-form.ts
@@ -33,7 +33,7 @@ export const usePersistForm = (
     dirty = false,
     touch = false,
     onTimeout,
-    timeout,
+    timeout = 86400000,
   }: FormPersistConfig
 ) => {
   const watchedValues = watch();
@@ -54,7 +54,7 @@ export const usePersistForm = (
       const currTimestamp = Date.now();
 
       if (timeout && currTimestamp - _timestamp > timeout) {
-        onTimeout && onTimeout();
+        onTimeout?.();
         clearStorage();
         return;
       }

--- a/packages/app/hooks/use-persist-form.ts
+++ b/packages/app/hooks/use-persist-form.ts
@@ -37,10 +37,7 @@ export const usePersistForm = (
   }: FormPersistConfig
 ) => {
   const watchedValues = watch();
-  const fileStorage = useMemo(
-    () => new FileStorage("persist_db", name),
-    [name]
-  );
+  const fileStorage = useMemo(() => new FileStorage(name), [name]);
 
   const clearStorage = () => {
     store.delete(name);

--- a/packages/app/hooks/use-persist-form.ts
+++ b/packages/app/hooks/use-persist-form.ts
@@ -1,7 +1,9 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 
 import { SetFieldValue } from "react-hook-form";
 import { MMKV } from "react-native-mmkv";
+
+import { FileStorage } from "app/lib/file-storage/file-storage";
 
 const store = new MMKV();
 
@@ -15,6 +17,7 @@ type FormPersistConfig = {
   touch?: boolean;
   onTimeout?: () => void;
   timeout?: number;
+  defaultValues?: { [key: string]: any };
 };
 
 export const usePersistForm = (
@@ -24,63 +27,96 @@ export const usePersistForm = (
     setValue,
     exclude = [],
     onDataRestored,
+    defaultValues,
     validate = false,
     dirty = false,
     touch = false,
     onTimeout,
-    // expire data after 24 hours by default
-    timeout = 86400000,
+    timeout,
   }: FormPersistConfig
 ) => {
   const watchedValues = watch();
+
   const clearStorage = () => store.delete(name);
+
+  const fileStorage = useMemo(
+    () => new FileStorage("persist_db", name),
+    [name]
+  );
 
   useEffect(() => {
     const str = store.getString(name);
+
     if (str) {
       const { _timestamp = null, ...values } = JSON.parse(str);
       const dataRestored: { [key: string]: any } = {};
       const currTimestamp = Date.now();
 
       if (timeout && currTimestamp - _timestamp > timeout) {
-        onTimeout?.();
+        onTimeout && onTimeout();
         clearStorage();
         return;
       }
 
-      Object.keys(values).forEach((key) => {
+      Object.keys(values).forEach(async (key) => {
         const shouldSet = !exclude.includes(key);
         if (shouldSet) {
-          dataRestored[key] = values[key];
-          setValue(key, values[key], {
-            shouldValidate: validate,
-            shouldDirty: dirty,
-            shouldTouch: touch,
-          });
+          if (values[key] === "instanceof File") {
+            try {
+              const file = await fileStorage.getFile(key);
+              setValue(key, file);
+            } catch (e) {
+              console.error(e);
+            }
+          } else {
+            dataRestored[key] = values[key] || defaultValues?.[key];
+            setValue(key, values[key], {
+              shouldValidate: validate,
+              shouldDirty: dirty,
+              shouldTouch: touch,
+            });
+          }
         }
       });
 
       if (onDataRestored) {
         onDataRestored(dataRestored);
       }
+    } else if (defaultValues) {
+      Object.keys(defaultValues).forEach((key) => {
+        const shouldSet = !exclude.includes(key);
+        if (shouldSet) {
+          setValue(key, defaultValues[key], {
+            shouldValidate: validate,
+            shouldDirty: dirty,
+            shouldTouch: touch,
+          });
+        }
+      });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [name, onDataRestored, setValue]);
 
   useEffect(() => {
-    const values = exclude.length
-      ? Object.entries(watchedValues)
-          .filter(([key]) => !exclude.includes(key))
-          .reduce((obj, [key, val]) => Object.assign(obj, { [key]: val }), {})
-      : Object.assign({}, watchedValues);
-
-    if (Object.entries(values).length) {
-      if (timeout !== undefined) {
-        values._timestamp = Date.now();
+    let stringValues: any = {};
+    for (let key in watchedValues) {
+      if (!exclude.includes(key)) {
+        if (watchedValues[key] instanceof File) {
+          fileStorage.saveFile(watchedValues[key], key);
+          stringValues[key] = "instanceof File";
+        } else {
+          stringValues[key] = watchedValues[key];
+        }
       }
-      store.set(name, JSON.stringify(values));
     }
-  }, [watchedValues, timeout, exclude, name]);
+
+    if (Object.keys(stringValues).length) {
+      if (timeout !== undefined) {
+        stringValues._timestamp = Date.now();
+      }
+      store.set(name, JSON.stringify(stringValues));
+    }
+  }, [watchedValues, timeout, exclude, fileStorage, name]);
 
   return {
     clearStorage,

--- a/packages/app/hooks/use-persist-form.ts
+++ b/packages/app/hooks/use-persist-form.ts
@@ -4,6 +4,7 @@ import { SetFieldValue } from "react-hook-form";
 import { MMKV } from "react-native-mmkv";
 
 import { FileStorage } from "app/lib/file-storage/file-storage";
+import { Logger } from "app/lib/logger";
 
 const store = new MMKV();
 
@@ -66,7 +67,7 @@ export const usePersistForm = (
               const file = await fileStorage.getFile(key);
               setValue(key, file);
             } catch (e) {
-              console.error(e);
+              Logger.error(e);
             }
           } else {
             dataRestored[key] = values[key] || defaultValues?.[key];

--- a/packages/app/lib/file-storage/file-storage.ts
+++ b/packages/app/lib/file-storage/file-storage.ts
@@ -1,0 +1,14 @@
+export class FileStorage {
+  private readonly dbName: string;
+  private readonly storeName: string;
+  private db?: IDBDatabase;
+
+  constructor(dbName: string, storeName: string) {
+    this.dbName = dbName;
+    this.storeName = storeName;
+  }
+
+  public async saveFile(file: File, id: string) {}
+
+  public async getFile(id: any) {}
+}

--- a/packages/app/lib/file-storage/file-storage.ts
+++ b/packages/app/lib/file-storage/file-storage.ts
@@ -1,11 +1,9 @@
 export class FileStorage {
   private readonly dbName: string;
-  private readonly storeName: string;
   private db?: IDBDatabase;
 
-  constructor(dbName: string, storeName: string) {
+  constructor(dbName: string) {
     this.dbName = dbName;
-    this.storeName = storeName;
   }
 
   public async saveFile(file: File, id: string) {}

--- a/packages/app/lib/file-storage/file-storage.ts
+++ b/packages/app/lib/file-storage/file-storage.ts
@@ -11,4 +11,6 @@ export class FileStorage {
   public async saveFile(file: File, id: string) {}
 
   public async getFile(id: any) {}
+
+  public async clearStorage() {}
 }

--- a/packages/app/lib/file-storage/file-storage.web.ts
+++ b/packages/app/lib/file-storage/file-storage.web.ts
@@ -46,15 +46,8 @@ export class FileStorage {
   public async clearStorage() {
     return new Promise<void>((resolve) => {
       if (this.db) {
-        const transaction = this.db.transaction([this.dbName], "readwrite");
-        const objectStore = transaction.objectStore(this.dbName);
-        const clearRequest = objectStore.clear();
-
-        clearRequest.onerror = (e) => {
-          Logger.error(e);
-        };
-
-        clearRequest.onsuccess = () => {
+        const req = indexedDB.deleteDatabase(this.dbName);
+        req.onsuccess = () => {
           resolve();
         };
       }

--- a/packages/app/lib/file-storage/file-storage.web.ts
+++ b/packages/app/lib/file-storage/file-storage.web.ts
@@ -4,42 +4,54 @@ export class FileStorage {
   private readonly dbName: string;
   private db?: IDBDatabase;
 
-  constructor(dbName: string, storeName: string) {
+  constructor(dbName: string) {
     this.dbName = dbName;
-    const request = window.indexedDB.open(this.dbName, 1);
-    request.onupgradeneeded = () => {
-      const db = request.result;
-      if (!db.objectStoreNames.contains(this.dbName)) {
-        db.createObjectStore(this.dbName, { keyPath: "id" });
+    this.getOrInitialiseDB();
+  }
+
+  getOrInitialiseDB() {
+    return new Promise<IDBDatabase>((resolve) => {
+      if (this.db) {
+        resolve(this.db);
+      } else {
+        const request = window.indexedDB.open(this.dbName, 1);
+        request.onupgradeneeded = () => {
+          const db = request.result;
+          if (!db.objectStoreNames.contains(this.dbName)) {
+            db.createObjectStore(this.dbName, { keyPath: "id" });
+          }
+        };
+
+        request.onerror = (error) => {
+          Logger.error(error);
+        };
+
+        request.onsuccess = () => {
+          this.db = request.result;
+          resolve(request.result);
+        };
       }
-    };
-
-    request.onerror = (error) => {
-      Logger.error(error);
-    };
-
-    request.onsuccess = () => {
-      this.db = request.result;
-    };
+    });
   }
 
   public async saveFile(file: File, id: string) {
-    return new Promise<any>((resolve) => {
-      if (this.db) {
-        const transaction = this.db.transaction([this.dbName], "readwrite");
-        const objectStore = transaction.objectStore(this.dbName);
-        const object = { id: id, data: file };
-        objectStore.delete(object.id);
-        const addRequest = objectStore.add(object);
-
-        addRequest.onerror = (e) => {
-          Logger.error(e);
-        };
-
-        addRequest.onsuccess = () => {
-          resolve(object.id);
-        };
+    return new Promise<any>(async (resolve) => {
+      if (!this.db) {
+        this.db = await this.getOrInitialiseDB();
       }
+      const transaction = this.db.transaction([this.dbName], "readwrite");
+      const objectStore = transaction.objectStore(this.dbName);
+      const object = { id: id, data: file };
+      objectStore.delete(object.id);
+      const addRequest = objectStore.add(object);
+
+      addRequest.onerror = (e) => {
+        Logger.error(e);
+      };
+
+      addRequest.onsuccess = () => {
+        resolve(object.id);
+      };
     });
   }
 
@@ -55,21 +67,22 @@ export class FileStorage {
   }
 
   public async getFile(id: any) {
-    return new Promise<File>((resolve) => {
-      if (this.db) {
-        const transaction = this.db.transaction([this.dbName], "readonly");
-        const objectStore = transaction.objectStore(this.dbName);
-        const getRequest = objectStore.get(id);
-
-        getRequest.onerror = (e) => {
-          Logger.error(e);
-        };
-
-        getRequest.onsuccess = () => {
-          const file = (getRequest.result as { id: number; data: File })?.data;
-          resolve(file);
-        };
+    return new Promise<File>(async (resolve) => {
+      if (!this.db) {
+        this.db = await this.getOrInitialiseDB();
       }
+      const transaction = this.db.transaction([this.dbName], "readonly");
+      const objectStore = transaction.objectStore(this.dbName);
+      const getRequest = objectStore.get(id);
+
+      getRequest.onerror = (e) => {
+        Logger.error(e);
+      };
+
+      getRequest.onsuccess = () => {
+        const file = (getRequest.result as { id: number; data: File })?.data;
+        resolve(file);
+      };
     });
   }
 }

--- a/packages/app/lib/file-storage/file-storage.web.ts
+++ b/packages/app/lib/file-storage/file-storage.web.ts
@@ -1,4 +1,4 @@
-import { Logger } from "app/logger";
+import { Logger } from "app/lib/logger";
 
 export class FileStorage {
   private readonly dbName: string;

--- a/packages/app/lib/file-storage/file-storage.web.ts
+++ b/packages/app/lib/file-storage/file-storage.web.ts
@@ -1,3 +1,5 @@
+import { Logger } from "app/logger";
+
 export class FileStorage {
   private readonly dbName: string;
   private readonly storeName: string;
@@ -15,7 +17,7 @@ export class FileStorage {
     };
 
     request.onerror = (error) => {
-      console.error(error);
+      Logger.error(error);
     };
 
     request.onsuccess = () => {
@@ -33,11 +35,29 @@ export class FileStorage {
         const addRequest = objectStore.add(object);
 
         addRequest.onerror = (e) => {
-          console.error(e);
+          Logger.error(e);
         };
 
         addRequest.onsuccess = () => {
           resolve(object.id);
+        };
+      }
+    });
+  }
+
+  public async clearStorage() {
+    return new Promise<void>((resolve) => {
+      if (this.db) {
+        const transaction = this.db.transaction([this.storeName], "readwrite");
+        const objectStore = transaction.objectStore(this.storeName);
+        const clearRequest = objectStore.clear();
+
+        clearRequest.onerror = (e) => {
+          Logger.error(e);
+        };
+
+        clearRequest.onsuccess = () => {
+          resolve();
         };
       }
     });
@@ -51,7 +71,7 @@ export class FileStorage {
         const getRequest = objectStore.get(id);
 
         getRequest.onerror = (e) => {
-          console.error(e);
+          Logger.error(e);
         };
 
         getRequest.onsuccess = () => {

--- a/packages/app/lib/file-storage/file-storage.web.ts
+++ b/packages/app/lib/file-storage/file-storage.web.ts
@@ -1,0 +1,65 @@
+export class FileStorage {
+  private readonly dbName: string;
+  private readonly storeName: string;
+  private db?: IDBDatabase;
+
+  constructor(dbName: string, storeName: string) {
+    this.dbName = dbName;
+    this.storeName = storeName;
+    const request = window.indexedDB.open(this.dbName, 1);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(this.storeName)) {
+        db.createObjectStore(this.storeName, { keyPath: "id" });
+      }
+    };
+
+    request.onerror = (error) => {
+      console.error(error);
+    };
+
+    request.onsuccess = () => {
+      this.db = request.result;
+    };
+  }
+
+  public async saveFile(file: File, id: string) {
+    return new Promise<any>((resolve) => {
+      if (this.db) {
+        const transaction = this.db.transaction([this.storeName], "readwrite");
+        const objectStore = transaction.objectStore(this.storeName);
+        const object = { id: id, data: file };
+        objectStore.delete(object.id);
+        const addRequest = objectStore.add(object);
+
+        addRequest.onerror = (e) => {
+          console.error(e);
+        };
+
+        addRequest.onsuccess = () => {
+          console.log("saved boi ", addRequest.result);
+          resolve(object.id);
+        };
+      }
+    });
+  }
+
+  public async getFile(id: any) {
+    return new Promise<File>((resolve) => {
+      if (this.db) {
+        const transaction = this.db.transaction([this.storeName], "readonly");
+        const objectStore = transaction.objectStore(this.storeName);
+        const getRequest = objectStore.get(id);
+
+        getRequest.onerror = (e) => {
+          console.error(e);
+        };
+
+        getRequest.onsuccess = () => {
+          const file = (getRequest.result as { id: number; data: File })?.data;
+          resolve(file);
+        };
+      }
+    });
+  }
+}

--- a/packages/app/lib/file-storage/file-storage.web.ts
+++ b/packages/app/lib/file-storage/file-storage.web.ts
@@ -2,17 +2,15 @@ import { Logger } from "app/lib/logger";
 
 export class FileStorage {
   private readonly dbName: string;
-  private readonly storeName: string;
   private db?: IDBDatabase;
 
   constructor(dbName: string, storeName: string) {
     this.dbName = dbName;
-    this.storeName = storeName;
     const request = window.indexedDB.open(this.dbName, 1);
     request.onupgradeneeded = () => {
       const db = request.result;
-      if (!db.objectStoreNames.contains(this.storeName)) {
-        db.createObjectStore(this.storeName, { keyPath: "id" });
+      if (!db.objectStoreNames.contains(this.dbName)) {
+        db.createObjectStore(this.dbName, { keyPath: "id" });
       }
     };
 
@@ -28,8 +26,8 @@ export class FileStorage {
   public async saveFile(file: File, id: string) {
     return new Promise<any>((resolve) => {
       if (this.db) {
-        const transaction = this.db.transaction([this.storeName], "readwrite");
-        const objectStore = transaction.objectStore(this.storeName);
+        const transaction = this.db.transaction([this.dbName], "readwrite");
+        const objectStore = transaction.objectStore(this.dbName);
         const object = { id: id, data: file };
         objectStore.delete(object.id);
         const addRequest = objectStore.add(object);
@@ -48,8 +46,8 @@ export class FileStorage {
   public async clearStorage() {
     return new Promise<void>((resolve) => {
       if (this.db) {
-        const transaction = this.db.transaction([this.storeName], "readwrite");
-        const objectStore = transaction.objectStore(this.storeName);
+        const transaction = this.db.transaction([this.dbName], "readwrite");
+        const objectStore = transaction.objectStore(this.dbName);
         const clearRequest = objectStore.clear();
 
         clearRequest.onerror = (e) => {
@@ -66,8 +64,8 @@ export class FileStorage {
   public async getFile(id: any) {
     return new Promise<File>((resolve) => {
       if (this.db) {
-        const transaction = this.db.transaction([this.storeName], "readonly");
-        const objectStore = transaction.objectStore(this.storeName);
+        const transaction = this.db.transaction([this.dbName], "readonly");
+        const objectStore = transaction.objectStore(this.dbName);
         const getRequest = objectStore.get(id);
 
         getRequest.onerror = (e) => {

--- a/packages/app/lib/file-storage/file-storage.web.ts
+++ b/packages/app/lib/file-storage/file-storage.web.ts
@@ -56,13 +56,14 @@ export class FileStorage {
   }
 
   public async clearStorage() {
-    return new Promise<void>((resolve) => {
-      if (this.db) {
-        const req = indexedDB.deleteDatabase(this.dbName);
-        req.onsuccess = () => {
-          resolve();
-        };
+    return new Promise<void>(async (resolve) => {
+      if (!this.db) {
+        this.db = await this.getOrInitialiseDB();
       }
+      const req = indexedDB.deleteDatabase(this.dbName);
+      req.onsuccess = () => {
+        resolve();
+      };
     });
   }
 

--- a/packages/app/lib/file-storage/file-storage.web.ts
+++ b/packages/app/lib/file-storage/file-storage.web.ts
@@ -37,7 +37,6 @@ export class FileStorage {
         };
 
         addRequest.onsuccess = () => {
-          console.log("saved boi ", addRequest.result);
           resolve(object.id);
         };
       }


### PR DESCRIPTION
# Why
- Form persistence is not working. Race condition between default values and the ones set by usePersistForm hook. 

## Before

https://user-images.githubusercontent.com/23293248/218955968-2296c7b7-d3d1-476a-aaa2-edd494827197.mov

## After

https://user-images.githubusercontent.com/23293248/218956195-f44f5684-7012-44f6-b29a-80d4b8f541b2.mov


<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- Add defaultValue support in usePersistForm hook to prevent the race condition
- Use indexed db to store/retrieve file on web. On native, it already works as file is just an URI.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Test form persistence in all drops on native and web


# P.S. 
- I'll be testing this more across browsers
- Also need to fix that flickering. 
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
