### PR TITLE
fix: message text cannot select

### DIFF
--- a/packages/app/components/messages/message-row.tsx
+++ b/packages/app/components/messages/message-row.tsx
@@ -118,7 +118,7 @@ interface MessageRowProps {
    */
   onUserPress?: (username: string) => void;
 }
-
+const PlatformSwipeable = Platform.OS === "web" ? View : Swipeable;
 export function MessageRow({
   address,
   username = "",
@@ -204,7 +204,7 @@ export function MessageRow({
   }, []);
 
   return (
-    <Swipeable
+    <PlatformSwipeable
       ref={swipeRef}
       renderRightActions={renderLeftActions}
       onSwipeableOpen={deleteComment}
@@ -301,6 +301,6 @@ export function MessageRow({
           </View>
         </View>
       </View>
-    </Swipeable>
+    </PlatformSwipeable>
   );
 }


### PR DESCRIPTION
# Why

currently, the comments text cannot select. we need to make it can be selected copy.

# How

instead of using the Swipeable component, we will use View on the web. 


