### PR TITLE
fix: native apple music auth shows sign in web header momentarily

### DIFF
--- a/apps/next/src/pages/_app.tsx
+++ b/apps/next/src/pages/_app.tsx
@@ -163,12 +163,16 @@ function App({ Component, pageProps, router }: AppProps) {
       </Head>
       <AppProviders>
         <Container>
-          <Header
-            canGoBack={
-              router.pathname === "/search" ||
-              router.pathname.split("/").length - 1 >= 2
-            }
-          />
+          {/* @ts-ignore */}
+          {!Component.hideHeader && (
+            <Header
+              canGoBack={
+                router.pathname === "/search" ||
+                router.pathname.split("/").length - 1 >= 2
+              }
+            />
+          )}
+
           <View
             tw="items-center"
             style={{

--- a/apps/next/src/pages/apple-music-auth/apple-music-auth.tsx
+++ b/apps/next/src/pages/apple-music-auth/apple-music-auth.tsx
@@ -21,3 +21,5 @@ export default function AppleMusicAuth() {
 
   return null;
 }
+
+AppleMusicAuth.hideHeader = true;


### PR DESCRIPTION
# Why
When doing apple music auth on native, we use webview but it shows our default header with sign in buttons momentarily before triggering apple music auth API.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
Pass a flag from component to hide header and hide it conditionally in _app.tsx. Not the best, but simplest solution for now. 
<!--
How did you build this feature or fix this bug and why?
-->

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
