### PR TITLE
feat: redirect to typeform

### DIFF
--- a/apps/next/next.config.js
+++ b/apps/next/next.config.js
@@ -249,6 +249,11 @@ const nextConfig = {
           "https://play.google.com/store/apps/details?id=io.showtime",
         permanent: true,
       },
+      {
+        source: "/apply",
+        destination: "https://showtimexyz.typeform.com/to/pXQVhkZo",
+        permanent: true,
+      },
     ];
   },
   async rewrites() {

--- a/packages/app/components/drop/drop-select.tsx
+++ b/packages/app/components/drop/drop-select.tsx
@@ -78,7 +78,7 @@ export const DropSelect = () => {
                   router.replace("/drop/music");
                 }
               } else {
-                Linking.openURL("https://form.typeform.com/to/pXQVhkZo");
+                Linking.openURL("https://showtimexyz.typeform.com/to/pXQVhkZo");
               }
             }}
           />


### PR DESCRIPTION
# Why
- replace the Typeform link, we should use better slugs.  

- now support access the `showtime.xyz/apply` to redirect to Typeform link. 
