### PR TITLE
fix: toast duration inconsistency between web and native

### DIFF
--- a/packages/app/hooks/use-spotify-gated-claim.ts
+++ b/packages/app/hooks/use-spotify-gated-claim.ts
@@ -52,7 +52,7 @@ export const useSpotifyGatedClaim = (edition: IEdition) => {
 
           toast.success(
             "You just saved this song to your library! Sign in now to collect this drop.",
-            { duration: 5 }
+            { duration: 5000 }
           );
           await loginPromise();
           await onboardingPromise();

--- a/packages/design-system/toast/toast.tsx
+++ b/packages/design-system/toast/toast.tsx
@@ -7,7 +7,12 @@ import type { ToasterProps } from "react-hot-toast";
 
 import { CustomOption, ValueOrFunction } from "./type";
 
-type ToastOptions = Omit<BurntToastOptions, "title" | "preset"> & {};
+type ToastOptions = Omit<BurntToastOptions, "title" | "preset" | "duration"> & {
+  /**
+   * Duration in milliseconds.
+   */
+  duration?: number;
+};
 
 type AlertOptions = Omit<BurntAlertOptions, "title"> & {};
 
@@ -16,6 +21,9 @@ function getPreset<T = string>(title: string, preset: T) {
 }
 
 const toast = (title: string, options?: ToastOptions) => {
+  if (typeof options?.duration === "number") {
+    options.duration = options.duration / 1000;
+  }
   return Burnt.toast({
     title: title,
     preset: "none",
@@ -24,6 +32,9 @@ const toast = (title: string, options?: ToastOptions) => {
 };
 
 toast.error = (title: string, options?: ToastOptions) => {
+  if (typeof options?.duration === "number") {
+    options.duration = options.duration / 1000;
+  }
   return Burnt.toast({
     title: title,
     preset: getPreset(title, "error"),
@@ -32,6 +43,9 @@ toast.error = (title: string, options?: ToastOptions) => {
   });
 };
 toast.success = (title: string, options?: ToastOptions) => {
+  if (typeof options?.duration === "number") {
+    options.duration = options.duration / 1000;
+  }
   return Burnt.toast({
     title: title,
     preset: getPreset(title, "done"),
@@ -41,12 +55,16 @@ toast.success = (title: string, options?: ToastOptions) => {
 };
 
 toast.custom = (title: string, options: CustomOption) => {
+  if (typeof options?.duration === "number") {
+    options.duration = options.duration / 1000;
+  }
   return Burnt.toast({
     title: title,
     preset: "custom",
     icon: {
       ios: options.ios,
     },
+    ...options,
   });
 };
 
@@ -61,6 +79,9 @@ toast.promise = function <T>(
   },
   options?: AlertOptions
 ) {
+  if (typeof options?.duration === "number") {
+    options.duration = options.duration / 1000;
+  }
   Burnt.alert({
     title: msgs.loading,
     preset: "spinner",

--- a/packages/design-system/toast/toast.tsx
+++ b/packages/design-system/toast/toast.tsx
@@ -64,7 +64,7 @@ toast.custom = (title: string, options: CustomOption) => {
     icon: {
       ios: options.ios,
     },
-    ...options,
+    duration: options.duration,
   });
 };
 

--- a/packages/design-system/toast/toast.web.tsx
+++ b/packages/design-system/toast/toast.web.tsx
@@ -38,6 +38,7 @@ const Toaster = () => {
 toast.custom = (message: any, options?: any): string => {
   return toast(message, {
     icon: options.web,
+    duration: options?.duration,
   });
 };
 export { Toaster, toast };

--- a/packages/design-system/toast/type.tsx
+++ b/packages/design-system/toast/type.tsx
@@ -8,4 +8,5 @@ export type ValueOrFunction<TValue, TArg> =
 export type CustomOption = {
   ios: CustomToastOptions["icon"]["ios"];
   web: JSX.Element | React.ReactNode;
+  duration?: number;
 };


### PR DESCRIPTION
# Why
Made toast duration to accept milliseconds on native same as on web
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->
