### PR TITLE
Add additional scopes to the Spotify OAuth request

### DIFF
--- a/packages/app/lib/spotify/queryString.ts
+++ b/packages/app/lib/spotify/queryString.ts
@@ -14,7 +14,7 @@ export const scope = [
   "user-library-read",
   "user-follow-modify",
   "user-follow-read",
-].join(" ");
+].join("%20");
 
 export const clientID = "e12f7eea542947ff843cfc68d762235a";
 
@@ -23,7 +23,6 @@ export const getQueryString = (_redirectUri?: string) => {
 
   const params = {
     client_id: clientID,
-    scope,
     redirect_uri: redirectUri,
     state,
     response_type: "code",
@@ -32,5 +31,11 @@ export const getQueryString = (_redirectUri?: string) => {
   const queryString = Object.entries(params)
     .map(([k, v]) => `${k}=${encodeURIComponent(v)}`)
     .join("&");
-  return `https://accounts.spotify.com/authorize?${queryString}`;
+
+  // Something about using encodeURIComponent and setting in the href
+  // changes %20 back to a space.
+  // https://stackoverflow.com/a/16598501
+  // I couldn't get it to work otherwise
+
+  return `https://accounts.spotify.com/authorize?${queryString}&${scope}`;
 };

--- a/packages/app/lib/spotify/queryString.ts
+++ b/packages/app/lib/spotify/queryString.ts
@@ -9,7 +9,12 @@ export const redirectUri = Platform.select({
   default: `io.showtime${__DEV__ ? ".development" : ""}://spotify-success`,
 });
 
-export const scope = "user-library-modify";
+export const scope = [
+  "user-library-modify",
+  "user-library-read",
+  "user-follow-modify",
+  "user-follow-read",
+].join(" ");
 
 export const clientID = "e12f7eea542947ff843cfc68d762235a";
 


### PR DESCRIPTION
# Why

In order to facilitate follow on spotify interaction as described in slack [here](https://showtime-rq88331.slack.com/archives/C02S5PQ1XJT/p1677623442101989)

# How

- Add additional scope strings from the documentation
- Put them in an array and join them because eslint complained the line was too long :cry: 

# Test Plan

Test locally and in staging
