### PR TITLE
fix: dont output "creator" by default

### DIFF
--- a/packages/app/components/card/rows/elements/creator.tsx
+++ b/packages/app/components/card/rows/elements/creator.tsx
@@ -33,7 +33,7 @@ export function Creator({
   nft,
   shouldShowCreatorIndicator = true,
   shouldShowDateCreated = true,
-  label = "Creator",
+  label = "",
 }: Props) {
   if (!nft) return null;
 


### PR DESCRIPTION
# Why

We're outputting "creator" everywhere, which is really redundant. 
Talked with Alex, we agreed to remove it globally. If its needed somewhere specific, the label can be passed.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Removed default value.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

![Bildschirm_foto 2023-04-05 um 23 25 34](https://user-images.githubusercontent.com/504909/230216141-01c22add-5a9d-4c12-a9bc-92985d418782.png)

