### PR TITLE
fix: button color

### DIFF
--- a/packages/app/components/feed-item/feed-item.md.tsx
+++ b/packages/app/components/feed-item/feed-item.md.tsx
@@ -190,7 +190,7 @@ export const FeedItemMD = memo<FeedItemProps>(function FeedItemMD({
               <Suspense fallback={<Skeleton width={24} height={24} />}>
                 <NFTDropdown
                   tw={[
-                    "rounded-full bg-gray-100 bg-white p-3 dark:bg-gray-900",
+                    "rounded-full bg-white p-3 dark:bg-gray-900",
                     showFullScreen ? "hidden" : "flex",
                   ]}
                   iconColor={isDark ? colors.white : colors.gray[900]}


### PR DESCRIPTION
# Why
the NFT dropdown button color is incorrect, so I need to quickly fix it. 

# Before 
![CleanShot 2023-03-04 at 3 34 29](https://user-images.githubusercontent.com/37520667/222810688-67d3591d-e1fd-467d-a8c0-94e08cda333f.png)

# After 
![CleanShot 2023-03-04 at 3 34 25](https://user-images.githubusercontent.com/37520667/222810700-d00db1fc-5cf6-453e-b0ef-0d177f6282e4.png)
