### PR TITLE
fix: comment count source

### DIFF
--- a/packages/app/hooks/api/use-comments.ts
+++ b/packages/app/hooks/api/use-comments.ts
@@ -38,6 +38,7 @@ export interface CommentType {
 export interface Data {
   comments: CommentType[];
   has_more: boolean;
+  count: number;
 }
 
 export interface CommentsPayload {
@@ -71,7 +72,7 @@ export const useComments = (nftId?: number) => {
     mutate: mutateComments,
   } = useInfiniteListQuerySWR<CommentsPayload>(fetchCommentsURL);
   const commentsCount = useMemo(() => {
-    return data?.[0].data?.comments?.length ?? 0;
+    return data?.[0].data?.count ?? 0;
   }, [data]);
   //#endregion
 
@@ -86,7 +87,7 @@ export const useComments = (nftId?: number) => {
         });
 
         // mutate customer info
-        mutate(
+        mutate<any>(
           MY_INFO_ENDPOINT,
           (data: UserType): UserType => ({
             data: {
@@ -114,7 +115,7 @@ export const useComments = (nftId?: number) => {
         });
 
         // mutate local data
-        mutate(
+        mutate<any>(
           MY_INFO_ENDPOINT,
           (data: UserType): UserType => ({
             data: {


### PR DESCRIPTION
# Why
For a view like this one: https://showtime.xyz/nft/polygon/0x961102D2A3200fC9207907953430dE2C7369E857/0

The comment count on the top right currently comes from `api/v2/token` response.

Frontend should read the comment count that is coming back from `api/v2/comments` endpoint (.data.count)

See: https://github.com/showtime-xyz/stbackend/pull/729


