### PR TITLE
fix: prevent text abuse in feed

### DIFF
--- a/packages/app/components/drop/drop-event.tsx
+++ b/packages/app/components/drop/drop-event.tsx
@@ -80,7 +80,11 @@ export const DropEvent = () => {
     () =>
       yup.object({
         file: yup.mixed().required("Media is required"),
-        title: yup.string().required("Title is a required field").max(50),
+        title: yup
+          .string()
+          .label("Title")
+          .required("Title is a required field")
+          .max(55),
         description: yup
           .string()
           .max(280)

--- a/packages/app/components/drop/drop-free/drop-free.tsx
+++ b/packages/app/components/drop/drop-free/drop-free.tsx
@@ -106,7 +106,11 @@ export const DropFree = () => {
   const dropValidationSchema = useMemo(() => {
     const validationObject = {
       file: yup.mixed().required("Media is required"),
-      title: yup.string().required("Title is a required field").max(50),
+      title: yup
+        .string()
+        .label("Title")
+        .required("Title is a required field")
+        .max(55),
       description: yup
         .string()
         .max(280)

--- a/packages/app/components/drop/drop-music.tsx
+++ b/packages/app/components/drop/drop-music.tsx
@@ -119,7 +119,11 @@ export const DropMusic = () => {
       yup.lazy((values) => {
         const baseSchema = yup.object({
           file: yup.mixed().required("Media is required"),
-          title: yup.string().required("Title is a required field").max(50),
+          title: yup
+            .string()
+            .label("Title")
+            .required("Title is a required field")
+            .max(55),
           description: yup
             .string()
             .max(280)

--- a/packages/app/components/drop/drop-private.tsx
+++ b/packages/app/components/drop/drop-private.tsx
@@ -82,7 +82,11 @@ export const DropPrivate = () => {
     () =>
       yup.object({
         file: yup.mixed().required("Media is required"),
-        title: yup.string().required("Title is a required field").max(50),
+        title: yup
+          .string()
+          .label("Title")
+          .required("Title is a required field")
+          .max(55),
         description: yup
           .string()
           .max(280)

--- a/packages/app/components/feed-item/details.tsx
+++ b/packages/app/components/feed-item/details.tsx
@@ -12,7 +12,12 @@ import { CreatorEditionResponse } from "app/hooks/use-creator-collection-detail"
 import { linkifyDescription } from "app/lib/linkify";
 import { TextLink } from "app/navigation/link";
 import type { NFT } from "app/types";
-import { getCreatorUsernameFromNFT, removeTags } from "app/utilities";
+import {
+  cleanUserTextInput,
+  getCreatorUsernameFromNFT,
+  limitLineBreaks,
+  removeTags,
+} from "app/utilities";
 
 import { ContentTypeTooltip } from "../content-type-tooltip";
 import { RaffleTooltip } from "./raffle-tooltip";
@@ -27,7 +32,7 @@ export const NFTDetails = ({ nft, edition, detail }: NFTDetailsProps) => {
   const description = useMemo(
     () =>
       linkifyDescription(
-        removeTags(nft?.token_description),
+        limitLineBreaks(cleanUserTextInput(removeTags(nft?.token_description))),
         "text-13 font-bold text-gray-100"
       ),
     [nft?.token_description]


### PR DESCRIPTION
# Why

The Text in the new Feed can break the layout. Added some logic to prevent too many line breaks.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
