### PR TITLE
fix: video is not rendering in the drop preview

### DIFF
--- a/patches/expo-av+13.0.1.patch
+++ b/patches/expo-av+13.0.1.patch
@@ -1,0 +1,15 @@
+diff --git a/node_modules/expo-av/build/Video.js b/node_modules/expo-av/build/Video.js
+index f4fa076..21a553a 100644
+--- a/node_modules/expo-av/build/Video.js
++++ b/node_modules/expo-av/build/Video.js
+@@ -249,8 +249,8 @@ class Video extends React.Component {
+                 'posterStyle',
+                 ...Object.keys(status),
+             ]),
+-            style: StyleSheet.flatten([_STYLES.base, this.props.style]),
+-            videoStyle: StyleSheet.flatten([_STYLES.video, this.props.videoStyle]),
++            style: [_STYLES.base, this.props.style],
++            videoStyle: [_STYLES.video, this.props.videoStyle],
+             source,
+             resizeMode: nativeResizeMode,
+             status,


### PR DESCRIPTION
# Why
Happened after this [change](https://github.com/showtime-xyz/showtime-frontend/pull/1869/files#diff-ac1ff1940b1877fe33119728519778e79a9c1a54c140ee3ca131f0d9a19f582fR253)

https://user-images.githubusercontent.com/23293248/219094317-0fc171c9-1821-40cc-8ef1-e8687f0fe42d.mov

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
Made a PR in expo. https://github.com/expo/expo/pull/21236 Until then we can use a patch 💀 
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
Test video previews work on web.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
