### PR TITLE
fix: carousel pagination color

### DIFF
--- a/packages/app/lib/carousel/carousel.css
+++ b/packages/app/lib/carousel/carousel.css
@@ -2,15 +2,17 @@
   top: 0;
   height: 24px;
 }
-.showtime-pagination-dark > .swiper-pagination-bullet {
+.showtime-pagination > .swiper-pagination-bullet {
+  background-color: #a1a1aa;
+}
+.showtime-pagination > .swiper-pagination-bullet-active {
   background-color: #71717a;
 }
-.showtime-pagination-light > .swiper-pagination-bullet {
-  background-color: #e4e4e7;
-}
-.showtime-pagination-dark > .swiper-pagination-bullet-active {
+[data-color-scheme="dark"] .showtime-pagination > .swiper-pagination-bullet {
   background-color: #fff;
 }
-.showtime-pagination-light > .swiper-pagination-bullet-active {
-  background-color: #a1a1aa;
+[data-color-scheme="dark"]
+  .showtime-pagination
+  > .swiper-pagination-bullet-active {
+  background-color: #fafafa;
 }

--- a/packages/app/lib/carousel/carousel.web.tsx
+++ b/packages/app/lib/carousel/carousel.web.tsx
@@ -45,8 +45,8 @@ function Carousel({
         }
         pagination={{
           horizontalClass: isDark
-            ? "showtime-pagination showtime-pagination-dark"
-            : "showtime-pagination showtime-pagination-light",
+            ? "showtime-pagination"
+            : "showtime-pagination",
           clickable: true,
         }}
         modules={[Pagination, EffectFade, Autoplay]}


### PR DESCRIPTION
# Why 

fix: slider dots do have not enough contrast.

## Before 
![image](https://user-images.githubusercontent.com/37520667/222116894-9a3fe89b-cc6b-41e6-a5d3-f827beab10b5.png)


## After 
![CleanShot 2023-03-01 at 6 41 48](https://user-images.githubusercontent.com/37520667/222116860-30387243-6fe6-4460-95a4-0c9ae09c59b3.png)
![CleanShot 2023-03-01 at 6 41 43](https://user-images.githubusercontent.com/37520667/222116871-048a8fc6-8a3d-4fae-bc0b-ac5c021c3e7c.png)
