### PR TITLE
fix: grid item performance and image crashes

### DIFF
--- a/apps/expo/App.tsx
+++ b/apps/expo/App.tsx
@@ -52,7 +52,8 @@ LogBox.ignoreLogs([
 ]);
 
 function App() {
-  const [notification, setNotification] = useState(null);
+  const [notification, setNotification] =
+    useState<Notifications.Notification | null>(null);
 
   useEffect(() => {
     AvoidSoftInput.setEnabled(true);
@@ -108,7 +109,9 @@ function App() {
           try {
             await Image.clearMemoryCache();
             Logger.log("did receive memory warning and cleared");
-          } catch {}
+          } catch {
+            // ignore
+          }
         }
         clearFastImageMemory();
       }

--- a/packages/app/components/card/card.tsx
+++ b/packages/app/components/card/card.tsx
@@ -11,9 +11,9 @@ import { ResizeMode } from "expo-av";
 import { Link, LinkProps } from "solito/link";
 
 import {
-  PressableScale,
-  Props as PressableScaleProps,
-} from "@showtime-xyz/universal.pressable-scale";
+  Pressable,
+  Props as PressableProps,
+} from "@showtime-xyz/universal.pressable";
 import { Skeleton } from "@showtime-xyz/universal.skeleton";
 import { View } from "@showtime-xyz/universal.view";
 
@@ -24,7 +24,7 @@ import { ClaimButton } from "app/components/claim/claim-button";
 import { ClaimedShareButton } from "app/components/claim/claimed-share-button";
 import { ErrorBoundary } from "app/components/error-boundary";
 import { ClaimedBy } from "app/components/feed-item/claimed-by";
-import { Media } from "app/components/media";
+import { GridMedia, Media } from "app/components/media";
 import { withMemoAndColorScheme } from "app/components/memo-with-theme";
 import { MuteButton } from "app/components/mute-button/mute-button";
 import { NFTDropdown } from "app/components/nft-dropdown";
@@ -43,7 +43,7 @@ const RouteComponent = ({
   children,
   onPress,
   ...rest
-}: (LinkProps | PressableScaleProps) & {
+}: (LinkProps | PressableProps) & {
   onPress: () => void;
   children: ReactNode;
 }) => {
@@ -51,9 +51,9 @@ const RouteComponent = ({
     return <Link {...(rest as LinkProps)}>{children}</Link>;
   }
   return (
-    <PressableScale onPress={onPress} {...(rest as PressableScaleProps)}>
+    <Pressable onPress={onPress} {...(rest as PressableProps)}>
       {children}
-    </PressableScale>
+    </Pressable>
   );
 };
 
@@ -111,7 +111,7 @@ function Card(props: Props) {
         style={[style as any, { marginBottom: GAP }]}
         onPress={handleOnPress}
       >
-        <Media
+        <GridMedia
           item={nft}
           tw={tw}
           numColumns={numColumns}

--- a/packages/app/components/media/grid-media.tsx
+++ b/packages/app/components/media/grid-media.tsx
@@ -1,0 +1,139 @@
+import { useMemo, RefObject } from "react";
+import { Platform } from "react-native";
+
+import { Video as ExpoVideo } from "expo-av";
+
+import { Play } from "@showtime-xyz/universal.icon";
+import { Image, ResizeMode } from "@showtime-xyz/universal.image";
+import { View } from "@showtime-xyz/universal.view";
+
+import { withMemoAndColorScheme } from "app/components/memo-with-theme";
+import { useContentWidth } from "app/hooks/use-content-width";
+import { CreatorEditionResponse } from "app/hooks/use-creator-collection-detail";
+import type { NFT } from "app/types";
+import { getMediaUrl } from "app/utilities";
+
+import { ContentTypeIcon } from "../content-type-tooltip";
+
+type Props = {
+  item?: NFT & { loading?: boolean };
+  numColumns?: number;
+  tw?: string;
+  sizeStyle?: {
+    width?: number;
+    height?: number;
+  };
+  resizeMode?: ResizeMode;
+  onPinchStart?: () => void;
+  onPinchEnd?: () => void;
+  isMuted?: boolean;
+  edition?: CreatorEditionResponse;
+  videoRef?: RefObject<ExpoVideo>;
+  theme?: "light" | "dark";
+};
+
+function GridMediaImpl({
+  item,
+  numColumns = 1,
+  sizeStyle = {},
+  resizeMode: propResizeMode,
+  edition,
+}: Props) {
+  const resizeMode = propResizeMode ?? "cover";
+
+  const mediaUri = useMemo(
+    () =>
+      item?.loading
+        ? item?.source_url
+        : getMediaUrl({ nft: item, stillPreview: false }),
+    [item]
+  );
+  const mediaStillPreviewUri = useMemo(
+    () => getMediaUrl({ nft: item, stillPreview: true }),
+    [item]
+  );
+  const contentWidth = useContentWidth();
+
+  const size = useMemo(() => {
+    if (sizeStyle?.width) return +sizeStyle?.width;
+    return contentWidth / (numColumns ?? 1);
+  }, [contentWidth, numColumns, sizeStyle?.width]);
+
+  const width = sizeStyle?.width ? +sizeStyle?.width : size;
+  const height = sizeStyle?.height ? +sizeStyle?.height : size;
+
+  return (
+    <View
+      style={{
+        opacity: item?.loading ? 0.5 : 1,
+      }}
+    >
+      {Boolean(edition) && (
+        <View tw="absolute bottom-0.5 left-0.5 z-10">
+          <ContentTypeIcon edition={edition} />
+        </View>
+      )}
+      {item?.mime_type?.startsWith("image") &&
+      item?.mime_type !== "image/gif" ? (
+        <Image
+          source={{
+            uri: mediaUri,
+          }}
+          recyclingKey={mediaUri}
+          blurhash={item?.blurhash}
+          data-test-id={Platform.select({ web: "nft-card-media" })}
+          width={width}
+          height={height}
+          style={sizeStyle}
+          resizeMode={resizeMode}
+          alt={item?.token_name}
+        />
+      ) : null}
+
+      {item?.mime_type?.startsWith("video") ||
+      item?.mime_type === "image/gif" ? (
+        <>
+          {numColumns > 1 && (
+            <View tw="absolute bottom-2.5 right-2.5 z-10 bg-transparent">
+              <Play height={24} width={24} color="white" />
+            </View>
+          )}
+          <Image
+            source={{
+              uri: mediaStillPreviewUri,
+            }}
+            recyclingKey={mediaUri}
+            data-test-id={Platform.select({ web: "nft-card-media" })}
+            width={width}
+            height={height}
+            style={sizeStyle}
+            resizeMode={resizeMode}
+            alt={item?.token_name}
+          />
+        </>
+      ) : null}
+
+      {item?.mime_type?.startsWith("model") ? (
+        // This is a legacy 3D model, we don't support it anymore and fallback to image
+
+        <Image
+          source={{
+            uri: item?.still_preview_url,
+          }}
+          recyclingKey={mediaUri}
+          blurhash={item?.blurhash}
+          data-test-id={Platform.select({ web: "nft-card-media-model" })}
+          width={width}
+          height={height}
+          style={sizeStyle}
+          resizeMode={resizeMode}
+          alt={item?.token_name}
+        />
+      ) : null}
+    </View>
+  );
+}
+
+export const GridMedia = withMemoAndColorScheme<typeof GridMediaImpl, Props>(
+  GridMediaImpl
+);

--- a/packages/app/components/media/index.ts
+++ b/packages/app/components/media/index.ts
@@ -1,2 +1,3 @@
 export { Media } from "./media";
 export { ListMedia } from "./list-media";
+export { GridMedia } from "./grid-media";

--- a/packages/app/navigation/index.tsx
+++ b/packages/app/navigation/index.tsx
@@ -1,6 +1,8 @@
 import { useState, useRef, useMemo } from "react";
 import { Platform } from "react-native";
 
+import { Image } from "expo-image";
+
 import { useIsDarkMode } from "@showtime-xyz/universal.hooks";
 
 import {
@@ -61,6 +63,13 @@ export function NavigationProvider({
         enabled: true,
         formatter: (options) =>
           options?.title ? `${options.title} | Showtime` : "Showtime",
+      }}
+      onStateChange={() => {
+        // this is a temporary workaround to reduce crashes.
+        // Once we have optimized images and pull from disk, we can remove this
+        // Currently we're collecting images into memory until the app crashes,
+        // therefore we want to clear it on every screen change
+        Image.clearMemoryCache();
       }}
     >
       <NavigationElementsProvider


### PR DESCRIPTION
# Why

PressableScale, Expo-AV for still previews, and PinchToZoom are pretty expensive for ListItems, while not adding any benefits.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Changed "PressableScale" to "Pressable", used still images for Grid-Items instead of paused videos, and added a new "GridMedia" component, which also does not include PinchToZoom. Additionally, a function was added to clear the image memory on every navigation state change.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
