### PR TITLE
chore: exclude search .yarn files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,5 +23,12 @@
   "explorer.autoRevealExclude": {
     "**/node_modules": false,
     "**/bower_components": true
+  },
+  "search.exclude": {
+    "**/node_modules": true,
+    "**/bower_components": true,
+    "**/*.code-search": true,
+    "**/.yarn/plugins/@yarnpkg": true,
+    "**/.yarn/releases": true
   }
 }


### PR DESCRIPTION
# Why 

Sometimes when you want to search for certain keywords, the `.yarn/releases` and `.yarn/plugins` folder's files always show up in the results, which can be very annoying.

# How

Exclude files in the `.yarn/plugins/@yarnpkg` and `.yarn/releases` folders when searching.

# Before  

![CleanShot 2023-04-18 at 2 13 41](https://user-images.githubusercontent.com/37520667/232575199-2eea5a8f-0df1-4deb-888d-5e50ef27c2c7.png) 

# After 

![CleanShot 2023-04-18 at 2 13 48](https://user-images.githubusercontent.com/37520667/232575216-06d8da35-5df6-442f-8585-973e0706105e.png)