### PR TITLE
fix: dont log while on prod

### DIFF
--- a/packages/app/lib/logger/index.ts
+++ b/packages/app/lib/logger/index.ts
@@ -1,13 +1,13 @@
 export const Logger = {
   log: (...args: any) => {
-    // if (__DEV__) {
-    console.log(...args);
-    // }
+    if (__DEV__) {
+      console.log(...args);
+    }
   },
 
   error: (...args: any) => {
-    // if (__DEV__) {
-    console.error(...args);
-    // }
+    if (__DEV__) {
+      console.error(...args);
+    }
   },
 };


### PR DESCRIPTION
# Why

Currently, we log on prod, which is bad for performance. If we decide to actually do something with our logs in the future, we can add a strategy.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Only output console.log on __DEV__

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
