### PR TITLE
fix: format error messages

### DIFF
--- a/packages/app/hooks/use-apple-music-gated-claim.ts
+++ b/packages/app/hooks/use-apple-music-gated-claim.ts
@@ -9,6 +9,7 @@ import { axios } from "app/lib/axios";
 import { Logger } from "app/lib/logger";
 import { useLogInPromise } from "app/lib/login-promise";
 import { MY_INFO_ENDPOINT } from "app/providers/user-provider";
+import { formatAPIErrorMessage } from "app/utilities";
 
 import { toast } from "design-system/toast";
 
@@ -79,7 +80,7 @@ export const useAppleMusicGatedClaim = (edition: IEdition) => {
       }
     } catch (error: any) {
       Logger.error("claimAppleMusicGatedDrop failed", error);
-      Alert.alert("Something went wrong", error.response?.data.error.message);
+      Alert.alert("Something went wrong", formatAPIErrorMessage(error));
       throw error;
     }
   });

--- a/packages/app/hooks/use-claim-nft.ts
+++ b/packages/app/hooks/use-claim-nft.ts
@@ -209,7 +209,8 @@ export const useClaimNFT = (edition: IEdition) => {
         return true;
       }
     } catch (e: any) {
-      dispatch({ type: "error", error: e?.message });
+      const errorMessage = formatAPIErrorMessage(e);
+      dispatch({ type: "error", error: errorMessage });
       forwarderRequestCached.current = null;
       Logger.error("nft drop claim failed", e);
 
@@ -271,7 +272,7 @@ export const useClaimNFT = (edition: IEdition) => {
       } else {
         Alert.alert(
           "Oops. An error occurred.",
-          formatAPIErrorMessage(e) +
+          errorMessage +
             ". Please contact us at help@showtime.xyz if this persists. Thanks!",
           [
             {

--- a/packages/app/hooks/use-claim-nft.ts
+++ b/packages/app/hooks/use-claim-nft.ts
@@ -268,7 +268,7 @@ export const useClaimNFT = (edition: IEdition) => {
         }
       } else if (e?.response?.status === 440) {
         Alert.alert("Wrong password or wrong location", "Please try again!");
-      } else if (e?.response?.status === 500) {
+      } else {
         Alert.alert(
           "Oops. An error occurred.",
           formatAPIErrorMessage(e) ??

--- a/packages/app/hooks/use-claim-nft.ts
+++ b/packages/app/hooks/use-claim-nft.ts
@@ -271,15 +271,16 @@ export const useClaimNFT = (edition: IEdition) => {
       } else {
         Alert.alert(
           "Oops. An error occurred.",
-          formatAPIErrorMessage(e) ??
-            "Please contact us at help@showtime.xyz if this persists. Thanks!",
+          formatAPIErrorMessage(e) +
+            ". Please contact us at help@showtime.xyz if this persists. Thanks!",
           [
             {
               text: "Cancel",
               style: "cancel",
             },
             {
-              text: "Okay",
+              text: "Contact",
+              onPress: onSendFeedback,
             },
           ]
         );

--- a/packages/app/hooks/use-claim-nft.ts
+++ b/packages/app/hooks/use-claim-nft.ts
@@ -15,7 +15,11 @@ import { axios } from "app/lib/axios";
 import { Logger } from "app/lib/logger";
 import { captureException } from "app/lib/sentry";
 import { IEdition } from "app/types";
-import { getFormatDistanceToNowStrict, ledgerWalletHack } from "app/utilities";
+import {
+  formatAPIErrorMessage,
+  getFormatDistanceToNowStrict,
+  ledgerWalletHack,
+} from "app/utilities";
 
 import { useSendFeedback } from "./use-send-feedback";
 import { useWallet } from "./use-wallet";
@@ -267,15 +271,15 @@ export const useClaimNFT = (edition: IEdition) => {
       } else if (e?.response?.status === 500) {
         Alert.alert(
           "Oops. An error occurred.",
-          "Please contact us at help@showtime.xyz if this persists. Thanks!",
+          formatAPIErrorMessage(e) ??
+            "Please contact us at help@showtime.xyz if this persists. Thanks!",
           [
             {
               text: "Cancel",
               style: "cancel",
             },
             {
-              text: "Contact",
-              onPress: onSendFeedback,
+              text: "Okay",
             },
           ]
         );

--- a/packages/app/hooks/use-drop-nft.ts
+++ b/packages/app/hooks/use-drop-nft.ts
@@ -288,8 +288,8 @@ export const useDropNFT = () => {
       } else {
         Alert.alert(
           "Oops. An error occurred.",
-          errorMessage ??
-            "Please contact us at help@showtime.xyz if this persists. Thanks!",
+          errorMessage +
+            ". Please contact us at help@showtime.xyz if this persists. Thanks!",
           [
             {
               text: "Cancel",

--- a/packages/app/hooks/use-drop-nft.ts
+++ b/packages/app/hooks/use-drop-nft.ts
@@ -10,7 +10,7 @@ import { axios } from "app/lib/axios";
 import { Logger } from "app/lib/logger";
 import { captureException } from "app/lib/sentry";
 import { GatingType } from "app/types";
-import { delay, getFileMeta } from "app/utilities";
+import { delay, formatAPIErrorMessage, getFileMeta } from "app/utilities";
 
 import { toast } from "design-system/toast";
 
@@ -276,7 +276,8 @@ export const useDropNFT = () => {
       });
       callback?.();
     } catch (e: any) {
-      dispatch({ type: "error", error: e?.message });
+      const errorMessage = formatAPIErrorMessage(e);
+      dispatch({ type: "error", error: errorMessage });
       Logger.error("nft drop failed", e);
 
       if (e?.response?.status === 420) {
@@ -284,12 +285,11 @@ export const useDropNFT = () => {
           "Wow, you love drops!",
           "Only one drop per day is allowed. Come back tomorrow!"
         );
-      }
-
-      if (e?.response?.status === 500) {
+      } else {
         Alert.alert(
           "Oops. An error occurred.",
-          "Please contact us at help@showtime.xyz if this persists. Thanks!",
+          errorMessage ??
+            "Please contact us at help@showtime.xyz if this persists. Thanks!",
           [
             {
               text: "Cancel",

--- a/packages/app/utilities.ts
+++ b/packages/app/utilities.ts
@@ -1,6 +1,7 @@
 import React from "react";
 import { Platform } from "react-native";
 
+import axios, { AxiosError } from "axios";
 import { formatDistanceToNowStrict } from "date-fns";
 import { ResizeMode } from "expo-av";
 import * as FileSystem from "expo-file-system";
@@ -838,4 +839,18 @@ export const getWebImageSize = (file: File) => {
     img.onerror = reject;
   });
   return promise;
+};
+
+export const formatAPIErrorMessage = (error: AxiosError | Error) => {
+  if (axios.isAxiosError(error)) {
+    const res = error.response?.data;
+    let messages = [];
+    if (res.errors) {
+      messages = res.errors.map((e: any) => e.message);
+    } else if (res.error) {
+      messages.push(res.error.message);
+    }
+
+    return messages.join("\n");
+  }
 };

--- a/packages/app/utilities.ts
+++ b/packages/app/utilities.ts
@@ -842,15 +842,17 @@ export const getWebImageSize = (file: File) => {
 };
 
 export const formatAPIErrorMessage = (error: AxiosError | Error) => {
+  let messages = [];
   if (axios.isAxiosError(error)) {
     const res = error.response?.data;
-    let messages = [];
     if (res.errors) {
       messages = res.errors.map((e: any) => e.message);
     } else if (res.error) {
       messages.push(res.error.message);
     }
-
-    return messages.join("\n");
+  } else if (error.message) {
+    messages.push(error.message);
   }
+
+  return messages.join("\n");
 };


### PR DESCRIPTION
# Why
Implements error message formatter based on new API response error [implementation](https://github.com/showtime-xyz/stbackend/pull/846)
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->


<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- We can use this formatter anywhere to display API error message. 

Not sure about the heading, should we remove the `Please contact..`

<img width="1512" alt="Screenshot 2023-04-28 at 12 59 49 PM" src="https://user-images.githubusercontent.com/23293248/235083364-e53855a3-2744-458f-b792-111e8d8538eb.png">

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
