### PR TITLE
feat: music drop/auth decoupling

### DIFF
--- a/apps/next/src/pages/login.tsx
+++ b/apps/next/src/pages/login.tsx
@@ -1,1 +1,3 @@
-export { default } from "app/pages/login";
+import { Fragment } from "react";
+
+export default Fragment;

--- a/packages/app/components/claim/claim-button.tsx
+++ b/packages/app/components/claim/claim-button.tsx
@@ -4,7 +4,8 @@ import { StyleProp, ViewStyle } from "react-native";
 import { Button } from "@showtime-xyz/universal.button";
 import { ButtonProps } from "@showtime-xyz/universal.button/types";
 import { useIsDarkMode } from "@showtime-xyz/universal.hooks";
-import { Check, Hourglass, Spotify } from "@showtime-xyz/universal.icon";
+import { Check, Hourglass } from "@showtime-xyz/universal.icon";
+import { Spotify } from "@showtime-xyz/universal.icon";
 import { colors } from "@showtime-xyz/universal.tailwind";
 import { Text } from "@showtime-xyz/universal.text";
 
@@ -90,7 +91,6 @@ export const ClaimButton = ({
     status === ClaimStatus.Soldout ||
     isExpired ||
     isProgress;
-  const isMusicDrop = edition?.gating_type === "spotify_save";
   const content = useMemo(() => {
     if (status === ClaimStatus.Claimed) {
       return (
@@ -120,8 +120,8 @@ export const ClaimButton = ({
           <ThreeDotsAnimation color={isDark ? colors.black : colors.white} />
         </Text>
       );
-    } else {
-      return isMusicDrop ? (
+    } else if (edition?.gating_type === "spotify_save") {
+      return (
         <>
           <Spotify
             color={isDark ? colors.black : colors.white}
@@ -132,11 +132,24 @@ export const ClaimButton = ({
             Save to Collect
           </Text>
         </>
-      ) : (
-        "Collect"
+      );
+    } else if (edition?.gating_type === "music_presave") {
+      return (
+        <>
+          <Spotify
+            color={isDark ? colors.black : colors.white}
+            width={20}
+            height={20}
+          />
+          <Text tw="ml-1 font-semibold text-white dark:text-black">
+            Pre-Save to Collect
+          </Text>
+        </>
       );
     }
-  }, [status, isProgress, isDark, isMusicDrop]);
+
+    return "Collect";
+  }, [status, isProgress, isDark, edition?.gating_type]);
 
   const opacityTw = useMemo(() => {
     if (isProgress) {

--- a/packages/app/components/claim/claim-button.tsx
+++ b/packages/app/components/claim/claim-button.tsx
@@ -11,6 +11,8 @@ import { Text } from "@showtime-xyz/universal.text";
 import { ClaimContext } from "app/context/claim-context";
 import { CreatorEditionResponse } from "app/hooks/use-creator-collection-detail";
 import { useRedirectToClaimDrop } from "app/hooks/use-redirect-to-claim-drop";
+import { useSpotifyGatedClaim } from "app/hooks/use-spotify-gated-claim";
+import { useUser } from "app/hooks/use-user";
 
 import { ThreeDotsAnimation } from "design-system/three-dots";
 
@@ -54,10 +56,23 @@ export const ClaimButton = ({
   const { state: claimStates, dispatch } = useContext(ClaimContext);
   const isProgress =
     claimStates.status === "loading" && claimStates.signaturePrompt === false;
+  const { claimSpotifyGatedDrop } = useSpotifyGatedClaim(
+    edition.creator_airdrop_edition
+  );
+
+  const { isAuthenticated } = useUser();
 
   const onClaimPress = () => {
     dispatch({ type: "initial" });
-    redirectToClaimDrop(edition.creator_airdrop_edition.contract_address);
+    if (
+      (edition.gating_type === "music_presave" ||
+        edition.gating_type === "spotify_save") &&
+      !isAuthenticated
+    ) {
+      claimSpotifyGatedDrop();
+    } else {
+      redirectToClaimDrop(edition.creator_airdrop_edition.contract_address);
+    }
   };
 
   let isExpired = false;

--- a/packages/app/components/claim/claim-form.tsx
+++ b/packages/app/components/claim/claim-form.tsx
@@ -152,7 +152,7 @@ export const ClaimForm = ({
       edition.gating_type === "spotify_save" ||
       edition.gating_type === "music_presave"
     ) {
-      success = await claimSpotifyGatedDrop(nft?.data.item, closeModal);
+      success = await claimSpotifyGatedDrop(closeModal);
     } else if (edition.gating_type === "password") {
       success = await claimNFT({ password: password.trim(), closeModal });
     } else if (edition.gating_type === "location") {

--- a/packages/app/components/onboarding/onboarding-promise.ts
+++ b/packages/app/components/onboarding/onboarding-promise.ts
@@ -1,5 +1,6 @@
 import { useStableCallback } from "app/hooks/use-stable-callback";
 import { useUser } from "app/hooks/use-user";
+import { Logger } from "app/lib/logger/index";
 import { useNavigateToOnboarding } from "app/navigation/use-navigate-to";
 
 export let onboardingPromiseCallbacks = {
@@ -8,17 +9,21 @@ export let onboardingPromiseCallbacks = {
 };
 
 export const useOnboardingPromise = () => {
-  const { isIncompletedProfile } = useUser();
+  const { isIncompletedProfile, isAuthenticated } = useUser();
   const navigateToOnboarding = useNavigateToOnboarding();
   const onboardingPromise = useStableCallback(
     () =>
       new Promise((resolve, reject) => {
-        if (isIncompletedProfile) {
-          navigateToOnboarding();
-          onboardingPromiseCallbacks.resolve = resolve;
-          onboardingPromiseCallbacks.reject = reject;
+        if (isAuthenticated) {
+          if (isIncompletedProfile) {
+            navigateToOnboarding();
+            onboardingPromiseCallbacks.resolve = resolve;
+            onboardingPromiseCallbacks.reject = reject;
+          } else {
+            resolve(true);
+          }
         } else {
-          resolve(true);
+          Logger.log("onboarding promise: User is not authenticated");
         }
       })
   );

--- a/packages/app/components/settings/tabs/account.tsx
+++ b/packages/app/components/settings/tabs/account.tsx
@@ -23,6 +23,8 @@ import { useListSocialAccounts } from "app/hooks/use-list-social-accounts";
 import { useManageAccount } from "app/hooks/use-manage-account";
 import { useUser } from "app/hooks/use-user";
 
+import { toast } from "design-system/toast";
+
 import { SettingsTitle } from "../settings-title";
 
 const SettingScrollComponent = Platform.OS === "web" ? View : TabScrollView;
@@ -71,11 +73,14 @@ const ConnectSpotify = () => {
         variant={
           user.user?.data.profile.has_spotify_token ? "danger" : "tertiary"
         }
-        onPress={() => {
+        onPress={async () => {
           if (user.user?.data.profile.has_spotify_token) {
             disconnectSpotify();
           } else {
-            connectSpotify();
+            const res = await connectSpotify();
+            if (res) {
+              toast.success("Spotify connected");
+            }
           }
         }}
       >

--- a/packages/app/hooks/use-connect-spotify.ts
+++ b/packages/app/hooks/use-connect-spotify.ts
@@ -6,8 +6,6 @@ import { Logger } from "app/lib/logger";
 import { getQueryString } from "app/lib/spotify";
 import { redirectUri } from "app/lib/spotify/queryString";
 
-import { toast } from "design-system/toast";
-
 import { useSaveSpotifyToken } from "./use-save-spotify-token";
 
 export const useConnectSpotify = () => {
@@ -27,7 +25,6 @@ export const useConnectSpotify = () => {
         const code = urlObj.searchParams.get("code");
         if (code) {
           await saveSpotifyToken({ code, redirectUri: redirectUri });
-          toast.success("Spotify connected");
           return {
             code,
             redirectUri,

--- a/packages/app/hooks/use-connect-spotify.ts
+++ b/packages/app/hooks/use-connect-spotify.ts
@@ -28,7 +28,10 @@ export const useConnectSpotify = () => {
         if (code) {
           await saveSpotifyToken({ code, redirectUri: redirectUri });
           toast.success("Spotify connected");
-          return true;
+          return {
+            code,
+            redirectUri,
+          };
         }
       } else {
         Logger.error("Spotify auth failed", res);

--- a/packages/app/hooks/use-spotify-gated-claim.ts
+++ b/packages/app/hooks/use-spotify-gated-claim.ts
@@ -1,9 +1,11 @@
+import { useOnboardingPromise } from "app/components/onboarding";
 import { useClaimNFT } from "app/hooks/use-claim-nft";
 import { axios } from "app/lib/axios";
 import { Logger } from "app/lib/logger";
 import { useLogInPromise } from "app/lib/login-promise";
 
-import { useOnboardingPromise } from "../components/onboarding";
+import { toast } from "design-system/toast";
+
 import { IEdition } from "../types";
 import { useConnectSpotify } from "./use-connect-spotify";
 import { useSaveSpotifyToken } from "./use-save-spotify-token";
@@ -46,6 +48,9 @@ export const useSpotifyGatedClaim = (edition: IEdition) => {
             method: "POST",
           });
 
+          toast.success(
+            "Song will be saved in your Spotify library. Please log in to collect your drop!"
+          );
           await loginPromise();
           await onboardingPromise();
 

--- a/packages/app/hooks/use-spotify-gated-claim.ts
+++ b/packages/app/hooks/use-spotify-gated-claim.ts
@@ -1,25 +1,59 @@
 import { useClaimNFT } from "app/hooks/use-claim-nft";
+import { axios } from "app/lib/axios";
 import { Logger } from "app/lib/logger";
+import { useLogInPromise } from "app/lib/login-promise";
 
-import { IEdition, NFT } from "../types";
+import { useOnboardingPromise } from "../components/onboarding";
+import { IEdition } from "../types";
 import { useConnectSpotify } from "./use-connect-spotify";
+import { useSaveSpotifyToken } from "./use-save-spotify-token";
 import { useUser } from "./use-user";
 
 export const useSpotifyGatedClaim = (edition: IEdition) => {
   const user = useUser();
   const { claimNFT } = useClaimNFT(edition);
   const { connectSpotify } = useConnectSpotify();
+  const { loginPromise } = useLogInPromise();
+  const { onboardingPromise } = useOnboardingPromise();
+  const { saveSpotifyToken } = useSaveSpotifyToken();
 
-  const claimSpotifyGatedDrop = async (nft?: NFT, closeModal?: () => void) => {
-    if (nft) {
+  const claimSpotifyGatedDrop = async (closeModal?: () => void) => {
+    if (user.isAuthenticated) {
       try {
         let spotifyConnected = user?.user?.data.profile.has_spotify_token;
         if (!spotifyConnected) {
-          spotifyConnected = await connectSpotify();
+          spotifyConnected = !!(await connectSpotify());
         }
         if (spotifyConnected) {
           const res = claimNFT({ closeModal });
           return res;
+        }
+      } catch (error: any) {
+        Logger.error("claimSpotifyGatedDrop failed", error);
+      }
+    } else {
+      try {
+        let spotifyToken = await connectSpotify();
+
+        if (spotifyToken) {
+          await axios({
+            url: "/v1/spotify/gate",
+            data: {
+              code: spotifyToken.code,
+              redirect_uri: spotifyToken.redirectUri,
+              edition_address: edition.contract_address,
+            },
+            method: "POST",
+          });
+
+          await loginPromise();
+          await onboardingPromise();
+
+          await saveSpotifyToken({
+            code: spotifyToken.code,
+            redirectUri: spotifyToken.redirectUri,
+          });
+          await claimNFT({ closeModal });
         }
       } catch (error: any) {
         Logger.error("claimSpotifyGatedDrop failed", error);

--- a/packages/app/providers/auth-provider.tsx
+++ b/packages/app/providers/auth-provider.tsx
@@ -91,6 +91,7 @@ export function AuthProvider({
       if (validResponse && res) {
         setTokens(accessToken, refreshToken);
         loginStorage.setLogin(Date.now().toString());
+        mutate(MY_INFO_ENDPOINT, res);
         setAuthenticationStatus("AUTHENTICATED");
 
         /*
@@ -110,7 +111,7 @@ export function AuthProvider({
       setAuthenticationStatus("UNAUTHENTICATED");
       throw "Login failed";
     },
-    [setTokens, setAuthenticationStatus, fetchOnAppForeground]
+    [setTokens, setAuthenticationStatus, fetchOnAppForeground, mutate]
   );
   /**
    * Log out the customer if logged in, and clear auth cache.


### PR DESCRIPTION
# Why
Allow user to save the song before sign up.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
Use loginPromise, onboardingPromise to do trigger saving spotify token. Follows [backend spec](https://www.notion.so/showtime-xyz/Spotify-de-coupling-5c5c71d6e194459587dcad8c0b9711f1)
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Create a new wallet account
- Try to claim this drop while you are signed out. http://localhost:3000/nft/mumbai/0x71778d2126CBbaf8BaaB2E22127E9bddf5c821fA/0

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
