### PR TITLE
fix: remove alert on spotify cancel

### DIFF
--- a/packages/app/hooks/use-connect-spotify.ts
+++ b/packages/app/hooks/use-connect-spotify.ts
@@ -30,9 +30,6 @@ export const useConnectSpotify = () => {
             redirectUri,
           };
         }
-      } else {
-        Logger.error("Spotify auth failed", res);
-        Alert.alert("Error", "Something went wrong");
       }
     } catch (e) {
       Logger.error("Spotify auth failed", e);


### PR DESCRIPTION
# Why
Remove alert if user presses cancel on spotify connect popup
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->
