### PR TITLE
feat: page auth permission on web

### DIFF
--- a/packages/app/components/drop/drop-event.tsx
+++ b/packages/app/components/drop/drop-event.tsx
@@ -122,7 +122,7 @@ export const DropEvent = () => {
   const bottomBarHeight = useBottomTabBarHeight();
 
   const { state, dropNFT } = useDropNFT();
-  const user = useUser();
+  const user = useUser({ redirectTo: "/login" });
 
   const headerHeight = useHeaderHeight();
   const redirectToCreateDrop = useRedirectToCreateDrop();

--- a/packages/app/components/drop/drop-free.tsx
+++ b/packages/app/components/drop/drop-free.tsx
@@ -118,7 +118,7 @@ export const DropFree = () => {
   // const [transactionId, setTransactionId] = useParam('transactionId')
 
   const { state, dropNFT, reset } = useDropNFT();
-  const user = useUser();
+  const user = useUser({ redirectTo: "/login" });
 
   const headerHeight = useHeaderHeight();
   const redirectToCreateDrop = useRedirectToCreateDrop();

--- a/packages/app/components/drop/drop-music.tsx
+++ b/packages/app/components/drop/drop-music.tsx
@@ -137,7 +137,7 @@ export const DropMusic = () => {
   const spotifyTextInputRef = React.useRef<TextInput | null>(null);
 
   const { state, dropNFT } = useDropNFT();
-  const user = useUser();
+  const user = useUser({ redirectTo: "/login" });
 
   const headerHeight = useHeaderHeight();
   const redirectToCreateDrop = useRedirectToCreateDrop();

--- a/packages/app/components/drop/drop-private.tsx
+++ b/packages/app/components/drop/drop-private.tsx
@@ -122,7 +122,7 @@ export const DropPrivate = () => {
   const bottomBarHeight = useBottomTabBarHeight();
 
   const { state, dropNFT } = useDropNFT();
-  const user = useUser();
+  const user = useUser({ redirectTo: "/login" });
 
   const headerHeight = useHeaderHeight();
   const redirectToCreateDrop = useRedirectToCreateDrop();

--- a/packages/app/components/drop/drop-select.tsx
+++ b/packages/app/components/drop/drop-select.tsx
@@ -17,7 +17,7 @@ import { useIsDarkMode } from "design-system/hooks";
 
 export const DropSelect = () => {
   const router = useRouter();
-  const user = useUser();
+  const user = useUser({ redirectTo: "/login" });
   const canCreateMusicDrop = !!user.user?.data.profile.spotify_artist_id;
   const isDark = useIsDarkMode();
 

--- a/packages/app/components/settings/setting.tsx
+++ b/packages/app/components/settings/setting.tsx
@@ -1,7 +1,6 @@
-import { useEffect, useCallback, useState } from "react";
+import { useCallback, useState } from "react";
 import { Platform } from "react-native";
 
-import { useRouter } from "@showtime-xyz/universal.router";
 import { useSafeAreaInsets } from "@showtime-xyz/universal.safe-area";
 import {
   HeaderTabView,
@@ -11,7 +10,6 @@ import {
 
 import { ErrorBoundary } from "app/components/error-boundary";
 import { useTabState } from "app/hooks/use-tab-state";
-import { useUser } from "app/hooks/use-user";
 import { useHeaderHeight } from "app/lib/react-navigation/elements";
 import { WalletAddressesV2 } from "app/types";
 
@@ -20,20 +18,11 @@ import { SettingsHeader } from "./setting-header";
 import { SettingTabsScene, SETTINGS_ROUTES } from "./tabs";
 
 const SettingsTabs = () => {
-  const { isAuthenticated } = useUser();
   const headerHeight = useHeaderHeight();
   const { bottom } = useSafeAreaInsets();
-  const router = useRouter();
   const [editingWallet, setEditingWallet] = useState<
     WalletAddressesV2 | undefined
   >(undefined);
-
-  useEffect(() => {
-    const isUnauthenticated = !isAuthenticated;
-    if (isUnauthenticated) {
-      router.pop();
-    }
-  }, [isAuthenticated, router]);
 
   const { index, setIndex, routes } = useTabState(SETTINGS_ROUTES);
 

--- a/packages/app/components/settings/setting.web.tsx
+++ b/packages/app/components/settings/setting.web.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useWindowDimensions } from "react-native";
 
+import { Spinner } from "@showtime-xyz/universal.spinner";
 import { View } from "@showtime-xyz/universal.view";
 
 import { ErrorBoundary } from "app/components/error-boundary";
@@ -10,6 +11,7 @@ import { WalletAddressesV2 } from "app/types";
 
 import { breakpoints } from "design-system/theme";
 
+import { useUser } from "../../hooks/use-user";
 import { EditNicknameModal } from "./setting-edit-nickname-moda";
 import { SettingsHeader } from "./setting-header";
 import { SettingsMd } from "./setting.md";
@@ -21,10 +23,17 @@ const SettingsTabs = () => {
     WalletAddressesV2 | undefined
   >(undefined);
   const { width } = useWindowDimensions();
+  const { isAuthenticated } = useUser({ redirectTo: "/login" });
   const isMdWidth = width >= breakpoints["md"];
-
   const { index, setIndex, routes } = useTabState(SETTINGS_ROUTES);
 
+  if (!isAuthenticated) {
+    return (
+      <View tw="flex-1 items-center justify-center">
+        <Spinner />
+      </View>
+    );
+  }
   return isMdWidth ? (
     <SettingsMd />
   ) : (

--- a/packages/app/components/settings/settings-account-item.tsx
+++ b/packages/app/components/settings/settings-account-item.tsx
@@ -131,7 +131,7 @@ export const AccountSettingItem = ({
           {Boolean(subTitle) && (
             <>
               <View tw="h-2" />
-              <Text tw="ml-2.5 text-xs italic text-gray-900 dark:text-white">
+              <Text tw="text-xs italic text-gray-900 dark:text-white">
                 {subTitle}
               </Text>
             </>

--- a/packages/app/components/settings/tabs/push-notifications.tsx
+++ b/packages/app/components/settings/tabs/push-notifications.tsx
@@ -1,14 +1,11 @@
-import { useEffect } from "react";
 import { Platform } from "react-native";
 
-import { useRouter } from "@showtime-xyz/universal.router";
 import { Switch } from "@showtime-xyz/universal.switch";
 import { TabScrollView } from "@showtime-xyz/universal.tab-view";
 import { Text } from "@showtime-xyz/universal.text";
 import { View } from "@showtime-xyz/universal.view";
 
 import { usePushNotificationsPreferences } from "app/hooks/use-push-notifications-preferences";
-import { useUser } from "app/hooks/use-user";
 import { axios } from "app/lib/axios";
 
 import { SettingsTitle } from "../settings-title";
@@ -19,17 +16,7 @@ export type PushNotificationTabProp = {
   index?: number;
 };
 export const PushNotificationTab = ({ index = 0 }: PushNotificationTabProp) => {
-  const { isAuthenticated } = useUser();
-  const router = useRouter();
   const pushNotificationsPreferences = usePushNotificationsPreferences();
-
-  useEffect(() => {
-    const isUnauthenticated = !isAuthenticated;
-    if (isUnauthenticated) {
-      router.pop();
-    }
-  }, [isAuthenticated, router]);
-
   return (
     <ScrollComponent index={index}>
       <SettingsTitle

--- a/packages/app/components/settings/tabs/wallets.tsx
+++ b/packages/app/components/settings/tabs/wallets.tsx
@@ -1,9 +1,7 @@
-import { useEffect } from "react";
 import { Platform, useWindowDimensions } from "react-native";
 
 import { Button } from "@showtime-xyz/universal.button";
 import { TabScrollView } from "@showtime-xyz/universal.collapsible-tab-view";
-import { useRouter } from "@showtime-xyz/universal.router";
 import { View } from "@showtime-xyz/universal.view";
 
 import { useAddWallet } from "app/hooks/use-add-wallet";
@@ -29,19 +27,12 @@ export const WalletsTab = ({
 }: WalletsTabProps) => {
   const { width } = useWindowDimensions();
   const isMdWidth = width >= breakpoints["md"];
-  const { user, isAuthenticated } = useUser();
-  const router = useRouter();
+  const { user } = useUser();
   const { state, addWallet } = useAddWallet();
 
   const wallets = user?.data.profile.wallet_addresses_v2;
   const walletCTA =
     state.status === "error" ? "Connect Lost, Retry" : "Add Wallet";
-  useEffect(() => {
-    const isUnauthenticated = !isAuthenticated;
-    if (isUnauthenticated) {
-      router.pop();
-    }
-  }, [isAuthenticated, router]);
 
   return (
     <SettingScrollComponent index={index}>

--- a/packages/app/hooks/use-user.ts
+++ b/packages/app/hooks/use-user.ts
@@ -1,9 +1,21 @@
-import { useContext } from "react";
+import { useContext, useEffect } from "react";
+
+import { useRouter } from "@showtime-xyz/universal.router";
 
 import { UserContext } from "app/context/user-context";
 
-export function useUser() {
+type UserParams = {
+  redirectTo?: string;
+};
+export function useUser(params?: UserParams) {
   const context = useContext(UserContext);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!context?.isAuthenticated && params?.redirectTo && router) {
+      router.replace(params?.redirectTo);
+    }
+  }, [context?.isAuthenticated, params?.redirectTo, router]);
 
   if (!context) {
     throw "You need to add `UserProvider` to your root component";

--- a/packages/app/screens/search.tsx
+++ b/packages/app/screens/search.tsx
@@ -1,12 +1,36 @@
+import { useEffect } from "react";
+import { Platform, useWindowDimensions } from "react-native";
+
+import { useRouter } from "@showtime-xyz/universal.router";
+import { Spinner } from "@showtime-xyz/universal.spinner";
 import { View } from "@showtime-xyz/universal.view";
 
 import { withColorScheme } from "app/components/memo-with-theme";
 import { Search } from "app/components/search";
 import { useTrackPageViewed } from "app/lib/analytics";
 
+import { breakpoints } from "design-system/theme";
+
 const SearchScreen = withColorScheme(() => {
   useTrackPageViewed({ name: "Search" });
+  const router = useRouter();
+  const { width } = useWindowDimensions();
+  const isMdWidth = width >= breakpoints["md"];
+  const isUnavailable = isMdWidth && Platform.OS === "web";
 
+  useEffect(() => {
+    if (isUnavailable) {
+      router.replace("/");
+    }
+  }, [isUnavailable, isMdWidth, router]);
+
+  if (isUnavailable) {
+    return (
+      <View tw="flex-1 items-center justify-center">
+        <Spinner />
+      </View>
+    );
+  }
   return (
     <View tw="w-full flex-1">
       <Search />


### PR DESCRIPTION
# Why

We haven't handled user authentication permission on the router, which allows users to access certain pages that require signing in by directly entering their URLs.

# How

Add the `redirectTo` parameter for the 'useUser' hooks. You can pass this parameter to specify the page you want to redirect to. If the user is not authenticated, they will be redirected to that page. 

# Test Plan 

Please ensure that you are not authenticated and try accessing a page that requires signing in. Check if you are redirected to the login page.




## Before 

https://user-images.githubusercontent.com/37520667/219308516-6f492443-ca7b-4311-ab85-93d9d8685460.mp4


## After 


https://user-images.githubusercontent.com/37520667/219308355-803eafe6-cf61-4955-b928-c49934dc130a.mp4

