### PR TITLE
fix: cover is not fill

### DIFF
--- a/packages/app/components/profile/profile-top.tsx
+++ b/packages/app/components/profile/profile-top.tsx
@@ -189,7 +189,9 @@ export const ProfileTop = ({
                   width={coverWidth}
                   height={coverHeight}
                   style={Platform.select({
-                    web: {},
+                    web: {
+                      height: "100%",
+                    },
                     default: { ...StyleSheet.absoluteFillObject },
                   })}
                 />


### PR DESCRIPTION
# Why
The profile cover does not fill the box.
## Before 

![CleanShot 2023-05-01 at 6 23 52](https://user-images.githubusercontent.com/37520667/235440405-1f591ab4-a9e1-4518-bb02-60ebbd8d4a0d.png)

## After 
![CleanShot 2023-05-01 at 6 24 11](https://user-images.githubusercontent.com/37520667/235440429-77a495a0-8336-47c1-88e6-4f65e2402f8e.png)

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
