### PR TITLE
improve deleting account

### DIFF
--- a/packages/app/components/settings/settings-account-item.tsx
+++ b/packages/app/components/settings/settings-account-item.tsx
@@ -16,6 +16,8 @@ import { useDeleteUser } from "app/hooks/use-delete-user";
 import { useUser } from "app/hooks/use-user";
 import { Logger } from "app/lib/logger";
 
+import { toast } from "design-system/toast";
+
 export const SettingDeleteAccount = () => {
   const { deleteUser } = useDeleteUser();
   const user = useUser();
@@ -40,8 +42,9 @@ export const SettingDeleteAccount = () => {
         onPress: async () => {
           await deleteUser().catch((e) => {
             Logger.error(e);
-            setError("Error deleting account");
+            toast.success("Error deleting account");
           });
+          toast.success("Your account has been deleted");
           logout();
         },
       },

--- a/packages/app/components/settings/settings-account-item.tsx
+++ b/packages/app/components/settings/settings-account-item.tsx
@@ -31,7 +31,7 @@ export const SettingDeleteAccount = () => {
       setError("Username does not match");
       return;
     }
-    Alert.alert("Delete Account", "This action cannot be undone.", [
+    Alert.alert("Delete Account", "Are you sure you want to delete your account? This action cannot be undone.", [
       {
         text: "Cancel",
         style: "cancel",

--- a/packages/app/components/settings/settings-account-item.tsx
+++ b/packages/app/components/settings/settings-account-item.tsx
@@ -2,6 +2,7 @@ import { useState, useRef } from "react";
 
 import { SvgProps } from "react-native-svg";
 
+import { Alert } from "@showtime-xyz/universal.alert";
 import { Button, ButtonProps } from "@showtime-xyz/universal.button";
 import { Fieldset } from "@showtime-xyz/universal.fieldset";
 import { Trash } from "@showtime-xyz/universal.icon";
@@ -28,14 +29,23 @@ export const SettingDeleteAccount = () => {
       setError("Username does not match");
       return;
     }
-
-    try {
-      await deleteUser();
-      logout();
-    } catch (e) {
-      Logger.error(e);
-      setError("Error deleting account");
-    }
+    Alert.alert("Delete Account", "This action cannot be undone.", [
+      {
+        text: "Cancel",
+        style: "cancel",
+      },
+      {
+        text: "Confirm",
+        style: "destructive",
+        onPress: async () => {
+          await deleteUser().catch((e) => {
+            Logger.error(e);
+            setError("Error deleting account");
+          });
+          logout();
+        },
+      },
+    ]);
   };
   return (
     <View>

--- a/packages/app/components/settings/tabs/advanced.tsx
+++ b/packages/app/components/settings/tabs/advanced.tsx
@@ -17,11 +17,11 @@ import { SettingsTitle } from "../settings-title";
 
 const SettingScrollComponent = Platform.OS === "web" ? View : TabScrollView;
 
-export type AccountTabProps = {
+export type AdvancedTabProps = {
   index?: number;
 };
 
-export const AdvancedTab = ({ index = 0 }: AccountTabProps) => {
+export const AdvancedTab = ({ index = 0 }: AdvancedTabProps) => {
   const router = useRouter();
   const { onSendFeedback } = useSendFeedback();
   return (


### PR DESCRIPTION
# Why 

- we should use Alert component to prompt users to double-check before deleting their account.
- we should prompt the status when a user's account deletion succeeds or fails.

![CleanShot 2023-03-16 at 2 40 26](https://user-images.githubusercontent.com/37520667/225410449-5f102308-a8f6-4c2e-b325-a94a82e605d5.png)


# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
