### PR TITLE
fix: hide create drop button for non verified creators

### DIFF
--- a/packages/app/components/drop/drop-select.tsx
+++ b/packages/app/components/drop/drop-select.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { Linking, Platform } from "react-native";
 
 import { Button } from "@showtime-xyz/universal.button";
-import { Globe, Lock } from "@showtime-xyz/universal.icon";
 import { Spotify } from "@showtime-xyz/universal.icon";
 import { Gift } from "@showtime-xyz/universal.icon";
 import { useRouter } from "@showtime-xyz/universal.router";
@@ -27,23 +26,32 @@ export const DropSelect = () => {
 
   return (
     <BottomSheetScrollView>
-      <View tw="flex-row flex-wrap items-center justify-center">
-        <View tw="mt-6 w-full px-4 lg:w-[360px]">
-          <CreateCard
-            title="Free drop"
-            description="Give your fans a free collectible."
-            ctaLabel="Create Free Drop"
-            icon={
-              <Gift color={isDark ? "black" : "white"} height={16} width={16} />
-            }
-            onPress={() => {
-              if (Platform.OS !== "web") {
-                router.pop();
+      <View tw="flex-row flex-wrap items-center justify-center pb-6">
+        {Platform.OS !== "web" && !user.user?.data.profile.verified ? null : (
+          <View tw="mt-6 w-full px-4 lg:w-[360px]">
+            <CreateCard
+              title="Drops: Free digital collectibles"
+              description="Share a link to instantly, create a collector list, and connect with your fans."
+              ctaLabel="Create Drop"
+              icon={
+                <Gift
+                  color={isDark ? "black" : "white"}
+                  height={16}
+                  width={16}
+                />
               }
-              router.push("/drop/free");
-            }}
-          />
-        </View>
+              onPress={() => {
+                if (Platform.OS !== "web") {
+                  router.pop();
+                  router.push("/drop/free");
+                } else {
+                  router.replace("/drop/free");
+                }
+              }}
+            />
+          </View>
+        )}
+
         <View tw="mt-6 w-full px-4 lg:w-[360px]">
           <CreateCard
             title="Music Drop: Pre-Save on Spotify"
@@ -56,53 +64,22 @@ export const DropSelect = () => {
             }
             description="Promote your latest music: give your fans a free collectible for saving your song to their library."
             ctaLabel={
-              canCreateMusicDrop ? "Create Music Drop" : "Request Access"
+              canCreateMusicDrop ? "Create a Music Drop" : "Request Access"
             }
             onPress={() => {
               if (Platform.OS !== "web") {
                 router.pop();
               }
               if (canCreateMusicDrop) {
-                router.push("/drop/music");
+                if (Platform.OS !== "web") {
+                  router.pop();
+                  router.push("/drop/music");
+                } else {
+                  router.replace("/drop/music");
+                }
               } else {
                 Linking.openURL("https://form.typeform.com/to/pXQVhkZo");
               }
-            }}
-          />
-        </View>
-        <View tw="mt-6 w-full px-4 lg:w-[360px]">
-          <CreateCard
-            title="Event drop"
-            icon={
-              <Globe
-                color={isDark ? "black" : "white"}
-                height={16}
-                width={16}
-              />
-            }
-            description="Connect with fans who show up to your events. This drop lets people mark themselves at your event location."
-            ctaLabel="Create Event Drop"
-            onPress={() => {
-              if (Platform.OS !== "web") {
-                router.pop();
-              }
-              router.push("/drop/event");
-            }}
-          />
-        </View>
-        <View tw="mt-6 w-full px-4 lg:w-[360px]">
-          <CreateCard
-            title="Private drop"
-            icon={
-              <Lock color={isDark ? "black" : "white"} height={16} width={16} />
-            }
-            description="A collectible for your biggest fans of your choice. Don't give up your password so easily!"
-            ctaLabel="Create Private Drop"
-            onPress={() => {
-              if (Platform.OS !== "web") {
-                router.pop();
-              }
-              router.push("/drop/private");
             }}
           />
         </View>


### PR DESCRIPTION
# Why
- Hide free drops on native for non verified creators. This PR adds small change from the bigger paid drop PR. 
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->


<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Test if create drop button is hidden on native for non verified creators. They can still see the request verification in music drop button
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
