### PR TITLE
feat: improve check receipt

### DIFF
--- a/packages/app/components/settings/tabs/billing.tsx
+++ b/packages/app/components/settings/tabs/billing.tsx
@@ -114,10 +114,6 @@ const HistoryItem = memo(function HistoryItem({
 }: {
   item: PaymentsHistory;
 }) {
-  const handleViewPress = useCallback((link: string) => {
-    Linking.openURL(link);
-  }, []);
-
   return (
     <View tw="flex-row justify-between py-3.5 px-4 md:px-0">
       <View tw="flex-col items-start justify-center md:flex-row md:items-center">
@@ -146,7 +142,7 @@ const HistoryItem = memo(function HistoryItem({
               {item.receipts.map((link, index) => {
                 return (
                   <DropdownMenuItem
-                    onSelect={() => handleViewPress(link)}
+                    onSelect={() => Linking.openURL(link)}
                     key={link}
                   >
                     <MenuItemIcon Icon={Receipt} />

--- a/packages/app/components/settings/tabs/billing.tsx
+++ b/packages/app/components/settings/tabs/billing.tsx
@@ -25,8 +25,17 @@ import {
 } from "app/hooks/api/use-payments-manage";
 import { exportFromJSON } from "app/lib/export-from-json";
 
+import {
+  DropdownMenuItem,
+  DropdownMenuItemTitle,
+  DropdownMenuRoot,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+} from "design-system/dropdown-menu";
+import { MoreHorizontal, Receipt } from "design-system/icon";
 import { breakpoints } from "design-system/theme";
 
+import { MenuItemIcon } from "../../dropdown/menu-item-icon";
 import { SettingItemSeparator } from "../setting-item-separator";
 import { SettingsTitle } from "../settings-title";
 
@@ -105,11 +114,9 @@ const HistoryItem = memo(function HistoryItem({
 }: {
   item: PaymentsHistory;
 }) {
-  const handleViewPress = useCallback(() => {
-    for (let link of item.receipts) {
-      Linking.openURL(link);
-    }
-  }, [item]);
+  const handleViewPress = useCallback((link: string) => {
+    Linking.openURL(link);
+  }, []);
 
   return (
     <View tw="flex-row justify-between py-3.5 px-4 md:px-0">
@@ -128,9 +135,31 @@ const HistoryItem = memo(function HistoryItem({
       </View>
       <View tw="h-8 flex-row">
         {item?.receipts?.length > 0 && (
-          <Button variant="tertiary" onPress={handleViewPress}>
-            View
-          </Button>
+          <DropdownMenuRoot>
+            <DropdownMenuTrigger>
+              <Button variant="tertiary" iconOnly>
+                <MoreHorizontal />
+              </Button>
+            </DropdownMenuTrigger>
+
+            <DropdownMenuContent loop>
+              {item.receipts.map((link, index) => {
+                return (
+                  <DropdownMenuItem
+                    onSelect={() => handleViewPress(link)}
+                    key={link}
+                  >
+                    <MenuItemIcon Icon={Receipt} />
+                    <DropdownMenuItemTitle tw="font-semibold text-gray-700 dark:text-neutral-300">
+                      {`Check Receipt ${
+                        item.receipts.length > 1 ? `#${index + 1}` : ``
+                      }`}
+                    </DropdownMenuItemTitle>
+                  </DropdownMenuItem>
+                );
+              })}
+            </DropdownMenuContent>
+          </DropdownMenuRoot>
         )}
       </View>
     </View>

--- a/packages/app/components/settings/tabs/billing.tsx
+++ b/packages/app/components/settings/tabs/billing.tsx
@@ -151,7 +151,7 @@ const HistoryItem = memo(function HistoryItem({
                   >
                     <MenuItemIcon Icon={Receipt} />
                     <DropdownMenuItemTitle tw="font-semibold text-gray-700 dark:text-neutral-300">
-                      {`Check Receipt ${
+                      {`View Receipt ${
                         item.receipts.length > 1 ? `#${index + 1}` : ``
                       }`}
                     </DropdownMenuItemTitle>

--- a/packages/design-system/icon/Receipt.svg
+++ b/packages/design-system/icon/Receipt.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-receipt-2" width="24" height="24"
+  viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+  <path d="M5 21v-16a2 2 0 0 1 2 -2h10a2 2 0 0 1 2 2v16l-3 -2l-2 2l-2 -2l-2 2l-2 -2l-3 2" />
+  <path d="M14 8h-2.5a1.5 1.5 0 0 0 0 3h1a1.5 1.5 0 0 1 0 3h-2.5m2 0v1.5m0 -9v1.5" />
+</svg>

--- a/packages/design-system/icon/Receipt.tsx
+++ b/packages/design-system/icon/Receipt.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+
+import Svg, { SvgProps, Path } from "react-native-svg";
+
+const SvgReceipt = (props: SvgProps) => (
+  <Svg
+    width={24}
+    height={24}
+    viewBox="0 0 24 24"
+    strokeWidth={2}
+    stroke="currentColor"
+    fill="none"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}
+  >
+    <Path d="M0 0h24v24H0z" stroke="none" />
+    <Path d="M5 21V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v16l-3-2-2 2-2-2-2 2-2-2-3 2" />
+    <Path d="M14 8h-2.5a1.5 1.5 0 0 0 0 3h1a1.5 1.5 0 0 1 0 3H10m2 0v1.5m0-9V8" />
+  </Svg>
+);
+
+export default SvgReceipt;

--- a/packages/design-system/icon/icon.stories.tsx
+++ b/packages/design-system/icon/icon.stories.tsx
@@ -141,6 +141,7 @@ export const Default = () => {
           title="PhonePortraitOutline"
         />
         <IconItem icon={Icon.CreditCard} title="CreditCard" />
+        <IconItem icon={Icon.Receipt} title="Receipt" />
       </View>
       <View tw="h-10" />
       <Text tw="text-xl font-bold">Social Icons</Text>

--- a/packages/design-system/icon/index.ts
+++ b/packages/design-system/icon/index.ts
@@ -121,6 +121,7 @@ export { default as BellMinus } from "./BellMinus";
 export { default as BellOff } from "./BellOff";
 export { default as PhonePortraitOutline } from "./PhonePortraitOutline";
 export { default as CreditCard } from "./CreditCard";
+export { default as Receipt } from "./Receipt";
 
 //#region social icons
 export { default as Twitter } from "./Twitter";


### PR DESCRIPTION
# Why

receipts are an array of URLs because one payment intent may have resulted in multiple charges being made (including refunds most likely) and we get a receipt for each charge, which now maybe cause multiple `openURL` triggers at the same time. 

# How

use the `Dropdown` component to handle this, so: 
- if only one receipt will display `Check Receipt` directly,  for example: 
![CleanShot 2023-02-24 at 10 06 52](https://user-images.githubusercontent.com/37520667/221199971-aaa23c99-9e90-4eb1-aa7f-2a480c9b5e0a.png)

- if has multiple receipts, will display `Check Receipt #index`, for example:  
![CleanShot 2023-02-24 at 10 07 48](https://user-images.githubusercontent.com/37520667/221200414-f79a5193-3597-49bc-9aff-0fe906bfefb5.png) 

I think this way will be better! WDYT? cc @hirbod 


