### PR TITLE
fix: pass token in login APIs

### DIFF
--- a/packages/app/components/connect-button/connect-button.tsx
+++ b/packages/app/components/connect-button/connect-button.tsx
@@ -1,11 +1,7 @@
 import { LoginButton } from "app/components/login/login-button";
 
 export type ConnectButtonProps = {
-  handleSubmitWallet: ({
-    onOpenConnectModal,
-  }?: {
-    onOpenConnectModal: () => void;
-  }) => void;
+  handleSubmitWallet: () => void;
 };
 
 export const ConnectButton: React.FC<ConnectButtonProps> = (

--- a/packages/app/components/connect-button/connect-button.web.tsx
+++ b/packages/app/components/connect-button/connect-button.web.tsx
@@ -61,11 +61,7 @@ export const ConnectButton = ({ handleSubmitWallet }: ConnectButtonProps) => {
               if (!mounted || !account || !chain) {
                 return (
                   <LoginButton
-                    onPress={() => {
-                      handleSubmitWallet({
-                        onOpenConnectModal: openConnectModal,
-                      });
-                    }}
+                    onPress={() => handleSubmitWallet()}
                     type="wallet"
                   />
                 );
@@ -77,9 +73,7 @@ export const ConnectButton = ({ handleSubmitWallet }: ConnectButtonProps) => {
                   size="regular"
                   tw="my-4"
                   onPress={() => {
-                    handleSubmitWallet({
-                      onOpenConnectModal: openAccountModal,
-                    });
+                    handleSubmitWallet();
                   }}
                 >
                   <>

--- a/packages/app/components/login/index.web.tsx
+++ b/packages/app/components/login/index.web.tsx
@@ -41,7 +41,7 @@ export function Login() {
               We need a signature in order to verify your identity. This won't
               cost any gas.
             </Text>
-            <Button tw="mt-8" onPress={verifySignature}>
+            <Button tw="mt-8" onPress={() => verifySignature()}>
               Sign the message
             </Button>
           </View>

--- a/packages/app/components/login/login-with-apple.tsx
+++ b/packages/app/components/login/login-with-apple.tsx
@@ -27,6 +27,8 @@ export const LoginWithApple = () => {
           const idToken = result.magic.idToken;
           const user = await login(LOGIN_MAGIC_ENDPOINT, {
             did: idToken,
+            provider_access_token: result.oauth.accessToken,
+            provider_scope: result.oauth.scope,
           });
           const EthersWeb3Provider = (await import("@ethersproject/providers"))
             .Web3Provider;

--- a/packages/app/components/login/login-with-google.tsx
+++ b/packages/app/components/login/login-with-google.tsx
@@ -27,6 +27,8 @@ export const LoginWithGoogle = () => {
           const idToken = result.magic.idToken;
           const user = await login(LOGIN_MAGIC_ENDPOINT, {
             did: idToken,
+            provider_access_token: result.oauth.accessToken,
+            provider_scope: result.oauth.scope,
           });
 
           const EthersWeb3Provider = (await import("@ethersproject/providers"))

--- a/packages/app/components/login/login-with-twitter.tsx
+++ b/packages/app/components/login/login-with-twitter.tsx
@@ -22,6 +22,8 @@ export const LoginWithTwitter = () => {
           const idToken = result.magic.idToken;
           await login(LOGIN_MAGIC_ENDPOINT, {
             did: idToken,
+            provider_access_token: result.oauth.accessToken,
+            provider_scope: result.oauth.scope,
           });
           router.pop();
         } catch (e) {

--- a/packages/app/components/login/use-login.ts
+++ b/packages/app/components/login/use-login.ts
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useRef } from "react";
-import { Platform } from "react-native";
 
 import { captureException } from "@sentry/nextjs";
 
@@ -11,9 +10,7 @@ import { useRudder } from "app/lib/rudderstack";
 
 type LoginSource = "undetermined" | "magic" | "wallet";
 
-export type SubmitWalletParams = {
-  onOpenConnectModal?: () => void;
-};
+export type SubmitWalletParams = {};
 export const useLogin = () => {
   const loginSource = useRef<LoginSource>("undetermined");
   const { rudder } = useRudder();
@@ -31,7 +28,6 @@ export const useLogin = () => {
     verifySignature,
   } = useWalletLogin();
   const { loginWithEmail, loginWithPhoneNumber } = useMagicLogin();
-  const isWeb = Platform.OS === "web";
   //#endregion
 
   //#region methods
@@ -55,7 +51,7 @@ export const useLogin = () => {
   );
 
   const handleSubmitWallet = useCallback(
-    async function handleSubmitWallet(params?: SubmitWalletParams) {
+    async function handleSubmitWallet() {
       try {
         loginSource.current = "wallet";
 
@@ -63,18 +59,12 @@ export const useLogin = () => {
           name: "Login with wallet",
         });
 
-        if (isWeb) {
-          console.log(loginSource.current);
-
-          params?.onOpenConnectModal?.();
-        } else {
-          await loginWithWallet();
-        }
+        await loginWithWallet();
       } catch (error) {
         handleLoginFailure(error);
       }
     },
-    [rudder, isWeb, loginWithWallet, handleLoginFailure]
+    [rudder, loginWithWallet, handleLoginFailure]
   );
   const handleSubmitEmail = useCallback(
     async function handleSubmitEmail(email: string) {


### PR DESCRIPTION
# Why
- We can pass `provider_access_token` in login APIs. 
- Also did some small refactor in web login with wallet. Made it more similar to native.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->


<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Test login with wallet works on web.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
