### PR TITLE
fix: enforce captcha gate to fix mismatch with backend

### DIFF
--- a/packages/app/components/onboarding/hcaptcha/challenge.tsx
+++ b/packages/app/components/onboarding/hcaptcha/challenge.tsx
@@ -36,6 +36,9 @@ export const Challenge = () => {
   const captchaRef = useRef<ConfirmHcaptcha>(null);
 
   const showCaptcha = () => {
+    // skip directly to the next step if user has already a social account
+    // connected or if the user has already completed the captcha challenge
+
     const hasSocialHandle =
       user?.data?.profile?.social_login_handles?.twitter ||
       user?.data?.profile?.social_login_handles?.instagram ||

--- a/packages/app/components/onboarding/hcaptcha/challenge.tsx
+++ b/packages/app/components/onboarding/hcaptcha/challenge.tsx
@@ -36,12 +36,12 @@ export const Challenge = () => {
   const captchaRef = useRef<ConfirmHcaptcha>(null);
 
   const showCaptcha = () => {
-    // skip directly to the next step if user has already a social account
-    // connected or if the user has already completed the captcha challenge
-    if (
-      user?.data.profile.captcha_completed_at ||
-      user?.data.profile.has_social_login
-    ) {
+    const hasSocialHandle =
+      user?.data?.profile?.social_login_handles?.twitter ||
+      user?.data?.profile?.social_login_handles?.instagram ||
+      false;
+
+    if (user?.data?.profile?.captcha_completed_at || hasSocialHandle) {
       finishOnboarding();
       return;
     }

--- a/packages/app/components/onboarding/hcaptcha/challenge.web.tsx
+++ b/packages/app/components/onboarding/hcaptcha/challenge.web.tsx
@@ -53,10 +53,12 @@ export const Challenge = () => {
     // skip directly to the next step if user has already a social account
     // connected or if the user has already completed the captcha challenge
 
-    if (
-      user?.data.profile.captcha_completed_at ||
-      user?.data.profile.has_social_login
-    ) {
+    const hasSocialHandle =
+      user?.data?.profile?.social_login_handles?.twitter ||
+      user?.data?.profile?.social_login_handles?.instagram ||
+      false;
+
+    if (user?.data?.profile?.captcha_completed_at || hasSocialHandle) {
       finishOnboarding();
       return;
     }

--- a/packages/app/components/onboarding/hcaptcha/sitekey.ts
+++ b/packages/app/components/onboarding/hcaptcha/sitekey.ts
@@ -1,3 +1,4 @@
-export const siteKey = process.env.E2E
-  ? "10000000-ffff-ffff-ffff-000000000001"
-  : "e75de5d7-0f0c-4061-8647-65362888979e";
+export const siteKey =
+  process.env.E2E || __DEV__
+    ? "10000000-ffff-ffff-ffff-000000000001"
+    : "e75de5d7-0f0c-4061-8647-65362888979e";

--- a/packages/app/utilities.ts
+++ b/packages/app/utilities.ts
@@ -631,9 +631,15 @@ export const isProfileIncomplete = (profile?: Profile) => {
       (k) => profile?.social_login_connections[k]
     );
 
+  const hasSocialHandle =
+    profile?.social_login_handles?.twitter ||
+    profile?.social_login_handles?.instagram ||
+    false;
+
   return profile
     ? !profile.username ||
-        (!hasConnectedSocialAccount && !profile.captcha_completed_at)
+        (!hasConnectedSocialAccount && !profile.captcha_completed_at) ||
+        (!hasSocialHandle && !profile.captcha_completed_at)
     : undefined;
 };
 


### PR DESCRIPTION
# Why

The gating was wrong and not in-line with the backend.
We had hundreds of issues raised in our Sentry logs, because the frontend logic did not align to https://github.com/showtime-xyz/stbackend/commit/a1b00f612cebc5499a050c4b2a8f7c21c9ee42d3#diff-ea7a8b8d5961cb00e2715e7572e49422b5ed37b7a328c4a9c77e2b66a90e3d46R19-R30

Our issue was that we focused on Instagram and Twitter connections and did not test the fact with a skipped hCaptcha

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

We will enforce the onboarding again for users without Instagram or Twitter, since only checking for SocialAccounts is not enough. Before, we did not show hCaptcha to users as soon as they had a username, which caused a wrong state.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
