### PR TITLE
fix: white flash on feed

### DIFF
--- a/packages/app/pages/home/index.tsx
+++ b/packages/app/pages/home/index.tsx
@@ -9,6 +9,9 @@ function HomeNavigator() {
     <HomeStack.Navigator
       screenOptions={{
         headerShown: false,
+        contentStyle: {
+          backgroundColor: "black",
+        },
       }}
     >
       <HomeStack.Screen name="home" component={HomeScreen} />


### PR DESCRIPTION
# Why

Fixes a report by @alantoa that the Home Feed has a white flash on load and I found it also happen on fast swipe with Android.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Added black background color to contentStyle of HomeNavigator

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
