### PR TITLE
fix: correctly handle video clicks

### DIFF
--- a/packages/app/components/feed/feed-item-tap-gesture.web.tsx
+++ b/packages/app/components/feed/feed-item-tap-gesture.web.tsx
@@ -14,6 +14,7 @@ import Animated, {
 import { HeartFilled, Play } from "@showtime-xyz/universal.icon";
 
 import { useLike } from "app/context/like-context";
+import { useMuted } from "app/providers/mute-provider";
 
 const heartContainerStyle: ViewStyle = {
   position: "absolute",
@@ -41,6 +42,7 @@ export const FeedItemTapGesture = ({
   isVideo,
 }: FeedItemTapGestureProps) => {
   const { like } = useLike();
+  const [muted, setMuted] = useMuted();
 
   const heartAnimation = useSharedValue(0);
   const playAnimation = useSharedValue(0);
@@ -64,8 +66,9 @@ export const FeedItemTapGesture = ({
     const curVideo = videoRef?.current?._nativeRef?.current?._video;
     if (!curVideo) return;
 
-    if (curVideo.muted) {
+    if (curVideo.muted || muted) {
       curVideo.muted = false;
+      setMuted(false);
       return;
     }
 
@@ -82,7 +85,7 @@ export const FeedItemTapGesture = ({
         withDelay(200, withSpring(0))
       );
     }
-  }, [videoRef, playAnimation, isVideo]);
+  }, [isVideo, videoRef, muted, setMuted, playAnimation]);
 
   const singleTapHandle = useMemo(
     () =>
@@ -137,7 +140,7 @@ export const FeedItemTapGesture = ({
             style={[heartContainerStyle, playStyle, sizeStyle]}
             pointerEvents="none"
           >
-            <Play width={120} height={120} color="#fff" />
+            <Play width={100} height={100} color="#fff" />
           </Animated.View>
         </>
       ) : null}

--- a/packages/app/providers/mute-provider.tsx
+++ b/packages/app/providers/mute-provider.tsx
@@ -21,12 +21,15 @@ type MuteState = [boolean, Dispatch<SetStateAction<boolean>>];
 
 const useAutoPlayWithSound = (values: MuteState) => {
   useEffect(() => {
-    const handleClick = async () => {
-      // now we want to check if the current page has a video
-      // if it does, we want to unmute it
-      // if it doesn't, we want to do nothing
-      const video = document.querySelector("video");
-      if (!video) return;
+    const handleClick = (event: PointerEvent | MouseEvent) => {
+      const target = event.target as HTMLElement;
+
+      // if the target is a video, we want to do nothing as well since this is handled by the video player
+      if (
+        typeof target === "object" &&
+        target.tagName.toLowerCase() === "video"
+      )
+        return;
 
       // get setter from mute context
       const setMuted = values[1];


### PR DESCRIPTION
# Why

Directly clicking on a video would unmute and pause at the same time, which lead into a weird UX.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

The global click interceptor checks for the target now and let handle muted videos directly in the item.
So on web, a click on a muted video will first unmute it and every further click will pause/resume.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
