### PR TITLE
fix: login stays open sometimes

### DIFF
--- a/packages/app/components/login/index.tsx
+++ b/packages/app/components/login/index.tsx
@@ -11,11 +11,7 @@ import { BottomSheetScrollView } from "app/components/bottom-sheet-scroll-view";
 import { LoginComponent } from "./login";
 import { useLogin } from "./use-login";
 
-interface LoginProps {
-  onLogin?: () => void;
-}
-
-export function Login({ onLogin }: LoginProps) {
+export function Login() {
   //#region hooks
   const {
     walletStatus,
@@ -24,7 +20,7 @@ export function Login({ onLogin }: LoginProps) {
     handleSubmitPhoneNumber,
     handleSubmitWallet,
     loading,
-  } = useLogin(onLogin);
+  } = useLogin();
 
   //#endregion
 

--- a/packages/app/components/login/index.web.tsx
+++ b/packages/app/components/login/index.web.tsx
@@ -10,11 +10,7 @@ import { View } from "@showtime-xyz/universal.view";
 import { LoginComponent } from "./login";
 import { useLogin } from "./use-login";
 
-interface LoginProps {
-  onLogin?: () => void;
-}
-
-export function Login({ onLogin }: LoginProps) {
+export function Login() {
   //#region hooks
   const {
     walletStatus,
@@ -25,7 +21,7 @@ export function Login({ onLogin }: LoginProps) {
     handleSubmitPhoneNumber,
     handleSubmitWallet,
     loading,
-  } = useLogin(onLogin);
+  } = useLogin();
   //#endregion
 
   return (

--- a/packages/app/components/login/use-login.ts
+++ b/packages/app/components/login/use-login.ts
@@ -14,7 +14,7 @@ type LoginSource = "undetermined" | "magic" | "wallet";
 export type SubmitWalletParams = {
   onOpenConnectModal?: () => void;
 };
-export const useLogin = (onLogin?: () => void) => {
+export const useLogin = () => {
   const loginSource = useRef<LoginSource>("undetermined");
   const { rudder } = useRudder();
 
@@ -123,17 +123,6 @@ export const useLogin = (onLogin?: () => void) => {
 
   //#region effects
   useStableBlurEffect(handleBlur);
-  useEffect(() => {
-    const isAuthenticated = authenticationStatus === "AUTHENTICATED";
-    const isLoggedInByMagic =
-      loginSource.current === "magic" && isAuthenticated;
-    const isLoggedInByWallet =
-      loginSource.current === "wallet" && walletStatus === "EXPIRED_NONCE";
-
-    if (isLoggedInByWallet || isLoggedInByMagic) {
-      onLogin?.();
-    }
-  }, [authenticationStatus, walletStatus, onLogin]);
 
   useEffect(() => {
     if (walletStatus === "ERRORED" && walletError) {

--- a/packages/app/providers/auth-provider.tsx
+++ b/packages/app/providers/auth-provider.tsx
@@ -89,6 +89,7 @@ export function AuthProvider({
       });
 
       if (validResponse && res) {
+        router.pop();
         setTokens(accessToken, refreshToken);
         loginStorage.setLogin(Date.now().toString());
         mutate(MY_INFO_ENDPOINT, res);
@@ -111,7 +112,7 @@ export function AuthProvider({
       setAuthenticationStatus("UNAUTHENTICATED");
       throw "Login failed";
     },
-    [setTokens, setAuthenticationStatus, fetchOnAppForeground, mutate]
+    [setTokens, setAuthenticationStatus, fetchOnAppForeground, mutate, router]
   );
   /**
    * Log out the customer if logged in, and clear auth cache.

--- a/packages/app/screens/login.tsx
+++ b/packages/app/screens/login.tsx
@@ -1,40 +1,12 @@
-import { useCallback } from "react";
-
 import { withModalScreen } from "@showtime-xyz/universal.modal-screen";
-import { useRouter } from "@showtime-xyz/universal.router";
 
 import { Login } from "app/components/login";
 import { useTrackPageViewed } from "app/lib/analytics";
-import { createParam } from "app/navigation/use-param";
-
-type Query = {
-  redirect_url: string;
-};
-
-const { useParam } = createParam<Query>();
 
 function LoginModal() {
-  //#region hooks
   useTrackPageViewed({ name: "Login" });
-  const [redirect_url] = useParam("redirect_url");
-  const router = useRouter();
-  //#endregion
 
-  //#region callbacks
-  const handleOnLogin = useCallback(() => {
-    if (redirect_url && redirect_url.length > 0) {
-      /**
-       * TODO: we need to get rid off this.
-       */
-      router.pop();
-      router.push(decodeURIComponent(redirect_url));
-    } else {
-      router.pop();
-    }
-  }, [redirect_url, router]);
-  //#endregion
-
-  return <Login onLogin={handleOnLogin} />;
+  return <Login />;
 }
 
 export const LoginScreen = withModalScreen(LoginModal, {


### PR DESCRIPTION
# Why
- Noticed during spotify decoupled flow, login modal stayed open.
### Root cause
During login we do `router.push(/login)`. router.pop was being done in a callback that would be called in a useEffect post login. Leading to weird race conditions. 

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
We make sure to call router.pop in login() function synchronously instead of useEffect. This makes sure it works well with our promise based await loginPromise(); await onboardingPromise() setup.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Test music drop decoupled flow
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
