### PR TITLE
feat (dev): music drop auth decoupling

### DIFF
--- a/packages/app/components/claim/claim-form.tsx
+++ b/packages/app/components/claim/claim-form.tsx
@@ -150,7 +150,7 @@ export const ClaimForm = ({
       edition.gating_type === "spotify_save" ||
       edition.gating_type === "music_presave"
     ) {
-      success = await claimSpotifyGatedDrop(nft?.data.item, closeModal);
+      success = await claimSpotifyGatedDrop(closeModal);
     } else if (edition.gating_type === "password") {
       success = await claimNFT({ password: password.trim(), closeModal });
     } else if (edition.gating_type === "location") {

--- a/packages/app/hooks/use-connect-spotify.ts
+++ b/packages/app/hooks/use-connect-spotify.ts
@@ -14,7 +14,7 @@ export const useConnectSpotify = () => {
   const { saveSpotifyToken } = useSaveSpotifyToken();
   const Alert = useAlert();
 
-  const connectSpotify = async () => {
+  const connectSpotify = async (editionAddress?: string) => {
     try {
       const queryString = getQueryString();
 
@@ -26,9 +26,13 @@ export const useConnectSpotify = () => {
         let urlObj = new URL(res.url);
         const code = urlObj.searchParams.get("code");
         if (code) {
-          await saveSpotifyToken({ code, redirectUri: redirectUri });
+          await saveSpotifyToken({
+            code,
+            redirectUri: redirectUri,
+            editionAddress,
+          });
           toast.success("Spotify connected");
-          return true;
+          return { code, redirectUri: redirectUri };
         }
       } else {
         Logger.error("Spotify auth failed", res);

--- a/packages/app/hooks/use-connect-spotify.ts
+++ b/packages/app/hooks/use-connect-spotify.ts
@@ -6,8 +6,6 @@ import { Logger } from "app/lib/logger";
 import { getQueryString } from "app/lib/spotify";
 import { redirectUri } from "app/lib/spotify/queryString";
 
-import { toast } from "design-system/toast";
-
 import { useSaveSpotifyToken } from "./use-save-spotify-token";
 
 export const useConnectSpotify = () => {
@@ -31,7 +29,6 @@ export const useConnectSpotify = () => {
             redirectUri: redirectUri,
             editionAddress,
           });
-          toast.success("Spotify connected");
           return { code, redirectUri: redirectUri };
         }
       } else {

--- a/packages/app/hooks/use-save-spotify-token.ts
+++ b/packages/app/hooks/use-save-spotify-token.ts
@@ -5,27 +5,43 @@ import { useSWRConfig } from "swr";
 import { axios } from "app/lib/axios";
 import { MY_INFO_ENDPOINT } from "app/providers/user-provider";
 
+import { useUser } from "./use-user";
+
 type SaveSpotifyTokenParams = {
   code: string;
   redirectUri: string;
+  editionAddress?: string;
 };
 
 function useSaveSpotifyToken() {
   const { mutate } = useSWRConfig();
+  const { isAuthenticated } = useUser();
 
   const saveSpotifyToken = useCallback(
-    async ({ code, redirectUri }: SaveSpotifyTokenParams) => {
-      await axios({
-        url: `/v1/spotify/get-and-save-token`,
-        method: "POST",
-        data: {
-          code,
-          redirect_uri: redirectUri,
-        },
-      });
-      mutate(MY_INFO_ENDPOINT);
+    async ({ code, redirectUri, editionAddress }: SaveSpotifyTokenParams) => {
+      if (isAuthenticated) {
+        await axios({
+          url: `/v1/spotify/get-and-save-token`,
+          method: "POST",
+          data: {
+            code,
+            redirect_uri: redirectUri,
+          },
+        });
+        mutate(MY_INFO_ENDPOINT);
+      } else {
+        await axios({
+          url: `/v1/spotify/gate`,
+          method: "POST",
+          data: {
+            code,
+            redirect_uri: redirectUri,
+            edition_address: editionAddress,
+          },
+        });
+      }
     },
-    [mutate]
+    [mutate, isAuthenticated]
   );
 
   return {

--- a/packages/app/hooks/use-spotify-gated-claim.ts
+++ b/packages/app/hooks/use-spotify-gated-claim.ts
@@ -1,7 +1,7 @@
 import { useClaimNFT } from "app/hooks/use-claim-nft";
 import { Logger } from "app/lib/logger";
 
-import { IEdition, NFT } from "../types";
+import { IEdition } from "../types";
 import { useConnectSpotify } from "./use-connect-spotify";
 import { useUser } from "./use-user";
 
@@ -10,20 +10,18 @@ export const useSpotifyGatedClaim = (edition: IEdition) => {
   const { claimNFT } = useClaimNFT(edition);
   const { connectSpotify } = useConnectSpotify();
 
-  const claimSpotifyGatedDrop = async (nft?: NFT, closeModal?: () => void) => {
-    if (nft) {
-      try {
-        let spotifyConnected = user?.user?.data.profile.has_spotify_token;
-        if (!spotifyConnected) {
-          spotifyConnected = await connectSpotify();
-        }
-        if (spotifyConnected) {
-          const res = claimNFT({ closeModal });
-          return res;
-        }
-      } catch (error: any) {
-        Logger.error("claimSpotifyGatedDrop failed", error);
+  const claimSpotifyGatedDrop = async (closeModal?: () => void) => {
+    try {
+      let spotifyConnected = !!user?.user?.data.profile.has_spotify_token;
+      if (!spotifyConnected) {
+        spotifyConnected = !!(await connectSpotify());
       }
+      if (spotifyConnected) {
+        const res = claimNFT({ closeModal });
+        return res;
+      }
+    } catch (error: any) {
+      Logger.error("claimSpotifyGatedDrop failed", error);
     }
   };
 

--- a/packages/app/hooks/use-spotify-presave-unauthenticated.ts
+++ b/packages/app/hooks/use-spotify-presave-unauthenticated.ts
@@ -1,6 +1,9 @@
 import useSWRMutation from "swr/mutation";
 
 import { useStableCallback } from "app/hooks/use-stable-callback";
+import { useNavigateToLogin } from "app/navigation/use-navigate-to";
+
+import { toast } from "design-system/toast";
 
 import { useConnectSpotify } from "./use-connect-spotify";
 
@@ -11,12 +14,17 @@ type IParams = {
 // const storedTokenKey = "spotify-unauthenticated-user-data";
 export const useSpotifyPresaveUnauthenticated = () => {
   const { connectSpotify } = useConnectSpotify();
+  const navigateToLogin = useNavigateToLogin();
   const state = useSWRMutation(
     "presave-spotify-unauthenticated",
     async (key: string, values: { arg: IParams }) => {
       const { editionAddress } = values.arg;
       const res = await connectSpotify(editionAddress);
       if (res) {
+        toast.success("Success. Complete your profile to collect the drop", {
+          duration: 5000,
+        });
+        navigateToLogin();
         // new MMKV().set(
         //   storedTokenKey,
         //   JSON.stringify({ code: res.code, redirectUri: res.redirectUri })

--- a/packages/app/hooks/use-spotify-presave-unauthenticated.ts
+++ b/packages/app/hooks/use-spotify-presave-unauthenticated.ts
@@ -1,0 +1,50 @@
+import useSWRMutation from "swr/mutation";
+
+import { useStableCallback } from "app/hooks/use-stable-callback";
+
+import { useConnectSpotify } from "./use-connect-spotify";
+
+type IParams = {
+  editionAddress: string;
+};
+
+// const storedTokenKey = "spotify-unauthenticated-user-data";
+export const useSpotifyPresaveUnauthenticated = () => {
+  const { connectSpotify } = useConnectSpotify();
+  const state = useSWRMutation(
+    "presave-spotify-unauthenticated",
+    async (key: string, values: { arg: IParams }) => {
+      const { editionAddress } = values.arg;
+      const res = await connectSpotify(editionAddress);
+      if (res) {
+        // new MMKV().set(
+        //   storedTokenKey,
+        //   JSON.stringify({ code: res.code, redirectUri: res.redirectUri })
+        // );
+      }
+      return res;
+    }
+  );
+  return state;
+};
+
+export const useSavePersistedSpotifyToken = () => {
+  const savePersistedSpotifyToken = useStableCallback(async () => {
+    // let data = new MMKV().getString(storedTokenKey);
+    // if (data) {
+    //   const parsedData = JSON.parse(data);
+    //   if (parsedData)
+    //     await axios({
+    //       url: `/v1/spotify/get-and-save-token`,
+    //       method: "POST",
+    //       data: {
+    //         code: parsedData.code,
+    //         redirect_uri: parsedData.redirectUri,
+    //       },
+    //     });
+    //   new MMKV().delete(storedTokenKey);
+    // }
+  });
+
+  return { savePersistedSpotifyToken };
+};

--- a/packages/app/lib/login-promise/index.ts
+++ b/packages/app/lib/login-promise/index.ts
@@ -1,0 +1,29 @@
+import { useAuth } from "app/hooks/auth/use-auth";
+import { useStableCallback } from "app/hooks/use-stable-callback";
+import { useNavigateToLogin } from "app/navigation/use-navigate-to";
+
+export let loginPromiseCallbacks = {
+  resolve: null as ((v: unknown) => void) | null,
+  reject: null as ((v: unknown) => void) | null,
+};
+
+export const useLogInPromise = () => {
+  const { accessToken } = useAuth();
+  const navigateToLogin = useNavigateToLogin();
+  const loginPromise = useStableCallback(
+    () =>
+      new Promise((resolve, reject) => {
+        if (accessToken) {
+          resolve(true);
+        } else {
+          navigateToLogin();
+          loginPromiseCallbacks.resolve = resolve;
+          loginPromiseCallbacks.reject = reject;
+        }
+      })
+  );
+
+  return {
+    loginPromise,
+  };
+};

--- a/packages/app/providers/auth-provider.tsx
+++ b/packages/app/providers/auth-provider.tsx
@@ -22,6 +22,7 @@ import { deleteAccessToken, useAccessToken } from "app/lib/access-token";
 import { axios } from "app/lib/axios";
 import { deleteAppCache } from "app/lib/delete-cache";
 import * as loginStorage from "app/lib/login";
+import { loginPromiseCallbacks } from "app/lib/login-promise";
 import * as logoutStorage from "app/lib/logout";
 import { useMagic } from "app/lib/magic";
 import { deleteRefreshToken } from "app/lib/refresh-token";
@@ -216,6 +217,13 @@ export function AuthProvider({
       subscription.remove();
     };
   }, [doRefreshToken]);
+
+  useEffect(() => {
+    if (authenticationStatus === "AUTHENTICATED") {
+      loginPromiseCallbacks.resolve?.(true);
+      loginPromiseCallbacks.resolve = null;
+    }
+  }, [authenticationStatus]);
 
   //#endregion
 

--- a/packages/app/providers/auth-provider.tsx
+++ b/packages/app/providers/auth-provider.tsx
@@ -15,6 +15,7 @@ import { clearPersistedForms } from "app/components/drop/utils";
 import { AuthContext } from "app/context/auth-context";
 import { useAccessTokenManager } from "app/hooks/auth/use-access-token-manager";
 import { useFetchOnAppForeground } from "app/hooks/use-fetch-on-app-foreground";
+import { useSavePersistedSpotifyToken } from "app/hooks/use-spotify-presave-unauthenticated";
 import { useWalletMobileSDK } from "app/hooks/use-wallet-mobile-sdk";
 import { useWeb3 } from "app/hooks/use-web3";
 import * as accessTokenStorage from "app/lib/access-token";
@@ -66,6 +67,7 @@ export function AuthProvider({
   const { setTokens, refreshTokens } = useAccessTokenManager();
   const fetchOnAppForeground = useFetchOnAppForeground();
   const router = useRouter();
+  const { savePersistedSpotifyToken } = useSavePersistedSpotifyToken();
   //#endregion
 
   //#region methods
@@ -216,6 +218,10 @@ export function AuthProvider({
       subscription.remove();
     };
   }, [doRefreshToken]);
+
+  useEffect(() => {
+    if (authenticationStatus === "AUTHENTICATED") savePersistedSpotifyToken();
+  }, [authenticationStatus, savePersistedSpotifyToken]);
 
   //#endregion
 


### PR DESCRIPTION
# Why

Makes presave available without user login. User login is triggered post presave.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
Try claiming a music drop without login. It should save the song and show you a popup to sign up.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
