### PR TITLE
fix: crop image cannot view button

### DIFF
--- a/apps/next/package.json
+++ b/apps/next/package.json
@@ -25,6 +25,7 @@
     "@radix-ui/react-popover": "^1.0.2",
     "@radix-ui/react-portal": "1.0.1",
     "@radix-ui/react-select": "1.2.0",
+    "@radix-ui/react-slider": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.0.2",
     "@radix-ui/react-use-escape-keydown": "^1.0.2",
     "@rainbow-me/rainbowkit": "^0.8.1",

--- a/apps/next/src/pages/api/.well-known/apple-app-site-association.ts
+++ b/apps/next/src/pages/api/.well-known/apple-app-site-association.ts
@@ -10,7 +10,7 @@ const association = {
     details: [
       {
         appID: `${TEAM_ID}.${BUNDLE_ID}`,
-        paths: ["/wsegue", "/nft/*", "/t/*", "/@*", "/profile/*", "/"],
+        paths: ["/wsegue", "/nft/*", "/t/*", "/@*", "/"],
       },
     ],
   },

--- a/packages/app/components/media-cropper/index.web.tsx
+++ b/packages/app/components/media-cropper/index.web.tsx
@@ -95,7 +95,7 @@ export const MediaCropper = ({
             )}
           />
           <View tw="max-h-[90vh] min-h-[560px]">
-            <View tw="h-[60vh] w-full md:w-[480px]">
+            <View tw="h-[60vh] min-h-[480px] w-full md:w-[480px]">
               {src && (
                 <Cropper
                   image={src}

--- a/packages/app/components/media-cropper/index.web.tsx
+++ b/packages/app/components/media-cropper/index.web.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback } from "react";
 import { Modal } from "react-native";
 
-import Slider from "@react-native-community/slider";
+import * as Slider from "@radix-ui/react-slider";
 import Cropper from "react-easy-crop";
 import type { Area } from "react-easy-crop";
 
@@ -79,7 +79,7 @@ export const MediaCropper = ({
     >
       <View tw="animate-fade-in-250 absolute inset-0 bg-black/30" />
       <View tw="h-full w-full items-center justify-end md:justify-center">
-        <View tw="w-full rounded-[32px] bg-white dark:bg-black md:w-auto">
+        <View tw="shadow-light dark:shadow-dark w-full rounded-[32px] bg-white dark:bg-black md:w-auto">
           <ModalHeader
             title={title}
             onClose={onClose}
@@ -95,7 +95,7 @@ export const MediaCropper = ({
             )}
           />
           <View tw="max-h-[90vh] min-h-[560px]">
-            <View tw="h-[576px] w-full md:w-[480px]">
+            <View tw="h-[60vh] w-full md:w-[480px]">
               {src && (
                 <Cropper
                   image={src}
@@ -110,30 +110,27 @@ export const MediaCropper = ({
                 />
               )}
             </View>
-            <View tw="mt-6 flex-row items-center justify-center px-6">
+            <View tw="mt-6 flex-row items-center justify-center px-4">
               <Pressable
                 onPress={() => setZoom((zoom) => Math.max(zoom - 1, 1))}
               >
                 <ZoomOut width={20} height={20} color={colors.gray[500]} />
               </Pressable>
-              <Slider
-                style={{
-                  width: "100%",
-                  marginVertical: 8,
-                  marginHorizontal: 12,
-                }}
-                minimumValue={1}
-                maximumValue={3}
-                value={zoom}
-                minimumTrackTintColor={colors.indigo[500]}
-                maximumTrackTintColor={
-                  isDark ? colors.gray[700] : colors.gray[200]
-                }
-                thumbTintColor={colors.indigo[500]}
-                onValueChange={setZoom}
-                // @ts-ignore
-                thumbSize={16}
-              />
+              <Slider.Root
+                className="relative mx-2 flex h-5 w-full touch-none select-none items-center"
+                defaultValue={[1]}
+                min={1}
+                max={3}
+                step={0.01}
+                value={[zoom]}
+                aria-label="Zoom Image"
+                onValueChange={(v) => setZoom(v[0])}
+              >
+                <Slider.Track className="bg-blackA10 relative h-1 grow rounded-full bg-gray-200 dark:bg-gray-700">
+                  <Slider.Range className="absolute h-full rounded-full bg-indigo-500" />
+                </Slider.Track>
+                <Slider.Thumb className="shadow-blackA7 hover:bg-violet3 focus:shadow-blackA8 block h-4 w-4 rounded-full bg-indigo-500 focus:outline-none" />
+              </Slider.Root>
               <Pressable
                 onPress={() => setZoom((zoom) => Math.min(zoom + 1, 3))}
               >
@@ -147,7 +144,7 @@ export const MediaCropper = ({
                 <RotateCw width={20} height={20} color={colors.gray[500]} />
               </Pressable>
             </View>
-            <View tw="mt-6 mb-4 px-4">
+            <View tw="mt-6 mb-8 px-4">
               <Button size="regular" onPress={showCroppedImage}>
                 Looks Good
               </Button>

--- a/packages/app/screens/edit-profile.tsx
+++ b/packages/app/screens/edit-profile.tsx
@@ -28,5 +28,5 @@ export const EditProfileScreen = withModalScreen(EditProfilePage, {
   enableContentPanningGesture: false,
   snapPoints: ["100%"],
   disableBackdropPress: true,
-  web_height: `h-[90vh]`,
+  web_height: `h-[82vh]`,
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6763,6 +6763,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-slider@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@radix-ui/react-slider@npm:1.1.0"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+    "@radix-ui/number": 1.0.0
+    "@radix-ui/primitive": 1.0.0
+    "@radix-ui/react-collection": 1.0.1
+    "@radix-ui/react-compose-refs": 1.0.0
+    "@radix-ui/react-context": 1.0.0
+    "@radix-ui/react-direction": 1.0.0
+    "@radix-ui/react-primitive": 1.0.1
+    "@radix-ui/react-use-controllable-state": 1.0.0
+    "@radix-ui/react-use-layout-effect": 1.0.0
+    "@radix-ui/react-use-previous": 1.0.0
+    "@radix-ui/react-use-size": 1.0.0
+  peerDependencies:
+    react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
+  checksum: 71923be5c7f2499e5035bb8c6824151ca1b3d9eda73f332df55df01ffa6fb47cb43e438da20ec1c80f32175687531f7a20875e1563cd3d258fa9e5e5bb01bf21
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-slot@npm:1.0.1":
   version: 1.0.1
   resolution: "@radix-ui/react-slot@npm:1.0.1"
@@ -9103,6 +9126,7 @@ __metadata:
     "@radix-ui/react-popover": ^1.0.2
     "@radix-ui/react-portal": 1.0.1
     "@radix-ui/react-select": 1.2.0
+    "@radix-ui/react-slider": ^1.1.0
     "@radix-ui/react-tooltip": ^1.0.2
     "@radix-ui/react-use-escape-keydown": ^1.0.2
     "@rainbow-me/rainbowkit": ^0.8.1


### PR DESCRIPTION
# Why
fix some feedback from users on the mobile web:  

- user cannot view the modal header in the edit-profile modal.
- user cannot view the `Looks good` button on the crop image modal.  

screenshot just like 
<img src="https://user-images.githubusercontent.com/37520667/223405011-5cd0fb93-5dd6-4ba4-b678-f2fcbc3241fb.png" width="200" />

<img src="https://user-images.githubusercontent.com/37520667/223405259-4d0690b1-46e0-44f5-941a-a8886929d7c0.PNG" width="200" />


this should be due to the modal too height causing that.

# How

- remove the `Open in App` banner in the `profile/*` screen since going to the user profile anyway will redirect to `showtime.xyz/@username`,  so we don't need to consider including the `profile/*` screen. 
- reduce modal height.  

# Test Plan

I need to deploy on the product to test it since local is without the `Open in App` banner.
