### PR TITLE
fix: twitter og-image for videos

### DIFF
--- a/packages/app/utilities.ts
+++ b/packages/app/utilities.ts
@@ -132,8 +132,8 @@ export const getMediaUrl = ({
 
   let cdnUrl = `${process.env.NEXT_PUBLIC_BACKEND_URL}/v1/media/nft/${
     nft.chain_name
-  }/${nft.contract_address}/${nft.token_id}?cache_key=1${
-    stillPreview ? "&still_preview=true" : ""
+  }/${nft.contract_address}/${nft.token_id}${
+    stillPreview ? "?still_preview=true&cache_key=1" : "?cache_key=1"
   }`;
 
   if (nft?.mime_type?.startsWith("image") && nft?.mime_type !== "image/gif") {


### PR DESCRIPTION
# Why

OG images for videos haven't been working on Twitter because of `&amp` escaping.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Changed the order of params to workaround this since Next adds this at runtime

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
