### PR TITLE
lazy load stripe

### DIFF
--- a/packages/app/components/checkout/checkout-form.tsx
+++ b/packages/app/components/checkout/checkout-form.tsx
@@ -40,7 +40,7 @@ export function CheckoutForm({ clientSecret }: { clientSecret: string }) {
   );
 
   return stripeOptions?.clientSecret ? (
-    <Elements stripe={stripePromise} options={stripeOptions}>
+    <Elements stripe={stripePromise()} options={stripeOptions}>
       <CheckoutFormStripe />
     </Elements>
   ) : null;

--- a/packages/app/components/checkout/checkout-return.tsx
+++ b/packages/app/components/checkout/checkout-return.tsx
@@ -30,7 +30,7 @@ export const CheckoutReturn = () => {
       window.location.search
     ).get("setAsDefaultPaymentMethod");
 
-    const stripe = await stripePromise;
+    const stripe = await stripePromise();
 
     const clientSecret = new URLSearchParams(window.location.search).get(
       "payment_intent_client_secret"

--- a/packages/app/components/checkout/stripe.ts
+++ b/packages/app/components/checkout/stripe.ts
@@ -1,5 +1,13 @@
-import { loadStripe } from "@stripe/stripe-js";
+import type { Stripe } from "@stripe/stripe-js";
+import { loadStripe } from "@stripe/stripe-js/pure";
 
-export const stripePromise = process.env.NEXT_PUBLIC_STRIPE_KEY
-  ? loadStripe(process.env.NEXT_PUBLIC_STRIPE_KEY)
-  : null;
+let cachedStripePromise: PromiseLike<Stripe | null> | Stripe | null = null;
+
+export const stripePromise = () => {
+  if (!cachedStripePromise)
+    cachedStripePromise = process.env.NEXT_PUBLIC_STRIPE_KEY
+      ? loadStripe(process.env.NEXT_PUBLIC_STRIPE_KEY)
+      : null;
+
+  return cachedStripePromise;
+};

--- a/packages/app/components/drop/drop-free/index.web.tsx
+++ b/packages/app/components/drop/drop-free/index.web.tsx
@@ -27,7 +27,7 @@ export const DropFree = () => {
       window.location.search
     ).get("setAsDefaultPaymentMethod");
 
-    const stripe = await stripePromise;
+    const stripe = await stripePromise();
 
     const clientSecret = new URLSearchParams(window.location.search).get(
       "payment_intent_client_secret"

--- a/packages/app/hooks/api/use-confirm-payment.ts
+++ b/packages/app/hooks/api/use-confirm-payment.ts
@@ -66,7 +66,7 @@ export const useConfirmPayment = () => {
         try {
           setMessage("Your payment is processing.");
           setPaymentStatus("processing");
-          const stripe = await stripePromise;
+          const stripe = await stripePromise();
 
           const paymentResponse = await stripe?.confirmCardPayment(
             clientSecret,


### PR DESCRIPTION
# Why
Lazy load stripe at the checkout form
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->



<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
Tested checkout flow works on local. Stripe only loads when the form shows up.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
