### PR TITLE
feat: login promise

### DIFF
--- a/packages/app/lib/login-promise/index.ts
+++ b/packages/app/lib/login-promise/index.ts
@@ -1,0 +1,29 @@
+import { useAuth } from "app/hooks/auth/use-auth";
+import { useStableCallback } from "app/hooks/use-stable-callback";
+import { useNavigateToLogin } from "app/navigation/use-navigate-to";
+
+export let loginPromiseCallbacks = {
+  resolve: null as ((v: unknown) => void) | null,
+  reject: null as ((v: unknown) => void) | null,
+};
+
+export const useLogInPromise = () => {
+  const { accessToken } = useAuth();
+  const navigateToLogin = useNavigateToLogin();
+  const loginPromise = useStableCallback(
+    () =>
+      new Promise((resolve, reject) => {
+        if (accessToken) {
+          resolve(true);
+        } else {
+          navigateToLogin();
+          loginPromiseCallbacks.resolve = resolve;
+          loginPromiseCallbacks.reject = reject;
+        }
+      })
+  );
+
+  return {
+    loginPromise,
+  };
+};

--- a/packages/app/providers/auth-provider.tsx
+++ b/packages/app/providers/auth-provider.tsx
@@ -22,6 +22,7 @@ import { deleteAccessToken, useAccessToken } from "app/lib/access-token";
 import { axios } from "app/lib/axios";
 import { deleteAppCache } from "app/lib/delete-cache";
 import * as loginStorage from "app/lib/login";
+import { loginPromiseCallbacks } from "app/lib/login-promise";
 import * as logoutStorage from "app/lib/logout";
 import { useMagic } from "app/lib/magic";
 import { deleteRefreshToken } from "app/lib/refresh-token";
@@ -216,6 +217,13 @@ export function AuthProvider({
       subscription.remove();
     };
   }, [doRefreshToken]);
+
+  useEffect(() => {
+    if (authenticationStatus === "AUTHENTICATED") {
+      loginPromiseCallbacks.resolve?.(true);
+      loginPromiseCallbacks.resolve = null;
+    }
+  }, [authenticationStatus]);
 
   //#endregion
 


### PR DESCRIPTION
# Why
- Adds a way to continue user-initiated authenticated actions after the user is authenticated.
- Realised it would be better to add it before doing Spotify decoupling PR as it would need it for better UX.

```
// User taps on authenticated action e.g. like
await loginPromise()
// continue with the action
```

https://user-images.githubusercontent.com/23293248/224194391-4b7eec06-3701-456f-9685-c843598780be.mov


<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- Some promise hacking
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Try liking, following when you are not logged in. Action should complete post login.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

P.S. for these actions we might also want to add `await onboarding()`. Not a blocker for now.
