### PR TITLE
fix: plenty of perf issues

### DIFF
--- a/packages/app/components/card/card.tsx
+++ b/packages/app/components/card/card.tsx
@@ -201,6 +201,7 @@ const CardLargeScreen = ({
               resizeMode={ResizeMode.COVER}
               optimizedWidth={600}
               loading={index > 0 ? "lazy" : "eager"}
+              withVideoBackdrop
             />
             <NSFWGate show={nft.nsfw} nftId={nft.nft_id} variant="thumbnail" />
             {numColumns === 1 && nft?.mime_type?.includes("video") ? (

--- a/packages/app/components/media/list-media.tsx
+++ b/packages/app/components/media/list-media.tsx
@@ -10,7 +10,7 @@ import { CreatorEditionResponse } from "app/hooks/use-creator-collection-detail"
 import type { NFT } from "app/types";
 import { getMediaUrl } from "app/utilities";
 
-import { ListVideo } from "design-system/list-video";
+//import { ListVideo } from "design-system/list-video";
 
 type Props = {
   item?: NFT & { loading?: boolean };
@@ -64,6 +64,23 @@ function ListMediaImpl({
 
       {item?.mime_type?.startsWith("video") ||
       item?.mime_type === "image/gif" ? (
+        <Image
+          source={{
+            uri: mediaStillPreviewUri,
+          }}
+          recyclingKey={mediaUri}
+          blurhash={item?.blurhash}
+          data-test-id={Platform.select({ web: "nft-card-media" })}
+          resizeMode={resizeMode}
+          alt={item?.token_name}
+          style={{ height: "100%", width: "100%" }}
+          loading={loading}
+        />
+      ) : null}
+
+      {/* TODO: Add back once we deliver videos from BunnyCDN
+      {item?.mime_type?.startsWith("video") ||
+      item?.mime_type === "image/gif" ? (
         <ListVideo
           source={{
             uri: mediaUri,
@@ -77,6 +94,7 @@ function ListMediaImpl({
           loading={loading}
         />
       ) : null}
+     */}
     </>
   );
 }

--- a/packages/app/components/media/media.tsx
+++ b/packages/app/components/media/media.tsx
@@ -35,6 +35,7 @@ type Props = {
   theme?: "light" | "dark";
   optimizedWidth?: number;
   loading?: "eager" | "lazy";
+  withVideoBackdrop?: boolean;
 };
 
 function MediaImplementation({
@@ -49,6 +50,7 @@ function MediaImplementation({
   videoRef,
   optimizedWidth = 800,
   loading = "lazy",
+  withVideoBackdrop = false,
 }: Props) {
   const resizeMode = propResizeMode ?? "cover";
 
@@ -70,6 +72,8 @@ function MediaImplementation({
     <View
       style={{
         opacity: item?.loading ? 0.5 : 1,
+        height: Platform.OS === "web" ? "inherit" : height,
+        width: Platform.OS === "web" ? "inherit" : width,
       }}
     >
       {Boolean(edition) && (
@@ -130,6 +134,7 @@ function MediaImplementation({
             loading={loading}
             //@ts-ignore
             dataset={Platform.select({ web: { testId: "nft-card-media" } })}
+            withVideoBackdrop={withVideoBackdrop}
           />
         </PinchToZoom>
       ) : null}

--- a/packages/design-system/image/image.tsx
+++ b/packages/design-system/image/image.tsx
@@ -1,5 +1,4 @@
 import { useMemo } from "react";
-import { Platform } from "react-native";
 
 import { Image, ImageProps as ExpoImageProps, ImageSource } from "expo-image";
 

--- a/packages/design-system/image/image.web.tsx
+++ b/packages/design-system/image/image.web.tsx
@@ -18,6 +18,8 @@ const getBase64Blurhash = (blurhash: string): string => {
   return src;
 };
 
+const noop = () => {};
+
 type Props = Pick<ImageNativeProps, "source" | "onLoad" | "recyclingKey"> &
   Omit<NextImageProps, "src"> & {
     className: string;
@@ -83,7 +85,7 @@ function Img({
         priority={loading === "eager"}
         width={width}
         height={height}
-        onLoadingComplete={onLoadingComplete}
+        onLoadingComplete={onLoad ? onLoadingComplete : noop}
         placeholder={width > 40 && props.blurhash ? "blur" : "empty"}
         blurDataURL={
           width > 40 && props.blurhash

--- a/packages/design-system/video/index.tsx
+++ b/packages/design-system/video/index.tsx
@@ -17,11 +17,12 @@ type VideoProps = {
   width: number;
   height: number;
   loading?: "eager" | "lazy";
+  withVideoBackdrop?: boolean;
 } & ComponentProps<typeof ExpoVideo>;
 
 const Video = forwardRef<ExpoVideo, VideoProps>(function Video(
   {
-    tw,
+    tw = "",
     blurhash,
     style,
     width,
@@ -81,7 +82,6 @@ const Video = forwardRef<ExpoVideo, VideoProps>(function Video(
               style={StyleSheet.absoluteFill}
               useNativeControls={videoConfig?.useNativeControls}
               resizeMode={ResizeMode.COVER}
-              posterSource={posterSource}
               isMuted={isMuted}
             />
           </>

--- a/packages/design-system/video/index.web.tsx
+++ b/packages/design-system/video/index.web.tsx
@@ -22,6 +22,7 @@ type VideoProps = Omit<AVVideoProps, "resizeMode"> & {
   height: number;
   resizeMode: ResizeMode;
   loading?: "eager" | "lazy";
+  withVideoBackdrop?: boolean;
 };
 const contentFitToresizeMode = (resizeMode: ResizeMode) => {
   switch (resizeMode) {
@@ -45,6 +46,7 @@ export const Video = forwardRef<ExpoVideo, VideoProps>(function Video(
     width,
     height,
     loading = "lazy",
+    withVideoBackdrop,
     ...props
   }: VideoProps,
   ref
@@ -72,23 +74,30 @@ export const Video = forwardRef<ExpoVideo, VideoProps>(function Video(
         />
       ) : (
         <View style={{ height: "inherit", width: "inherit" }}>
-          <Image
-            tw={tw}
-            style={style as ImageStyle}
-            resizeMode={resizeMode}
-            blurhash={blurhash}
-            source={posterSource}
-            width={width}
-            height={height}
-            alt={"Video Background"}
-            loading={loading}
-          />
-          <View tw="absolute inset-0 backdrop-blur-md" />
+          {withVideoBackdrop ? (
+            <>
+              <Image
+                tw={"blur-lg"}
+                style={style as ImageStyle}
+                resizeMode={resizeMode}
+                blurhash={blurhash}
+                source={posterSource}
+                width={width}
+                height={height}
+                alt={"Video Background"}
+                loading={loading}
+              />
+            </>
+          ) : (
+            <View style={{ width, height }} />
+          )}
+
           <ExpoVideo
             style={[StyleSheet.absoluteFill, { justifyContent: "center" }]}
             useNativeControls={videoConfig?.useNativeControls}
             resizeMode={contentFitToresizeMode(resizeMode)}
             posterSource={posterSource}
+            usePoster={true}
             source={props.source}
             ref={(innerRef) => {
               if (videoRef) {


### PR DESCRIPTION
# Why

Trending List with Video previews is currently to slow and consume too much traffic. Furthermore, backdrop-blur-md was expensive and had weird effects on Desktop in the full detail preview

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

For now, removed video previews in the Trending List (will add back with Bunny but optimized) and also introduced a new prop called `withBackDropBlur` to control the blurred background image more granular. Furthermore, on web, instead of rendering a second video placeholder, we use the native solution inside videos (usePoster prop was missing while we did provide a posterSource)

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
