### PR TITLE
fix: spotify before login save success event

### DIFF
--- a/packages/app/components/claim/claim-button.tsx
+++ b/packages/app/components/claim/claim-button.tsx
@@ -86,9 +86,7 @@ export const ClaimButton = ({
       !isAuthenticated
     ) {
       Analytics.track(EVENTS.SPOTIFY_SAVE_PRESSED_BEFORE_LOGIN);
-      claimSpotifyGatedDrop().then(() => {
-        Analytics.track(EVENTS.SPOTIFY_SAVE_SUCCESS_BEFORE_LOGIN);
-      });
+      claimSpotifyGatedDrop();
     } else {
       redirectToClaimDrop(edition.creator_airdrop_edition.contract_address);
     }

--- a/packages/app/hooks/use-spotify-gated-claim.ts
+++ b/packages/app/hooks/use-spotify-gated-claim.ts
@@ -1,5 +1,6 @@
 import { useOnboardingPromise } from "app/components/onboarding";
 import { useClaimNFT } from "app/hooks/use-claim-nft";
+import { Analytics, EVENTS } from "app/lib/analytics";
 import { axios } from "app/lib/axios";
 import { Logger } from "app/lib/logger";
 import { useLogInPromise } from "app/lib/login-promise";
@@ -47,6 +48,7 @@ export const useSpotifyGatedClaim = (edition: IEdition) => {
             },
             method: "POST",
           });
+          Analytics.track(EVENTS.SPOTIFY_SAVE_SUCCESS_BEFORE_LOGIN);
 
           toast.success(
             "You just saved this song to your library! Sign in now to collect this drop."


### PR DESCRIPTION
# Why
Need to fire it after spotify save and not after claiming drop
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->
