### PR TITLE
fix: send logs to sentry

### DIFF
--- a/packages/app/hooks/use-expo-update.tsx
+++ b/packages/app/hooks/use-expo-update.tsx
@@ -5,6 +5,7 @@ import * as Updates from "expo-updates";
 import { useSnackbar } from "@showtime-xyz/universal.snackbar";
 
 import { usePlatformBottomHeight } from "app/hooks/use-platform-bottom-height";
+import { Logger } from "app/lib/logger";
 import { captureException } from "app/lib/sentry";
 
 // import { MMKV } from "react-native-mmkv";
@@ -32,9 +33,12 @@ export function useExpoUpdate() {
         const update = await Updates.checkForUpdateAsync();
         if (!update.isAvailable) return;
         const result = await Updates.fetchUpdateAsync();
+        Logger.log("New update downloaded success");
         if (result.isNew) {
           if (isAutoUpdate) {
+            Logger.log("Performing auto update");
             await Updates.reloadAsync();
+            Logger.log("Auto update succeeded");
           } else {
             snackbar?.show({
               text: "New update available 🎉",

--- a/packages/app/lib/logger/index.ts
+++ b/packages/app/lib/logger/index.ts
@@ -1,13 +1,19 @@
+import { captureException, captureMessage } from "../sentry";
+
 export const Logger = {
   log: (...args: any) => {
     if (__DEV__) {
       console.log(...args);
+    } else {
+      captureMessage(args);
     }
   },
 
   error: (...args: any) => {
     if (__DEV__) {
       console.error(...args);
+    } else {
+      captureException(args);
     }
   },
   warn: (...args: any) => {


### PR DESCRIPTION
# Why
Added some logging before and after update happens to debug expo-update related crash.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->


<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
