### PR TITLE
feat: update gating type

### DIFF
--- a/packages/app/components/claim/claim-button.tsx
+++ b/packages/app/components/claim/claim-button.tsx
@@ -83,7 +83,7 @@ export const ClaimButton = ({
   const raffleConcludedAt = useMemo(() => {
     if (!isSelf || !isRaffleDrop) return null;
     if (
-      edition.gating_type === "music_presave" &&
+      edition.gating_type === "spotify_presave" &&
       edition?.presave_release_date
     ) {
       return formatDistanceToNowStrict(
@@ -125,7 +125,7 @@ export const ClaimButton = ({
     }
     dispatch({ type: "initial" });
     if (
-      (edition.gating_type === "music_presave" ||
+      (edition.gating_type === "spotify_presave" ||
         edition.gating_type === "spotify_save") &&
       !isAuthenticated
     ) {
@@ -220,7 +220,7 @@ export const ClaimButton = ({
           </Text>
         </>
       );
-    } else if (edition?.gating_type === "music_presave") {
+    } else if (edition?.gating_type === "spotify_presave") {
       return (
         <>
           <Spotify

--- a/packages/app/components/claim/claim-button.tsx
+++ b/packages/app/components/claim/claim-button.tsx
@@ -83,7 +83,8 @@ export const ClaimButton = ({
   const raffleConcludedAt = useMemo(() => {
     if (!isSelf || !isRaffleDrop) return null;
     if (
-      edition.gating_type === "spotify_presave" &&
+      (edition.gating_type === "spotify_presave" ||
+        edition?.gating_type === "music_presave") &&
       edition?.presave_release_date
     ) {
       return formatDistanceToNowStrict(
@@ -126,7 +127,8 @@ export const ClaimButton = ({
     dispatch({ type: "initial" });
     if (
       (edition.gating_type === "spotify_presave" ||
-        edition.gating_type === "spotify_save") &&
+        edition.gating_type === "spotify_save" ||
+        edition?.gating_type === "music_presave") &&
       !isAuthenticated
     ) {
       Analytics.track(EVENTS.SPOTIFY_SAVE_PRESSED_BEFORE_LOGIN);
@@ -220,7 +222,10 @@ export const ClaimButton = ({
           </Text>
         </>
       );
-    } else if (edition?.gating_type === "spotify_presave") {
+    } else if (
+      edition?.gating_type === "spotify_presave" ||
+      edition?.gating_type === "music_presave"
+    ) {
       return (
         <>
           <Spotify

--- a/packages/app/components/claim/claim-form.tsx
+++ b/packages/app/components/claim/claim-form.tsx
@@ -156,7 +156,8 @@ export const ClaimForm = ({
 
     if (
       edition.gating_type === "spotify_save" ||
-      edition.gating_type === "spotify_presave"
+      edition.gating_type === "spotify_presave" ||
+      edition?.gating_type === "music_presave"
     ) {
       success = await claimSpotifyGatedDrop(closeModal);
     } else if (edition.gating_type === "password") {
@@ -258,6 +259,7 @@ export const ClaimForm = ({
             </Text>
           </View>
           {edition.gating_type === "spotify_save" ||
+          edition?.gating_type === "music_presave" ||
           edition.gating_type === "spotify_presave" ? (
             <>
               <View tw="mt-4 flex-row items-center">
@@ -372,7 +374,8 @@ export const ClaimForm = ({
               ) : state.status === "error" ? (
                 "Failed. Retry!"
               ) : edition.gating_type === "spotify_save" ||
-                edition.gating_type === "spotify_presave" ? (
+                edition.gating_type === "spotify_presave" ||
+                edition?.gating_type === "music_presave" ? (
                 <View tw="w-full flex-row items-center justify-center">
                   <Spotify color={isDark ? "#000" : "#fff"} />
                   <Text tw="ml-2 font-semibold text-white dark:text-black">

--- a/packages/app/components/claim/claim-form.tsx
+++ b/packages/app/components/claim/claim-form.tsx
@@ -156,7 +156,7 @@ export const ClaimForm = ({
 
     if (
       edition.gating_type === "spotify_save" ||
-      edition.gating_type === "music_presave"
+      edition.gating_type === "spotify_presave"
     ) {
       success = await claimSpotifyGatedDrop(closeModal);
     } else if (edition.gating_type === "password") {
@@ -258,7 +258,7 @@ export const ClaimForm = ({
             </Text>
           </View>
           {edition.gating_type === "spotify_save" ||
-          edition.gating_type === "music_presave" ? (
+          edition.gating_type === "spotify_presave" ? (
             <>
               <View tw="mt-4 flex-row items-center">
                 {user.data.profile.has_spotify_token ? (
@@ -372,7 +372,7 @@ export const ClaimForm = ({
               ) : state.status === "error" ? (
                 "Failed. Retry!"
               ) : edition.gating_type === "spotify_save" ||
-                edition.gating_type === "music_presave" ? (
+                edition.gating_type === "spotify_presave" ? (
                 <View tw="w-full flex-row items-center justify-center">
                   <Spotify color={isDark ? "#000" : "#fff"} />
                   <Text tw="ml-2 font-semibold text-white dark:text-black">

--- a/packages/app/components/content-type-tooltip.tsx
+++ b/packages/app/components/content-type-tooltip.tsx
@@ -35,7 +35,7 @@ export const contentGatingType = {
     text: "Enter password & location to collect",
     typeName: "Password & Location",
   },
-  music_presave: {
+  spotify_presave: {
     icon: Spotify,
     text: "Pre-Save to collect",
     typeName: "Pre-Save",
@@ -52,7 +52,7 @@ export const ContentTypeTooltip = ({
   }
 
   if (
-    edition?.gating_type === "music_presave" &&
+    edition?.gating_type === "spotify_presave" &&
     edition?.spotify_track_url &&
     edition?.presave_release_date &&
     new Date() >= new Date(edition?.presave_release_date)

--- a/packages/app/components/content-type-tooltip.tsx
+++ b/packages/app/components/content-type-tooltip.tsx
@@ -40,6 +40,11 @@ export const contentGatingType = {
     text: "Pre-Save to collect",
     typeName: "Pre-Save",
   },
+  music_presave: {
+    icon: Spotify,
+    text: "Pre-Save to collect",
+    typeName: "Pre-Save",
+  },
 };
 
 export const ContentTypeTooltip = ({
@@ -52,7 +57,8 @@ export const ContentTypeTooltip = ({
   }
 
   if (
-    edition?.gating_type === "spotify_presave" &&
+    (edition?.gating_type === "spotify_presave" ||
+      edition?.gating_type === "music_presave") &&
     edition?.spotify_track_url &&
     edition?.presave_release_date &&
     new Date() >= new Date(edition?.presave_release_date)

--- a/packages/app/components/drop/drop-music.tsx
+++ b/packages/app/components/drop/drop-music.tsx
@@ -297,7 +297,7 @@ export const DropMusic = () => {
       await dropNFT(
         {
           ...values,
-          gatingType: isSaveDrop ? "spotify_save" : "music_presave",
+          gatingType: isSaveDrop ? "spotify_save" : "spotify_presave",
           editionSize: isUnlimited ? 0 : values.editionSize,
           releaseDate: isSaveDrop
             ? undefined

--- a/packages/app/components/nft-dropdown.tsx
+++ b/packages/app/components/nft-dropdown.tsx
@@ -151,7 +151,7 @@ function NFTDropdown({
             </DropdownMenuItem>
           ) : null}
 
-          {edition?.gating_type === "music_presave" &&
+          {edition?.gating_type === "spotify_presave" &&
           nft.creator_username === user?.data.profile.username ? (
             <DropdownMenuItem
               onSelect={() => {
@@ -191,12 +191,7 @@ function NFTDropdown({
               }}
               key="open-in-app"
             >
-              <MenuItemIcon
-                Icon={Showtime}
-                ios={{
-                  name: isBlocked ? "circle" : "circle.slash",
-                }}
-              />
+              <MenuItemIcon Icon={Showtime} />
 
               <DropdownMenuItemTitle tw="font-semibold text-gray-700 dark:text-neutral-300">
                 Open in app
@@ -342,7 +337,7 @@ function NFTDropdown({
                 <MenuItemIcon
                   Icon={Slash}
                   ios={{
-                    name: isBlocked ? "circle" : "circle.slash",
+                    name: isBlocked ? "circle" : ("circle.slash" as any),
                   }}
                 />
                 <DropdownMenuItemTitle tw="font-semibold text-gray-700 dark:text-neutral-300">

--- a/packages/app/components/nft-dropdown.tsx
+++ b/packages/app/components/nft-dropdown.tsx
@@ -151,7 +151,8 @@ function NFTDropdown({
             </DropdownMenuItem>
           ) : null}
 
-          {edition?.gating_type === "spotify_presave" &&
+          {(edition?.gating_type === "spotify_presave" ||
+            edition?.gating_type === "music_presave") &&
           nft.creator_username === user?.data.profile.username ? (
             <DropdownMenuItem
               onSelect={() => {

--- a/packages/app/hooks/use-drop-nft.ts
+++ b/packages/app/hooks/use-drop-nft.ts
@@ -259,7 +259,7 @@ export const useDropNFT = () => {
             : undefined,
       };
 
-      if (params.releaseDate && params.gatingType === "music_presave") {
+      if (params.releaseDate && params.gatingType === "spotify_presave") {
         requestData.release_date = params.releaseDate;
       }
       const relayerResponse = await axios({

--- a/packages/app/types.ts
+++ b/packages/app/types.ts
@@ -257,4 +257,4 @@ export type GatingType =
   | "password"
   | "location"
   | "multi"
-  | "music_presave";
+  | "spotify_presave";

--- a/packages/app/types.ts
+++ b/packages/app/types.ts
@@ -257,4 +257,6 @@ export type GatingType =
   | "password"
   | "location"
   | "multi"
-  | "spotify_presave";
+  | "spotify_presave"
+  // This is for compatibility with the old spotify_presave
+  | "music_presave";


### PR DESCRIPTION
# Why

Backend has updated the `gating_type` field and created a new type called `spotify_presave ` to replace the `music_presave` field. 
This is in anticipation of Apple Music Presaves, so that we can have clear gating types for each platform.


# How

Just replaced instances of the `spotify_presave` type with `music_presave`.

# Test Plan

This PR needs to wait for the backend team to merge their PR into staging before we can test it.
