### PR TITLE
feat: new media upload pipeline (only merge when backend changes are live on production)

### DIFF
--- a/packages/app/components/drop/drop-event.tsx
+++ b/packages/app/components/drop/drop-event.tsx
@@ -24,7 +24,6 @@ import { ErrorText, Fieldset } from "@showtime-xyz/universal.fieldset";
 import { useIsDarkMode } from "@showtime-xyz/universal.hooks";
 import { FlipIcon, Image as ImageIcon } from "@showtime-xyz/universal.icon";
 import { Pressable } from "@showtime-xyz/universal.pressable";
-import { useRouter } from "@showtime-xyz/universal.router";
 import { useSafeAreaInsets } from "@showtime-xyz/universal.safe-area";
 import { ScrollView } from "@showtime-xyz/universal.scroll-view";
 import { Text } from "@showtime-xyz/universal.text";
@@ -256,7 +255,7 @@ export const DropEvent = () => {
     }
     if (size && size > MAX_FILE_SIZE) {
       Alert.alert(
-        "Oops, this file is too large (>50MB). Please upload a smaller file."
+        "Oops, this file is too large (>30MB). Please upload a smaller file."
       );
       setError("file", {
         type: "custom",

--- a/packages/app/components/drop/drop-free/drop-free.tsx
+++ b/packages/app/components/drop/drop-free/drop-free.tsx
@@ -286,7 +286,7 @@ export const DropFree = () => {
     }
     if (size && size > MAX_FILE_SIZE) {
       Alert.alert(
-        "Oops, this file is too large (>50MB). Please upload a smaller file."
+        "Oops, this file is too large (>30MB). Please upload a smaller file."
       );
       setError("file", {
         type: "custom",

--- a/packages/app/components/drop/drop-music.tsx
+++ b/packages/app/components/drop/drop-music.tsx
@@ -348,7 +348,7 @@ export const DropMusic = () => {
     }
     if (size && size > MAX_FILE_SIZE) {
       Alert.alert(
-        "Oops, this file is too large (>50MB). Please upload a smaller file."
+        "Oops, this file is too large (>30MB). Please upload a smaller file."
       );
       setError("file", {
         type: "custom",

--- a/packages/app/components/drop/drop-private.tsx
+++ b/packages/app/components/drop/drop-private.tsx
@@ -254,7 +254,7 @@ export const DropPrivate = () => {
     }
     if (size && size > MAX_FILE_SIZE) {
       Alert.alert(
-        "Oops, this file is too large (>50MB). Please upload a smaller file."
+        "Oops, this file is too large (>30MB). Please upload a smaller file."
       );
       setError("file", {
         type: "custom",

--- a/packages/app/hooks/use-drop-nft.ts
+++ b/packages/app/hooks/use-drop-nft.ts
@@ -17,7 +17,7 @@ import { toast } from "design-system/toast";
 import { DropContext } from "../context/drop-context";
 import { useSendFeedback } from "./use-send-feedback";
 
-export const MAX_FILE_SIZE = 50 * 1024 * 1024; // in bytes
+export const MAX_FILE_SIZE = 30 * 1024 * 1024; // in bytes
 
 type IEdition = {
   contract_address: string;
@@ -197,13 +197,12 @@ export const useDropNFT = () => {
 
       const ipfsHash = await uploadMedia({
         file: params.file,
-        notSafeForWork: params.notSafeForWork,
       });
 
       if (!ipfsHash) {
         dispatch({
           type: "error",
-          error: "Failed to upload the media on IPFS. Please try again!",
+          error: "Failed to upload the media onto IPFS. Please try again!",
         });
         return;
       }

--- a/packages/app/utilities.ts
+++ b/packages/app/utilities.ts
@@ -461,6 +461,7 @@ export const getFileMeta = async (file?: File | string) => {
         return {
           name: fileName,
           type: "image/" + fileExtension,
+          // @ts-expect-error - size is not defined in type
           size: fileInfo.size,
         };
       } else if (
@@ -470,6 +471,7 @@ export const getFileMeta = async (file?: File | string) => {
         return {
           name: fileName,
           type: "video/" + fileExtension,
+          // @ts-expect-error - size is not defined in type
           size: fileInfo.size,
         };
       }
@@ -499,14 +501,6 @@ function dataURLtoFile(dataurl: string, filename: string) {
 
   return new File([u8arr], filename, { type: mime });
 }
-
-export const getPinataToken = async () => {
-  return showtimeAPIAxios({
-    url: "/v1/pinata/key",
-    method: "POST",
-    data: {},
-  }).then((res) => res.token);
-};
 
 export async function delay(ms: number) {
   return await new Promise((resolve) => setTimeout(resolve, ms));


### PR DESCRIPTION
# Why

This PR brings our new media upload pipeline to life!

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

From now on, we will be uploading all of our media directly to our server and processing them on GCP before uploading them to IPFS/Bunny. Due to GCP's 32 MB limit, we have temporarily reduced the upload amount to 30 MB until we find a solution. However, note that 50 MB for IPFS is already a limiting factor.


<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
