### PR TITLE
fix: collect button text color on music drop

### DIFF
--- a/packages/app/components/claim/claim-button.tsx
+++ b/packages/app/components/claim/claim-button.tsx
@@ -109,8 +109,14 @@ export const ClaimButton = ({
     } else {
       return isMusicDrop ? (
         <View tw="flex-row items-center">
-          <Spotify color="white" width={20} height={20} />
-          <Text tw="ml-1 font-semibold text-white">Save to Collect</Text>
+          <Spotify
+            color={isDark ? colors.black : colors.white}
+            width={20}
+            height={20}
+          />
+          <Text tw="ml-1 font-semibold text-white dark:text-black">
+            Save to Collect
+          </Text>
         </View>
       ) : (
         "Collect"


### PR DESCRIPTION
# Why

The music drop's collect button text color is not correct in dark mode. 


## Before 

![CleanShot 2023-03-07 at 8 46 44](https://user-images.githubusercontent.com/37520667/223426153-399a5839-19f9-4af2-8176-a858f3dc3ecb.png)

## After 

![CleanShot 2023-03-07 at 8 47 14](https://user-images.githubusercontent.com/37520667/223426286-1caa5431-61cd-46f0-84fb-b6e942d5fb7f.png)

