### PR TITLE
fix: tab view list blank sometimes

### DIFF
--- a/packages/design-system/collapsible-tab-view/scene.tsx
+++ b/packages/design-system/collapsible-tab-view/scene.tsx
@@ -60,7 +60,7 @@ export function SceneComponent<P extends object>({
     onScroll: (e) => {
       const moveY = e.contentOffset.y;
       scrollY.value = moveY;
-      if (curIndexValue.value !== index) return;
+      // if (curIndexValue.value !== index) return;
       shareAnimatedValue.value = moveY;
       if (propOnScroll) {
         runOnJS(propOnScroll as any)({ nativeEvent: e });


### PR DESCRIPTION
# Why
sometimes tabview list is empty when you scroll to top and switch tab, it's reported by @hirbod , I checked that it's working well on FlatList, ScrollView, SectionList but not on FlastList. 

# How


It may be due to the fact that FlatList has an inner list wrapped, so you may need to call it twice or more. I'm not entirely sure of the reason, but at least it's fixed now. 

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
## Before 


https://user-images.githubusercontent.com/37520667/230948658-f706a2cc-ece0-4d43-9fd6-3c3e8864d14e.MP4




## After 
https://user-images.githubusercontent.com/37520667/230948204-0f1563f6-5054-4f57-a161-f082c407f7e6.MP4


