### PR TITLE
fix: toast duration & memorize toast options

### DIFF
--- a/packages/design-system/toast/toast.tsx
+++ b/packages/design-system/toast/toast.tsx
@@ -19,7 +19,6 @@ const toast = (title: string, options?: ToastOptions) => {
   return Burnt.toast({
     title: title,
     preset: "none",
-    duration: 3000,
     ...options,
   });
 };

--- a/packages/design-system/toast/toast.web.tsx
+++ b/packages/design-system/toast/toast.web.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from "react";
+
 import { Toaster as RHToaster, toast } from "react-hot-toast";
 
 import { useIsDarkMode } from "@showtime-xyz/universal.hooks";
@@ -10,29 +12,29 @@ const defaultStyle = {
 };
 const Toaster = () => {
   const isDark = useIsDarkMode();
-  return (
-    <RHToaster
-      toastOptions={{
-        style: {
-          ...defaultStyle,
-          ...(isDark
-            ? {
-                background: "#000",
-                color: "#fff",
-                boxShadow:
-                  "0px 0px 2px rgba(255, 255, 255, 0.5), 0px 16px 48px rgba(255, 255, 255, 0.2)",
-              }
-            : {
-                color: "#18181B",
-                background: "#fff",
-                boxShadow:
-                  "0px 12px 16px rgba(0, 0, 0, 0.1), 0px 16px 48px rgba(0, 0, 0, 0.1)",
-              }),
-        },
-      }}
-    />
-  );
+  const toastOptions = useMemo(() => {
+    return {
+      style: {
+        ...defaultStyle,
+        ...(isDark
+          ? {
+              background: "#000",
+              color: "#fff",
+              boxShadow:
+                "0px 0px 2px rgba(255, 255, 255, 0.5), 0px 16px 48px rgba(255, 255, 255, 0.2)",
+            }
+          : {
+              color: "#18181B",
+              background: "#fff",
+              boxShadow:
+                "0px 12px 16px rgba(0, 0, 0, 0.1), 0px 16px 48px rgba(0, 0, 0, 0.1)",
+            }),
+      },
+    };
+  }, [isDark]);
+  return <RHToaster toastOptions={toastOptions} />;
 };
+
 toast.custom = (message: any, options?: any): string => {
   return toast(message, {
     icon: options.web,


### PR DESCRIPTION
# Why

- fix toast duration since the duration is `s` instead of `ms`. 🤣  
- memorize the toast options will be better. 

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
