### PR TITLE
fix: play on spotify

### DIFF
--- a/packages/app/components/content-type-tooltip.tsx
+++ b/packages/app/components/content-type-tooltip.tsx
@@ -75,10 +75,6 @@ export const ContentTypeTooltip = ({
     return <PlayOnAppleMusic edition={edition} />;
   }
 
-  if (edition?.spotify_track_url) {
-    return <PlayOnSpotify edition={edition} />;
-  }
-
   if (
     (edition?.gating_type === "spotify_presave" ||
       edition?.gating_type === "music_presave") &&


### PR DESCRIPTION
# Why 

Currently, the "Pre-Save to collect" label is never shown on the card because the logic is incorrect. 

# How

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
