### PR TITLE
fix: don't prefetch links visible in viewport

### DIFF
--- a/packages/app/navigation/link/link-core.web.tsx
+++ b/packages/app/navigation/link/link-core.web.tsx
@@ -20,7 +20,7 @@ function LinkCore({
   componentProps?: any;
 }) {
   return (
-    <NextLink {...props} href={href} as={as} passHref>
+    <NextLink {...props} href={href} as={as} passHref prefetch={false}>
       <Component {...componentProps} onClick={componentProps?.onPress}>
         {children}
       </Component>


### PR DESCRIPTION
# Why

The Link component in Next.js prefetches links that are visible in the viewport, leading to inaccurate analytics, unnecessary fetches, and increased AppEngine costs.

Some more background: https://github.com/vercel/next.js/discussions/24009

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

I have disabled that feature since it only provides a minor speed improvement at the cost of unnecessary prefetching. The Link component still preloads on hover by default, so there is no need to worry about losing that functionality.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
