### PR TITLE
fix: empty profile list copy

### DIFF
--- a/packages/app/components/profile/profile.web.tsx
+++ b/packages/app/components/profile/profile.web.tsx
@@ -274,13 +274,29 @@ const Profile = ({ username }: ProfileScreenProps) => {
         <ProfileError error={error} isBlocked={isBlocked} username={username} />
       );
     }
-    if (chuckList.length === 0 && !isLoading && !error && !isBlocked) {
+
+    if (
+      chuckList.length === 0 &&
+      !isLoading &&
+      !profileIsLoading &&
+      !error &&
+      type &&
+      !isBlocked
+    ) {
       return (
         <EmptyPlaceholder tw="h-[50vh]" title="No drops, yet." hideLoginBtn />
       );
     }
     return null;
-  }, [isLoading, error, chuckList.length, isBlocked, username]);
+  }, [
+    error,
+    isBlocked,
+    chuckList.length,
+    isLoading,
+    profileIsLoading,
+    type,
+    username,
+  ]);
 
   return (
     <ProfileHeaderContext.Provider

--- a/packages/app/components/profile/profile.web.tsx
+++ b/packages/app/components/profile/profile.web.tsx
@@ -45,6 +45,7 @@ import { formatProfileRoutes } from "app/utilities";
 import { Spinner } from "design-system/spinner";
 import { breakpoints } from "design-system/theme";
 
+import { EmptyPlaceholder } from "../empty-placeholder";
 import { FilterContext } from "./fillter-context";
 import { ProfileError } from "./profile-error";
 import { ProfileTop } from "./profile-top";
@@ -268,13 +269,18 @@ const Profile = ({ username }: ProfileScreenProps) => {
   }, [contentWidth, isDark, isLoadingMore, profileIsLoading, error]);
 
   const ListEmptyComponent = useCallback(() => {
-    if ((isLoading || profileIsLoading || !type) && !error) {
-      return null;
+    if (error || isBlocked) {
+      return (
+        <ProfileError error={error} isBlocked={isBlocked} username={username} />
+      );
     }
-    return (
-      <ProfileError error={error} isBlocked={isBlocked} username={username} />
-    );
-  }, [isBlocked, isLoading, profileIsLoading, type, username, error]);
+    if (chuckList.length === 0 && !isLoading && !error && !isBlocked) {
+      return (
+        <EmptyPlaceholder tw="h-[50vh]" title="No drops, yet." hideLoginBtn />
+      );
+    }
+    return null;
+  }, [isLoading, error, chuckList.length, isBlocked, username]);
 
   return (
     <ProfileHeaderContext.Provider


### PR DESCRIPTION
# Why 

just add a `No drops, yet` copy for profile empty list on web. 

![CleanShot 2023-04-25 at 7 44 37](https://user-images.githubusercontent.com/37520667/234266511-ed003edf-6e4c-4c30-b605-4e1540a806ca.png)

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
