### PR TITLE
fix: Android StatusBar shift on cold boot

### DIFF
--- a/apps/expo/app.config.js
+++ b/apps/expo/app.config.js
@@ -102,6 +102,10 @@ export default {
     barStyle: "dark-content",
     backgroundColor: "#FFFFFF",
   },
+  androidStatusBar: {
+    backgroundColor: "#00000000",
+    barStyle: "light-content",
+  },
   assetBundlePatterns: ["**/*"],
   orientation: "portrait",
   updates: {
@@ -158,6 +162,7 @@ export default {
     "./plugins/with-fast-image-webp-support-android.js",
     "./plugins/with-fast-image-webp-support-ios.js",
     "./plugins/with-spotify-sdk.js",
+    "./plugins/with-android-splash-screen.js",
     [
       withInfoPlist,
       (config) => {

--- a/apps/expo/plugins/with-android-splash-screen.js
+++ b/apps/expo/plugins/with-android-splash-screen.js
@@ -1,0 +1,29 @@
+const {
+  createRunOncePlugin,
+  AndroidConfig,
+  withStringsXml,
+} = require("@expo/config-plugins");
+
+// This plugin fixes the initial statusbar shifting when the android app is booting up.
+const withAndroidSplashScreen = (expoConfig) =>
+  withStringsXml(expoConfig, (modConfig) => {
+    modConfig.modResults = AndroidConfig.Strings.setStringItem(
+      [
+        {
+          _: "true",
+          $: {
+            name: "expo_splash_screen_status_bar_translucent",
+            translatable: "false",
+          },
+        },
+      ],
+      modConfig.modResults
+    );
+    return modConfig;
+  });
+
+module.exports = createRunOncePlugin(
+  withAndroidSplashScreen,
+  "android-splash",
+  "1.0.0"
+);


### PR DESCRIPTION
# Why

When cold-booting Android, the status bar is not translucent and will be changed declaratively, which causes ugly and expensive layout shifts on boot

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Fixing this is not as easy as it seems. There are different results on Android versions less than 10, 10, and 12+, and it gets even worse with Edge-to-Edge mode. Luckily, I've invested a lot of time in this issue in the past and could copy my solution, which just works™. It needs a config plugin that changes something specific caused by Expo.

This should improve initial perf.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Here is a slow downed video. Left is the current live behavior and right is the fixed one.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->


https://user-images.githubusercontent.com/504909/221229231-9719e9fb-8e12-44ed-b6fb-161dd2e88dab.mp4


