### PR TITLE
fix: harmonize tooltips, badges, claimers

### DIFF
--- a/packages/app/components/content-type-tooltip.tsx
+++ b/packages/app/components/content-type-tooltip.tsx
@@ -68,10 +68,11 @@ export const ContentTypeTooltip = ({
     const Icon = contentGatingType[edition?.gating_type].icon;
     return (
       <TextTooltip
+        side="bottom"
         triggerElement={
           <>
             <View
-              tw="rounded bg-black/60"
+              tw="rounded-sm bg-black/60"
               style={StyleSheet.absoluteFillObject}
             />
             <View tw="flex-row items-center py-0.5 pl-0.5">
@@ -105,7 +106,10 @@ export const ContentTypeIcon = ({ edition }: ContentTypeTooltipProps) => {
     const Icon = contentGatingType[edition?.gating_type]?.icon;
     return (
       <View>
-        <View tw="rounded bg-black/60" style={StyleSheet.absoluteFillObject} />
+        <View
+          tw="rounded-sm bg-black/60"
+          style={StyleSheet.absoluteFillObject}
+        />
         <View tw="z-10">
           <Icon color="#fff" width={20} height={20} />
         </View>

--- a/packages/app/components/feed-item/details.tsx
+++ b/packages/app/components/feed-item/details.tsx
@@ -43,16 +43,16 @@ export const NFTDetails = ({ nft, edition, detail }: NFTDetailsProps) => {
       <View tw="flex flex-row justify-between">
         <View tw="flex-1 flex-col justify-end">
           <View>
-            <View tw="z-9 absolute -top-6">
-              <ContentTypeTooltip edition={edition} theme="dark" />
-            </View>
-            <View tw="mb-3 flex-row justify-between">
+            <View tw="-mt-5 mb-3 h-6 flex-row justify-start space-x-2">
               <RaffleTooltip edition={edition} theme="dark" />
-              <View />
+              <ContentTypeTooltip edition={edition} theme="dark" />
             </View>
 
             <View tw="mb-3 flex flex-row items-center justify-between">
-              <Text tw="flex-1 text-sm font-bold text-white dark:text-white md:text-gray-900">
+              <Text
+                tw="flex-1 text-sm font-bold text-white dark:text-white md:text-gray-900"
+                numberOfLines={2}
+              >
                 {nft.token_name}
               </Text>
             </View>
@@ -80,11 +80,12 @@ export const NFTDetails = ({ nft, edition, detail }: NFTDetailsProps) => {
                 {description}
               </Text>
             </Text>
-            <ClaimedBy
-              claimersList={detail?.multiple_owners_list}
-              nft={nft}
-              tw="mt-3"
-            />
+            <View tw="mt-3 h-5">
+              <ClaimedBy
+                claimersList={detail?.multiple_owners_list}
+                nft={nft}
+              />
+            </View>
           </View>
 
           {edition ? (

--- a/packages/app/components/feed-item/feed-item.md.tsx
+++ b/packages/app/components/feed-item/feed-item.md.tsx
@@ -324,12 +324,12 @@ export const FeedItemMD = memo<FeedItemProps>(function FeedItemMD({
           }}
         >
           <View tw="px-4">
-            <View tw="pt-4">
+            <View tw="flex-row items-center justify-between pt-4">
               <Social nft={nft} />
+              <RaffleTooltip edition={edition} tw="mr-1" />
             </View>
             <LikedBy nft={nft} tw="mt-4" />
             <View tw="my-4 mr-4 flex-row items-center">
-              <RaffleTooltip edition={edition} tw="mr-1" />
               <Text tw="text-xl font-bold text-black dark:text-white">
                 {nft.token_name}
               </Text>

--- a/packages/app/components/feed-item/raffle-tooltip.tsx
+++ b/packages/app/components/feed-item/raffle-tooltip.tsx
@@ -1,6 +1,4 @@
-import { Platform } from "react-native";
-
-import { Raffle, RaffleHorizontal } from "@showtime-xyz/universal.icon";
+import { RaffleHorizontal } from "@showtime-xyz/universal.icon";
 import { Text } from "@showtime-xyz/universal.text";
 import { View } from "@showtime-xyz/universal.view";
 
@@ -23,15 +21,16 @@ export const RaffleTooltip = ({
   if (!edition?.raffles || !edition?.raffles?.length) return null;
   return (
     <TextTooltip
+      side="bottom"
       triggerElement={
         <View
           tw={[
-            "h-5 flex-row items-center justify-center self-start rounded-sm bg-black/50 px-1",
+            "h-6 flex-row items-center justify-center self-start rounded-sm bg-black/60 px-1",
             tw,
           ]}
         >
           <RaffleHorizontal color={"#FFC633"} width={20} height={20} />
-          <Text tw="ml-1 text-xs text-white">Raffle</Text>
+          <Text tw="ml-1 text-xs font-semibold text-white">Raffle</Text>
         </View>
       }
       text="Collect to enter a raffle"

--- a/packages/app/components/play-on-spotify.tsx
+++ b/packages/app/components/play-on-spotify.tsx
@@ -30,10 +30,7 @@ export const PlayOnSpotify = ({
         }
       }}
     >
-      <View
-        tw="rounded-xl bg-gray-800/80"
-        style={StyleSheet.absoluteFillObject}
-      />
+      <View tw="rounded-sm bg-black/60" style={StyleSheet.absoluteFillObject} />
       <View tw="flex-row items-center">
         <Spotify color="white" width={20} height={20} />
         <Text


### PR DESCRIPTION
# Why

The Claimers and Tooltips have been not harmonized. Different Badges, Shapes and looks.
Also it caused CLS. I optimized the appearance, added some safety nets, put Spotify and raffle into the same column etc

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
