### PR TITLE
fix: increase toast duration on pre-save before login

### DIFF
--- a/packages/app/hooks/use-spotify-gated-claim.ts
+++ b/packages/app/hooks/use-spotify-gated-claim.ts
@@ -51,7 +51,8 @@ export const useSpotifyGatedClaim = (edition: IEdition) => {
           Analytics.track(EVENTS.SPOTIFY_SAVE_SUCCESS_BEFORE_LOGIN);
 
           toast.success(
-            "You just saved this song to your library! Sign in now to collect this drop."
+            "You just saved this song to your library! Sign in now to collect this drop.",
+            { duration: 5000 }
           );
           await loginPromise();
           await onboardingPromise();


### PR DESCRIPTION
https://linear.app/showtime/issue/SHOW2-1680/bug-make-pre-save-logged-out-confirmation-5-seconds