### PR TITLE
fix: modal auto-responsive height

### DIFF
--- a/packages/app/components/drop/drop-free/drop-free.tsx
+++ b/packages/app/components/drop/drop-free/drop-free.tsx
@@ -484,7 +484,7 @@ export const DropFree = () => {
                   return (
                     <Fieldset
                       ref={ref}
-                      tw="mt-4 flex-1"
+                      tw="mt-4"
                       label="Description"
                       multiline
                       textAlignVertical="top"

--- a/packages/app/screens/checkout-return.tsx
+++ b/packages/app/screens/checkout-return.tsx
@@ -8,6 +8,5 @@ export const CheckoutReturnScreen = withModalScreen(CheckoutReturn, {
   matchingQueryParam: "checkoutReturnModal",
   tw: "w-full lg:w-[500px]",
   disableBackdropPress: true,
-  web_height: `max-h-[100vh] md:max-h-[82vh]`,
   snapPoints: ["100%"],
 });

--- a/packages/app/screens/checkout.tsx
+++ b/packages/app/screens/checkout.tsx
@@ -8,6 +8,5 @@ export const CheckoutScreen = withModalScreen(Checkout, {
   matchingQueryParam: "checkoutModal",
   tw: "w-full lg:w-[500px]",
   disableBackdropPress: true,
-  web_height: `max-h-[100vh] md:max-h-[82vh]`,
   snapPoints: ["100%"],
 });

--- a/packages/app/screens/drop-event.tsx
+++ b/packages/app/screens/drop-event.tsx
@@ -8,6 +8,5 @@ export const DropEventScreen = withModalScreen(DropEvent, {
   matchingQueryParam: "dropEvent",
   tw: "w-full lg:w-[800px]",
   disableBackdropPress: true,
-  web_height: `max-h-[100vh] md:max-h-[82vh]`,
   snapPoints: ["100%"],
 });

--- a/packages/app/screens/drop-free.tsx
+++ b/packages/app/screens/drop-free.tsx
@@ -8,6 +8,5 @@ export const DropFreeScreen = withModalScreen(DropFree, {
   matchingQueryParam: "dropFree",
   tw: "w-full lg:w-[800px]",
   disableBackdropPress: true,
-  web_height: `max-h-[100vh] md:max-h-[82vh]`,
   snapPoints: ["100%"],
 });

--- a/packages/app/screens/drop-music.tsx
+++ b/packages/app/screens/drop-music.tsx
@@ -8,6 +8,5 @@ export const DropMusicScreen = withModalScreen(DropMusic, {
   matchingQueryParam: "dropMusic",
   tw: "w-full lg:w-[800px]",
   disableBackdropPress: true,
-  web_height: `max-h-[100vh] md:max-h-[82vh]`,
   snapPoints: ["100%"],
 });

--- a/packages/app/screens/drop-private.tsx
+++ b/packages/app/screens/drop-private.tsx
@@ -8,6 +8,5 @@ export const DropPrivateScreen = withModalScreen(DropPrivate, {
   matchingQueryParam: "dropPrivate",
   tw: "w-full lg:w-[800px]",
   disableBackdropPress: true,
-  web_height: `max-h-[100vh] md:max-h-[82vh]`,
   snapPoints: ["100%"],
 });

--- a/packages/app/screens/drop.tsx
+++ b/packages/app/screens/drop.tsx
@@ -12,6 +12,5 @@ export const DropScreen = withModalScreen(DropModal, {
   matchingQueryParam: "dropModal",
   tw: "w-full lg:w-[800px] web:lg:pb-14",
   disableBackdropPress: true,
-  web_height: `max-h-[100vh] md:max-h-[82vh]`,
   snapPoints: ["100%"],
 });

--- a/packages/app/screens/edit-profile.tsx
+++ b/packages/app/screens/edit-profile.tsx
@@ -24,5 +24,4 @@ export const EditProfileScreen = withModalScreen(EditProfilePage, {
   enableContentPanningGesture: false,
   snapPoints: ["100%"],
   disableBackdropPress: true,
-  web_height: `h-[82vh]`,
 });

--- a/packages/app/screens/login.tsx
+++ b/packages/app/screens/login.tsx
@@ -14,6 +14,5 @@ export const LoginScreen = withModalScreen(LoginModal, {
   matchingPathname: "/login",
   matchingQueryParam: "loginModal",
   snapPoints: ["90%"],
-  web_height: `max-h-[100vh] md:max-h-[95vh]`,
   disableBackdropPress: true,
 });

--- a/packages/app/screens/onboarding.tsx
+++ b/packages/app/screens/onboarding.tsx
@@ -16,6 +16,5 @@ export const OnboardingScreen = withModalScreen(OnboardingPage, {
   headerShown: false,
   snapPoints: ["100%"],
   disableBackdropPress: true,
-  web_height: `h-[90vh]`,
   backPressHandlerEnabled: false,
 });

--- a/packages/design-system/fieldset/index.tsx
+++ b/packages/design-system/fieldset/index.tsx
@@ -154,13 +154,14 @@ function FieldsetImpl(props: FieldsetProps, ref: any) {
         {helperText ? (
           <>
             <View tw="mt-4 h-[1px] w-full bg-gray-200 dark:bg-gray-800" />
-            <View tw="h-4" />
-            <Text
-              nativeID={helperTextId}
-              tw="text-sm leading-6 text-gray-700 dark:text-gray-300"
-            >
-              {helperText}
-            </Text>
+            <View tw="mt-4">
+              <Text
+                nativeID={helperTextId}
+                tw="text-sm leading-6 text-gray-700 dark:text-gray-300"
+              >
+                {helperText}
+              </Text>
+            </View>
           </>
         ) : null}
       </PlatformAnimateHeight>

--- a/packages/design-system/fieldset/index.tsx
+++ b/packages/design-system/fieldset/index.tsx
@@ -102,7 +102,7 @@ function FieldsetImpl(props: FieldsetProps, ref: any) {
           {leftElement}
           {!selectOnly ? (
             <Component
-              tw="flex-1 text-base text-black focus-visible:ring-1 dark:text-white"
+              tw="w-full flex-1 text-base text-black focus-visible:ring-1 dark:text-white"
               //@ts-ignore - web only
               style={Platform.select({
                 web: { outline: "none" },

--- a/packages/design-system/modal-screen/with-modal-screen.web.tsx
+++ b/packages/design-system/modal-screen/with-modal-screen.web.tsx
@@ -50,13 +50,7 @@ function withModalScreen<P extends object>(
 
     return (
       <ModalScreenContext.Provider value={contextValues}>
-        <Modal
-          ref={modalRef}
-          title={title}
-          web_height="auto"
-          onClose={onClose}
-          {...rest}
-        >
+        <Modal ref={modalRef} title={title} onClose={onClose} {...rest}>
           <Screen {...props} />
         </Modal>
       </ModalScreenContext.Provider>

--- a/packages/design-system/modal/constants.ts
+++ b/packages/design-system/modal/constants.ts
@@ -1,2 +1,2 @@
 export const MOBILE_SNAP_POINTS = ["90%", "100%"];
-export const WEB_HEIGHT = "max-h-[280px]";
+export const WEB_HEIGHT = "max-h-[85vh] web:max-h-[99svh] md:max-h-[82vh]";

--- a/packages/design-system/modal/types.ts
+++ b/packages/design-system/modal/types.ts
@@ -31,7 +31,7 @@ export interface ModalProps {
   /**
    * **WEB ONLY**: Defines the modal container height.
    * It could be static value or responsive.
-   * @default "max-h-[280px]"
+   * @default "max-h-[85vh] web:max-h-[99svh] md:max-h-[82vh]"
    */
   web_height?: string;
 


### PR DESCRIPTION
# Why

Currently, our modal height is not perfect and sometimes exceeds the window screen. 
Now that CSS supports `svh` and `lvh` units, we can use them to improve it. 

# How

Use `svh` instead of `vh` on mobile browsers. If the current browser does not support svh, it will fallback to using `vh`. 



## Before 
![CleanShot 2023-03-29 at 4 07 01](https://user-images.githubusercontent.com/37520667/228468399-415a4ded-b689-42fd-928c-387f91c7c4d5.png)

## After 
![CleanShot 2023-03-29 at 4 07 51](https://user-images.githubusercontent.com/37520667/228468528-2a74149c-253e-4509-ae80-09d7a3ad3153.png)

