### PR TITLE
fix: XCode 14.3 temp issues with config plugin

### DIFF
--- a/apps/expo/app.config.js
+++ b/apps/expo/app.config.js
@@ -160,6 +160,7 @@ export default {
     "./plugins/react-native-cronet.js",
     "./plugins/with-spotify-sdk.js",
     "./plugins/with-android-splash-screen.js",
+    "./plugins/fix-deployment-target.js",
     [
       withInfoPlist,
       (config) => {

--- a/apps/expo/plugins/fix-deployment-target.js
+++ b/apps/expo/plugins/fix-deployment-target.js
@@ -1,0 +1,42 @@
+// Credit: https://github.com/facebook/react-native/issues/34106#issuecomment-1493040686
+// This plugin is used to fix the deployment target issue in iOS
+const { withDangerousMod, withPlugins } = require("@expo/config-plugins");
+const {
+  mergeContents,
+} = require("@expo/config-plugins/build/utils/generateCode");
+const { readFileSync, writeFileSync } = require("fs");
+const { resolve } = require("path");
+
+const withFixedDeploymentTarget = (c) => {
+  return withDangerousMod(c, [
+    "ios",
+    async (config) => {
+      const file = resolve(config.modRequest.platformProjectRoot, "Podfile");
+      const contents = readFileSync(file, { encoding: "utf-8" });
+      writeFileSync(file, fixDeploymentTarget(contents));
+      return config;
+    },
+  ]);
+};
+
+function fixDeploymentTarget(src) {
+  return mergeContents({
+    tag: `rn-fix-deployment-target`,
+    src,
+    newSrc: `
+  installer.pods_project.targets.each do |target|
+    if target.to_s === 'React-Codegen'
+      target.build_configurations.each do |config|
+        config.build_settings['SWIFT_VERSION'] = '5.0'
+        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '13.0'
+      end
+    end
+  end
+`,
+    anchor: /post_install/,
+    offset: 1,
+    comment: "#",
+  }).contents;
+}
+
+module.exports = (config) => withPlugins(config, [withFixedDeploymentTarget]);


### PR DESCRIPTION
# Why

Our App can't compile with the new XCode 14.3 currently. 

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Looks like there are packages which haven't updated their podspecs to target the correct deployment target. Added a Config plugin to fix this issue for now, since build properties alone are not enough to fix this.

Credit goes to: https://github.com/facebook/react-native/issues/34106#issuecomment-1493040686

The upstream bugfix is already merged but I don't know if this is going to be backported, so we need to monitor new releases.
https://github.com/facebook/react-native/pull/36759

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
