### PR TITLE
fix: modal not popping when route pattern matches url

### DIFF
--- a/packages/design-system/router/use-router.web.ts
+++ b/packages/design-system/router/use-router.web.ts
@@ -33,14 +33,13 @@ export function useRouter() {
         );
         if (modal) {
           const as = nextRouter.asPath;
+          const newQuery = { ...nextRouter.query };
+          delete newQuery[modal];
 
           nextRouter.replace(
             {
               pathname: as,
-              query: {
-                ...nextRouter.query,
-                [modal]: undefined,
-              },
+              query: newQuery,
             },
             as,
             { shallow: true, scroll: false }

--- a/packages/design-system/router/use-router.web.ts
+++ b/packages/design-system/router/use-router.web.ts
@@ -34,7 +34,17 @@ export function useRouter() {
         if (modal) {
           const as = nextRouter.asPath;
 
-          nextRouter.replace(as, as, { shallow: true, scroll: false });
+          nextRouter.replace(
+            {
+              pathname: as,
+              query: {
+                ...nextRouter.query,
+                [modal]: undefined,
+              },
+            },
+            as,
+            { shallow: true, scroll: false }
+          );
         } else {
           nextRouter.back();
         }

--- a/packages/design-system/router/use-router.web.ts
+++ b/packages/design-system/router/use-router.web.ts
@@ -32,15 +32,7 @@ export function useRouter() {
           key.includes("Modal")
         );
         if (modal) {
-          // Sometimes we open a modal and we also update the URL to match the
-          // modal name. Example: /nft/id/details
-          const modalName = modal.split("Modal")[0];
-          const shouldRemoveModalNameFromAsPath =
-            nextRouter.asPath.includes(modalName);
-
-          const as = shouldRemoveModalNameFromAsPath
-            ? nextRouter.asPath.split("/").slice(0, -1).join("/")
-            : nextRouter.asPath;
+          const as = nextRouter.asPath;
 
           nextRouter.replace(as, as, { shallow: true, scroll: false });
         } else {


### PR DESCRIPTION
# Why
I don't think we're supporting the below usecase in any of the URLs. So I thought of removing the special handling.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->


<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
Test all modals with close button on web
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
