### PR TITLE
fix: forward button browser

### DIFF
--- a/packages/app/components/swipe-list.web.tsx
+++ b/packages/app/components/swipe-list.web.tsx
@@ -72,6 +72,10 @@ export const SwipeList = ({
   );
 
   useEffect(() => {
+    const popStateListener = () => {
+      window.removeEventListener("popstate", popStateListener);
+      router.pop();
+    };
     if (
       !initialURLSet.current &&
       isSwipeListScreen &&
@@ -79,12 +83,17 @@ export const SwipeList = ({
     ) {
       const nft = data[Number(initialParamProp)];
       if (nft) {
-        window.history.replaceState(null, "", getNFTSlug(nft));
+        window.history.pushState({}, "", getNFTSlug(nft));
+        window.addEventListener("popstate", popStateListener);
       }
 
       initialURLSet.current = true;
     }
-  }, [data, isSwipeListScreen, initialParamProp]);
+
+    return () => {
+      window.removeEventListener("popstate", popStateListener);
+    };
+  }, [data, isSwipeListScreen, initialParamProp, router]);
 
   const onRealIndexChange = useCallback(
     (e: SwiperClass) => {


### PR DESCRIPTION
# Why
- This is a workaround solution to fix the forward button. Reported by @hirbod https://showtime-rq88331.slack.com/archives/C02QD3J7DJM/p1680177169673189?thread_ts=1680117135.634529&cid=C02QD3J7DJM
- Long term fix would be use a context to store the ephemeral state instead of this URL hack. Keeping it low priority if this solution is good enough 😅 

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- Use pushState and listen to window popstate to inform next router to go back. It is very hacky. 
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
Test forward and back button from feed to detail screen
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
