### PR TITLE
Spotify auth refactor

### DIFF
--- a/apps/next/src/pages/spotify-auth/redirect.tsx
+++ b/apps/next/src/pages/spotify-auth/redirect.tsx
@@ -4,10 +4,7 @@ import * as WebBrowser from "expo-web-browser";
 
 const SpotifyAuthRedirect = () => {
   useEffect(() => {
-    (async () => {
-      const res = await WebBrowser.maybeCompleteAuthSession();
-      console.log("rkrokr ", res);
-    })();
+    WebBrowser.maybeCompleteAuthSession();
   }, []);
   return null;
 };

--- a/apps/next/src/pages/spotify-auth/redirect.tsx
+++ b/apps/next/src/pages/spotify-auth/redirect.tsx
@@ -2,11 +2,22 @@ import { useEffect } from "react";
 
 import * as WebBrowser from "expo-web-browser";
 
+import { Spinner } from "@showtime-xyz/universal.spinner";
+import { View } from "@showtime-xyz/universal.view";
+
 const SpotifyAuthRedirect = () => {
   useEffect(() => {
     WebBrowser.maybeCompleteAuthSession();
   }, []);
-  return null;
+  return (
+    <View tw="flex-1 items-center justify-center">
+      <Spinner size="large" />
+    </View>
+  );
+};
+
+SpotifyAuthRedirect.getLayout = function getLayout(page) {
+  return page.children;
 };
 
 export default SpotifyAuthRedirect;

--- a/apps/next/src/pages/spotify-auth/redirect.tsx
+++ b/apps/next/src/pages/spotify-auth/redirect.tsx
@@ -1,83 +1,15 @@
-import { useEffect, useState } from "react";
-import { Linking } from "react-native";
+import { useEffect } from "react";
 
-import { Button } from "@showtime-xyz/universal.button";
-import { useRouter } from "@showtime-xyz/universal.router";
-import { Spinner } from "@showtime-xyz/universal.spinner";
-import { Text } from "@showtime-xyz/universal.text";
-import { View } from "@showtime-xyz/universal.view";
-
-import { useSaveSpotifyToken } from "app/hooks/use-save-spotify-token";
-import { Logger } from "app/lib/logger";
-import { redirectUri } from "app/lib/spotify/queryString";
-import { createParam } from "app/navigation/use-param";
-
-type Query = {
-  error?: string;
-  state?: string;
-  code?: string;
-};
-
-const { useParam } = createParam<Query>();
+import * as WebBrowser from "expo-web-browser";
 
 const SpotifyAuthRedirect = () => {
-  const [spotifyError] = useParam("error");
-  const [state] = useParam("state");
-  const [code] = useParam("code");
-  const { saveSpotifyToken } = useSaveSpotifyToken();
-  const urlParams = new URLSearchParams(state);
-  const _redirectUri = urlParams.get("redirectUri");
-  const [fetching, setFetching] = useState(false);
-  const [error, setError] = useState(false);
-  const router = useRouter();
-
   useEffect(() => {
-    if (code) {
-      (async () => {
-        try {
-          setFetching(true);
-          setError(false);
-          await saveSpotifyToken({ code, redirectUri: redirectUri });
-          router.replace(_redirectUri);
-        } catch (e) {
-          setError(e);
-          Logger.error("Save spotify token error", e);
-        }
-      })();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [saveSpotifyToken, code, redirectUri]);
-
-  useEffect(() => {
-    if (spotifyError) {
-      Logger.error("fetch spotify token error", spotifyError);
-    }
-  }, [spotifyError]);
-
-  if (spotifyError || error) {
-    return (
-      <View tw="flex-1 items-center justify-center">
-        <Text tw="pb-4 text-black dark:text-white">Something went wrong</Text>
-        <Button
-          onPress={() =>
-            //@ts-ignore
-            Linking.openURL("https://" + process.env.NEXT_PUBLIC_WEBSITE_DOMAIN)
-          }
-        >
-          Go back to the app
-        </Button>
-      </View>
-    );
-  }
-
-  return (
-    <View tw="h-screen flex-row items-center justify-center">
-      <Text tw="light:text-black mr-2 text-lg dark:text-white">
-        Taking you back to Showtime...
-      </Text>
-      <Spinner size="small" />
-    </View>
-  );
+    (async () => {
+      const res = await WebBrowser.maybeCompleteAuthSession();
+      console.log("rkrokr ", res);
+    })();
+  }, []);
+  return null;
 };
 
 export default SpotifyAuthRedirect;

--- a/packages/app/components/claim/claim-form.tsx
+++ b/packages/app/components/claim/claim-form.tsx
@@ -150,8 +150,7 @@ export const ClaimForm = ({
       edition.gating_type === "spotify_save" ||
       edition.gating_type === "music_presave"
     ) {
-      closeModal();
-      success = await claimSpotifyGatedDrop(nft?.data.item);
+      success = await claimSpotifyGatedDrop(nft?.data.item, closeModal);
     } else if (edition.gating_type === "password") {
       success = await claimNFT({ password: password.trim(), closeModal });
     } else if (edition.gating_type === "location") {

--- a/packages/app/hooks/use-connect-spotify.ts
+++ b/packages/app/hooks/use-connect-spotify.ts
@@ -15,13 +15,11 @@ export const useConnectSpotify = () => {
   const connectSpotify = async () => {
     try {
       const queryString = getQueryString();
-      console.log("redirect uri ", queryString, redirectUri);
 
       const res = await WebBrowser.openAuthSessionAsync(
         queryString,
         redirectUri
       );
-      console.log("spotify code ", res);
       if (res.type === "success") {
         let urlObj = new URL(res.url);
         const code = urlObj.searchParams.get("code");

--- a/packages/app/hooks/use-connect-spotify.ts
+++ b/packages/app/hooks/use-connect-spotify.ts
@@ -6,6 +6,8 @@ import { Logger } from "app/lib/logger";
 import { getQueryString } from "app/lib/spotify";
 import { redirectUri } from "app/lib/spotify/queryString";
 
+import { toast } from "design-system/toast";
+
 import { useSaveSpotifyToken } from "./use-save-spotify-token";
 
 export const useConnectSpotify = () => {
@@ -25,6 +27,7 @@ export const useConnectSpotify = () => {
         const code = urlObj.searchParams.get("code");
         if (code) {
           await saveSpotifyToken({ code, redirectUri: redirectUri });
+          toast.success("Spotify connected");
           return true;
         }
       } else {

--- a/packages/app/hooks/use-connect-spotify.ts
+++ b/packages/app/hooks/use-connect-spotify.ts
@@ -1,5 +1,3 @@
-import { Platform } from "react-native";
-
 import * as WebBrowser from "expo-web-browser";
 
 import { useAlert } from "@showtime-xyz/universal.alert";
@@ -14,31 +12,29 @@ export const useConnectSpotify = () => {
   const { saveSpotifyToken } = useSaveSpotifyToken();
   const Alert = useAlert();
 
-  const connectSpotify = async (_redirectURI?: string) => {
-    if (Platform.OS === "web") {
-      const queryString = getQueryString(_redirectURI);
-      window.location.href = queryString;
-    } else {
-      try {
-        const queryString = getQueryString();
+  const connectSpotify = async () => {
+    try {
+      const queryString = getQueryString();
+      console.log("redirect uri ", queryString, redirectUri);
 
-        const res = await WebBrowser.openAuthSessionAsync(
-          queryString,
-          redirectUri
-        );
-        if (res.type === "success") {
-          let urlObj = new URL(res.url);
-          const code = urlObj.searchParams.get("code");
-          if (code) {
-            await saveSpotifyToken({ code, redirectUri: redirectUri });
-          }
-        } else {
-          Alert.alert("Error", "Something went wrong");
+      const res = await WebBrowser.openAuthSessionAsync(
+        queryString,
+        redirectUri
+      );
+      console.log("spotify code ", res);
+      if (res.type === "success") {
+        let urlObj = new URL(res.url);
+        const code = urlObj.searchParams.get("code");
+        if (code) {
+          await saveSpotifyToken({ code, redirectUri: redirectUri });
         }
-      } catch (e) {
-        Logger.error("native spotify auth failed", e);
+      } else {
+        Logger.error("Spotify auth failed", res);
         Alert.alert("Error", "Something went wrong");
       }
+    } catch (e) {
+      Logger.error("Spotify auth failed", e);
+      Alert.alert("Error", "Something went wrong");
     }
   };
 

--- a/packages/app/hooks/use-connect-spotify.ts
+++ b/packages/app/hooks/use-connect-spotify.ts
@@ -25,6 +25,7 @@ export const useConnectSpotify = () => {
         const code = urlObj.searchParams.get("code");
         if (code) {
           await saveSpotifyToken({ code, redirectUri: redirectUri });
+          return true;
         }
       } else {
         Logger.error("Spotify auth failed", res);

--- a/packages/app/hooks/use-spotify-gated-claim.ts
+++ b/packages/app/hooks/use-spotify-gated-claim.ts
@@ -1,4 +1,5 @@
 import { useClaimNFT } from "app/hooks/use-claim-nft";
+import { Logger } from "app/lib/logger";
 
 import { IEdition, NFT } from "../types";
 import { useConnectSpotify } from "./use-connect-spotify";
@@ -11,18 +12,17 @@ export const useSpotifyGatedClaim = (edition: IEdition) => {
 
   const claimSpotifyGatedDrop = async (nft?: NFT, closeModal?: () => void) => {
     if (nft) {
-      // if (false) {
-      // TODO: remove this after testing
-      if (user?.user?.data.profile.has_spotify_token) {
-        try {
-          const res = claimNFT({ closeModal });
-
-          return res;
-        } catch (error: any) {
-          // TODO: handle error. Could be unauthorized, so we need to redirect to spotify auth flow
+      try {
+        let spotifyConnected = user?.user?.data.profile.has_spotify_token;
+        if (!spotifyConnected) {
+          spotifyConnected = await connectSpotify();
         }
-      } else {
-        return connectSpotify();
+        if (spotifyConnected) {
+          const res = claimNFT({ closeModal });
+          return res;
+        }
+      } catch (error: any) {
+        Logger.error("claimSpotifyGatedDrop failed", error);
       }
     }
   };

--- a/packages/app/hooks/use-spotify-gated-claim.ts
+++ b/packages/app/hooks/use-spotify-gated-claim.ts
@@ -9,22 +9,20 @@ export const useSpotifyGatedClaim = (edition: IEdition) => {
   const { claimNFT } = useClaimNFT(edition);
   const { connectSpotify } = useConnectSpotify();
 
-  const claimSpotifyGatedDrop = async (nft?: NFT) => {
+  const claimSpotifyGatedDrop = async (nft?: NFT, closeModal?: () => void) => {
     if (nft) {
       // if (false) {
       // TODO: remove this after testing
       if (user?.user?.data.profile.has_spotify_token) {
         try {
-          const res = claimNFT({});
+          const res = claimNFT({ closeModal });
 
           return res;
         } catch (error: any) {
           // TODO: handle error. Could be unauthorized, so we need to redirect to spotify auth flow
         }
       } else {
-        return connectSpotify(
-          `/nft/${nft?.chain_name}/${nft?.contract_address}/${nft?.token_id}?showClaim=true`
-        );
+        return connectSpotify();
       }
     }
   };

--- a/packages/app/lib/spotify/queryString.ts
+++ b/packages/app/lib/spotify/queryString.ts
@@ -13,14 +13,11 @@ export const scope = "user-library-modify";
 
 export const clientID = "e12f7eea542947ff843cfc68d762235a";
 
-export const getQueryString = (_redirectUri?: string) => {
-  const state = _redirectUri ? `redirectUri=${_redirectUri}` : "";
-
+export const getQueryString = () => {
   const params = {
     client_id: clientID,
     scope,
     redirect_uri: redirectUri,
-    state,
     response_type: "code",
   };
 


### PR DESCRIPTION
# Why
- Makes Spotify auth on web similar to native. 
- Code cleanup and remove additional redirect handling.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- Using expo's `openAuthSessionAsync`
<!--
How did you build this feature or fix this bug and why?
-->

https://user-images.githubusercontent.com/23293248/223131815-a743c52f-f854-4414-ab1b-7654d38ba04a.mov



# Test Plan
- Affects web only, tested on twitter browser, mobile browser, desktop browser
- Test by disconnecting and reconnecting Spotify
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
