### PR TITLE
fix: drop music triggering validation on mount

### DIFF
--- a/packages/app/components/drop/drop-music.tsx
+++ b/packages/app/components/drop/drop-music.tsx
@@ -217,8 +217,10 @@ export const DropMusic = () => {
 
   // this effect should be triggered when the user changes the drop type
   // it will revalidate the form and show the errors if any
+  const previousIsSaveDrop = useRef(isSaveDrop);
   useEffect(() => {
-    trigger();
+    if (isSaveDrop !== previousIsSaveDrop.current) trigger();
+    previousIsSaveDrop.current = isSaveDrop;
   }, [isSaveDrop, trigger]);
 
   const scrollToErrorField = useCallback(() => {


### PR DESCRIPTION
# Why
- Drop music form triggers validation on mount.
- To reproduce the issue, comment `usePersistForm` and open a drop music modal
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- Trigger validation only when isSaveDrop is changed
<!--
How did you build this feature or fix this bug and why?
-->



<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
