### PR TITLE
fix: disable username/name for verified profiles

### DIFF
--- a/packages/app/components/edit-profile.tsx
+++ b/packages/app/components/edit-profile.tsx
@@ -4,6 +4,7 @@ import {
   useWindowDimensions,
   ScrollView as RNScrollView,
   View as RNView,
+  Keyboard,
 } from "react-native";
 
 import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
@@ -19,7 +20,9 @@ import {
   Twitter,
   Check,
   InstagramColorful,
+  InformationCircle,
 } from "@showtime-xyz/universal.icon";
+import { ModalSheet } from "@showtime-xyz/universal.modal-sheet";
 import { Pressable } from "@showtime-xyz/universal.pressable";
 import { PressableHover } from "@showtime-xyz/universal.pressable-hover";
 import { useRouter } from "@showtime-xyz/universal.router";
@@ -46,6 +49,7 @@ import { getFileFormData } from "app/utilities";
 import { breakpoints } from "design-system/theme";
 
 import { MediaCropper } from "./media-cropper";
+import { ProfileVerifiedExplanation } from "./profile/profile-verified-explanation";
 
 type Query = {
   redirectUri?: string;
@@ -112,14 +116,19 @@ export const EditProfile = () => {
   const isMdWidth = width >= breakpoints["md"];
   const { isValid, validate } = useValidateUsername();
   const socialLinks = useLinkOptions();
+  const isDark = useIsDarkMode();
   const pickFile = useFilePicker();
   const [cropViewHeight, setCropViewHeight] = useState(400);
   const scrollViewRef = useRef<RNScrollView>(null);
   const socialRef = useRef<RNView>(null);
   // edit media regin
   const [selectedImg, setSelectedImg] = useState<string | File | null>(null);
+  const [showVerifiedExplanation, setShowVerifiedExplanation] = useState(false);
 
   const [redirectUri] = useParam("redirectUri");
+
+  // store if the user is verified
+  const isVerified = user?.data?.profile?.verified || false;
 
   const [currentCropField, setCurrentCropField] = useState<
     null | "coverPicture" | "profilePicture"
@@ -383,57 +392,100 @@ export const EditProfile = () => {
                 )}
               />
               <View tw="pt-6">
-                <Text tw="text-base font-bold text-gray-900 dark:text-gray-500">
-                  About me
-                </Text>
-                <View tw="mt-4 flex-row">
-                  <Controller
-                    control={control}
-                    name="name"
-                    render={({ field: { onChange, onBlur, value, ref } }) => (
-                      <Fieldset
-                        ref={ref}
-                        tw="mr-2 w-1/2 flex-1"
-                        label="Name"
-                        placeholder="Your display name"
-                        value={value}
-                        textContentType="name"
-                        errorText={errors.name?.message}
-                        onBlur={onBlur}
-                        onChangeText={onChange}
+                <View tw="flex-row items-center justify-between">
+                  <Text tw="text-base font-bold text-gray-900 dark:text-gray-500">
+                    About me
+                  </Text>
+                  {isVerified && (
+                    <Pressable
+                      onPress={() => {
+                        Keyboard.dismiss();
+                        setShowVerifiedExplanation(true);
+                      }}
+                    >
+                      <InformationCircle
+                        height={20}
+                        width={20}
+                        color={isDark ? colors.gray[400] : colors.gray[600]}
                       />
-                    )}
-                  />
+                    </Pressable>
+                  )}
+                </View>
 
-                  <Controller
-                    control={control}
-                    rules={{
-                      onChange: (v) => {
-                        validate(v.target.value);
-                      },
+                <View tw="mt-4 flex-row">
+                  <Pressable
+                    tw={`mr-2 w-1/2 flex-1 ${
+                      isVerified ? "opacity-60" : "opacity-100"
+                    }`}
+                    onPress={() => {
+                      if (isVerified) setShowVerifiedExplanation(true);
                     }}
-                    name="username"
-                    render={({ field: { onChange, onBlur, value, ref } }) => (
-                      <Fieldset
-                        ref={ref}
-                        tw="ml-2 w-1/2 flex-1"
-                        label="Username"
-                        placeholder="Your username"
-                        value={value}
-                        textContentType="username"
-                        errorText={
-                          !isValid
-                            ? "Username has been taken"
-                            : errors.username?.message
-                        }
-                        autoCorrect={false}
-                        autoCapitalize="none"
-                        autoComplete="off"
-                        onBlur={onBlur}
-                        onChangeText={onChange}
-                      />
-                    )}
-                  />
+                  >
+                    <Controller
+                      control={control}
+                      name="name"
+                      render={({ field: { onChange, onBlur, value, ref } }) => (
+                        <Fieldset
+                          ref={ref}
+                          label="Name"
+                          placeholder="Your display name"
+                          value={value}
+                          textContentType="name"
+                          errorText={errors.name?.message}
+                          onBlur={onBlur}
+                          onChangeText={onChange}
+                          keyboardAppearance={isDark ? "dark" : "light"}
+                          disabled={isVerified}
+                          onPressIn={() => {
+                            if (isVerified) setShowVerifiedExplanation(true);
+                          }}
+                        />
+                      )}
+                    />
+                  </Pressable>
+
+                  <Pressable
+                    tw={`ml-2 w-1/2 flex-1 ${
+                      isVerified ? "opacity-60" : "opacity-100"
+                    }`}
+                    onPress={() => {
+                      if (isVerified) setShowVerifiedExplanation(true);
+                    }}
+                  >
+                    <Controller
+                      control={control}
+                      rules={{
+                        onChange: (v) => {
+                          validate(v.target.value);
+                        },
+                      }}
+                      name="username"
+                      render={({ field: { onChange, onBlur, value, ref } }) => (
+                        <Fieldset
+                          ref={ref}
+                          label="Username"
+                          placeholder="Your username"
+                          value={value}
+                          textContentType="username"
+                          errorText={
+                            !isValid
+                              ? "Username has been taken"
+                              : errors.username?.message
+                          }
+                          autoCorrect={false}
+                          autoCapitalize="none"
+                          autoComplete="off"
+                          onBlur={onBlur}
+                          onChangeText={onChange}
+                          keyboardAppearance={isDark ? "dark" : "light"}
+                          disabled={isVerified}
+                          onPressIn={() => {
+                            if (isVerified) setShowVerifiedExplanation(true);
+                          }}
+                        />
+                      )}
+                    />
+                  </Pressable>
                 </View>
               </View>
 
@@ -454,6 +506,7 @@ export const EditProfile = () => {
                     errorText={errors.bio?.message}
                     onBlur={onBlur}
                     onChangeText={onChange}
+                    keyboardAppearance={isDark ? "dark" : "light"}
                   />
                 )}
               />
@@ -474,12 +527,13 @@ export const EditProfile = () => {
                     onBlur={onBlur}
                     onChangeText={onChange}
                     errorText={errors.website_url?.message}
+                    keyboardAppearance={isDark ? "dark" : "light"}
                   />
                 )}
               />
 
               {/* Social */}
-              <View tw="mt-6 mb-10" ref={socialRef}>
+              <View tw="mb-10 mt-6" ref={socialRef}>
                 <View tw="mb-4 rounded-xl bg-gray-100 px-4 py-4 dark:bg-gray-800">
                   <View tw="flex-row items-center justify-between">
                     <View tw="flex-row items-center">
@@ -535,6 +589,15 @@ export const EditProfile = () => {
             </Text>
           </View>
         </View>
+        <ModalSheet
+          snapPoints={[240]}
+          title="Verified profiles"
+          visible={showVerifiedExplanation}
+          close={() => setShowVerifiedExplanation(false)}
+          onClose={() => setShowVerifiedExplanation(false)}
+        >
+          <ProfileVerifiedExplanation />
+        </ModalSheet>
       </BottomSheetModalProvider>
       <MediaCropper
         src={selectedImg}
@@ -587,7 +650,7 @@ const ConnectButton = ({
       tw={"items-center justify-center"}
     >
       <View
-        tw={`min-h-4 flex flex-row items-center justify-center rounded-2xl border py-2 px-4 ${
+        tw={`min-h-4 flex flex-row items-center justify-center rounded-2xl border px-4 py-2 ${
           !isConnected
             ? isDark
               ? "border-white"

--- a/packages/app/components/feed-item/feed-item.web.tsx
+++ b/packages/app/components/feed-item/feed-item.web.tsx
@@ -88,12 +88,12 @@ export const FeedItem = memo<FeedItemProps>(function FeedItem({
     <>
       <LikeContextProvider nft={nft} key={nft.nft_id}>
         {nft?.mime_type?.startsWith("video") ? (
-          <View tw="absolute top-2 left-1/2 z-50 -translate-x-1/2">
+          <View tw="absolute left-1/2 top-2 z-50 -translate-x-1/2">
             <MuteButton variant="mobile-web" />
           </View>
         ) : null}
         <View
-          tw="max-h-[100dvh] min-h-[100svh] w-full"
+          tw="max-h-[100svh] min-h-[100svh] w-full"
           style={{ height: itemHeight, overflow: "hidden" }}
         >
           <View

--- a/packages/app/components/profile/profile-verified-explanation.tsx
+++ b/packages/app/components/profile/profile-verified-explanation.tsx
@@ -1,0 +1,13 @@
+import { Text } from "@showtime-xyz/universal.text";
+import { View } from "@showtime-xyz/universal.view";
+
+export const ProfileVerifiedExplanation = () => {
+  return (
+    <View tw="mb-6 justify-center px-4 pt-4">
+      <Text tw="text-sm leading-5 text-black dark:text-white">
+        Verified Profiles cannot change their display name or username. If you
+        need to change it, contact us at help@showtime.xyz.
+      </Text>
+    </View>
+  );
+};


### PR DESCRIPTION
# Why

Verified profiles can't change username and display name, which is intentional. But we haven't disabled the fields which lead to weird UX.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Added info circle and opacity hints why they can't change it.
Tested on Desktop, Web, App, Mobile

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
![Simulator Screen Shot - iPhone 14 Pro Max - 2023-03-31 at 21 57 14](https://user-images.githubusercontent.com/504909/229223789-99564f92-b22a-4370-91c8-a3e6de767c5e.png)

https://user-images.githubusercontent.com/504909/229223793-2d1c4a83-30e5-423b-abe8-c0108e661866.mp4



![Simulator Screen Shot - iPhone 14 Pro Max - 2023-03-31 at 21 57 06](https://user-images.githubusercontent.com/504909/229223780-f13351c3-2866-4ace-9920-97ff135dec54.png)


