### PR TITLE
fix: twitter intent mention

### DIFF
--- a/packages/app/components/raffle/raffle.tsx
+++ b/packages/app/components/raffle/raffle.tsx
@@ -216,7 +216,7 @@ export const Raffle = (props?: RaffleModalParams) => {
     Linking.openURL(
       getTwitterIntent({
         url: "",
-        message: `Congratulations to @${getTwitterIntentUsername(
+        message: `Congratulations to ${getTwitterIntentUsername(
           winnerProfile
         )}: you just won the raffle for "${
           edition?.creator_airdrop_edition.name

--- a/packages/app/components/raffle/raffle.tsx
+++ b/packages/app/components/raffle/raffle.tsx
@@ -216,11 +216,11 @@ export const Raffle = (props?: RaffleModalParams) => {
     Linking.openURL(
       getTwitterIntent({
         url: "",
-        message: `Congratulations to ${getTwitterIntentUsername(
+        message: `Congratulations to @${getTwitterIntentUsername(
           winnerProfile
         )}: you just won the raffle for "${
           edition?.creator_airdrop_edition.name
-        }" on @showtime_xyz ✦ \nDM me for more details.`,
+        }" on @showtime_xyz ✦\n\nDM me for more details.`,
       })
     );
   }, [edition?.creator_airdrop_edition.name, winnerProfile]);

--- a/packages/app/utilities.ts
+++ b/packages/app/utilities.ts
@@ -443,9 +443,11 @@ export const getTwitterIntentUsername = (profile?: Profile) => {
     return `@${twitterUsername.replace(/@/g, "")}`;
   }
 
-  return profile.username
-    ? profile.username
-    : profile.name
+  if (profile.username) {
+    // because we don't have a real Twitter username, we need to silently mention on Twitter intent.
+    return `@\u2060${profile.username}`;
+  }
+  return profile.name
     ? profile.name
     : profile.wallet_addresses_v2?.[0]?.ens_domain
     ? profile.wallet_addresses_v2[0].ens_domain


### PR DESCRIPTION
# Why

Sometimes, we don't have the user's real Twitter username, but if we mention an incorrect username on Twitter, it can cause inconvenience to others.

# How

If we don't have the user's real Twitter username but have a username on Showtime, we can silently mention the user on Twitter.

# Before  

![CleanShot 2023-04-19 at 3 28 24](https://user-images.githubusercontent.com/37520667/232884728-dac40cc5-c495-4e6b-b030-f647267136df.png)

# After 

![CleanShot 2023-04-19 at 3 28 31](https://user-images.githubusercontent.com/37520667/232884733-fcf8993e-ae59-4a8f-ae9b-d47918d543cd.png)
