### PR TITLE
fix: reanimated+gesturehandler crash

### DIFF
--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -38,7 +38,7 @@
     "@amplitude/analytics-react-native": "^1.1.3",
     "@bacons/link-assets": "^1.1.0",
     "@capsizecss/core": "^3.1.0",
-    "@coinbase/wallet-mobile-sdk": "^1.0.5",
+    "@coinbase/wallet-mobile-sdk": "1.0.6",
     "@ethersproject/shims": "^5.7.0",
     "@gorhom/bottom-sheet": "4.4.5",
     "@hcaptcha/react-native-hcaptcha": "^1.5.1",

--- a/packages/app/components/feed/feed-item-tap-gesture.tsx
+++ b/packages/app/components/feed/feed-item-tap-gesture.tsx
@@ -105,7 +105,8 @@ export const FeedItemTapGesture = ({
         .numberOfTaps(1)
         .onEnd(() => {
           runOnJS(toggleVideoPlayback)();
-        }),
+        })
+        .runOnJS(true),
 
     [toggleVideoPlayback]
   );
@@ -121,7 +122,8 @@ export const FeedItemTapGesture = ({
             withDelay(200, withSpring(0))
           );
           runOnJS(doubleTapHandleOnJS)();
-        }),
+        })
+        .runOnJS(true),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [doubleTapHandleOnJS]
   );
@@ -142,7 +144,8 @@ export const FeedItemTapGesture = ({
           if (toggleHeader) {
             runOnJS(toggleHeader)();
           }
-        }),
+        })
+        .runOnJS(true),
     [toggleHeader]
   );
 

--- a/packages/design-system/collapsible-tab-view/gesture-container.ios.tsx
+++ b/packages/design-system/collapsible-tab-view/gesture-container.ios.tsx
@@ -294,7 +294,8 @@ export const GestureContainer = React.forwardRef<
           isSlidingHeader.value = false;
         }
       );
-    });
+    })
+    .runOnJS(true);
 
   const gestureHandler = Gesture.Pan()
     .simultaneousWithExternalGesture(gestureHandlerHeader, ...childGestures)
@@ -381,7 +382,8 @@ export const GestureContainer = React.forwardRef<
       } else {
         tabsRefreshTrans.value < 0 ? onTabsStartRefresh() : onTabsEndRefresh();
       }
-    });
+    })
+    .runOnJS(true);
   //#endregion
 
   useEffect(() => {

--- a/packages/design-system/collapsible-tab-view/gesture-container.tsx
+++ b/packages/design-system/collapsible-tab-view/gesture-container.tsx
@@ -293,7 +293,8 @@ export const GestureContainer = React.forwardRef<
           isSlidingHeader.value = false;
         }
       );
-    });
+    })
+    .runOnJS(true);
 
   const gestureHandler = Gesture.Pan()
     .simultaneousWithExternalGesture(gestureHandlerHeader, ...childGestures)
@@ -377,7 +378,8 @@ export const GestureContainer = React.forwardRef<
       } else {
         tabsRefreshTrans.value < 0 ? onTabsStartRefresh() : onTabsEndRefresh();
       }
-    });
+    })
+    .runOnJS(true);
   //#endregion
 
   useEffect(() => {

--- a/packages/design-system/light-box/light-box-modal.tsx
+++ b/packages/design-system/light-box/light-box-modal.tsx
@@ -108,7 +108,8 @@ export const LightImageModal = ({
         translateY.value = withTiming(0, timingConfig);
       }
       scale.value = withTiming(1, timingConfig);
-    });
+    })
+    .runOnJS(true);
 
   const imageStyles = useAnimatedStyle(() => {
     const interpolateProgress = (range: [number, number]) =>
@@ -186,13 +187,15 @@ export const LightImageModal = ({
       if (onLongPress) {
         runOnJS(onLongPress)();
       }
-    });
-
+    })
+    .runOnJS(true);
   // Todo: add pinch
-  const pinchGesture = Gesture.Pinch().enabled(false);
-
+  const pinchGesture = Gesture.Pinch().enabled(false).runOnJS(true);
   // Todo: add double tab
-  const doubleTapGesture = Gesture.Tap().numberOfTaps(2).enabled(false);
+  const doubleTapGesture = Gesture.Tap()
+    .numberOfTaps(2)
+    .enabled(false)
+    .runOnJS(true);
   const tapGesture = Gesture.Tap()
     .enabled(tapToClose || !!onTap)
     .numberOfTaps(1)
@@ -204,7 +207,8 @@ export const LightImageModal = ({
       if (onTap) {
         runOnJS(onTap)();
       }
-    });
+    })
+    .runOnJS(true);
   return (
     <GestureDetector
       gesture={Gesture.Race(

--- a/packages/design-system/light-box/light-box.tsx
+++ b/packages/design-system/light-box/light-box.tsx
@@ -92,15 +92,17 @@ export const LightBox: React.FC<LightBoxProps> = ({
     });
   };
 
-  const tapGesture = Gesture.Tap().onEnd((_, success) => {
-    if (!success) return;
-    const measurements = measure(animatedRef);
-    width.value = measurements!.width;
-    height.value = measurements!.height;
-    x.value = measurements!.pageX;
-    y.value = measurements!.pageY - nativeHeaderHeight;
-    runOnJS(handlePress)();
-  });
+  const tapGesture = Gesture.Tap()
+    .onEnd((_, success) => {
+      if (!success) return;
+      const measurements = measure(animatedRef);
+      width.value = measurements!.width;
+      height.value = measurements!.height;
+      x.value = measurements!.pageX;
+      y.value = measurements!.pageY - nativeHeaderHeight;
+      runOnJS(handlePress)();
+    })
+    .runOnJS(true);
   const longPressGesture = Gesture.LongPress()
     .enabled(!!onLongPress)
     .maxDistance(10)
@@ -109,7 +111,8 @@ export const LightBox: React.FC<LightBoxProps> = ({
       if (onLongPress) {
         runOnJS(onLongPress)();
       }
-    });
+    })
+    .runOnJS(true);
   return (
     //@ts-ignore
     <GestureDetector gesture={Gesture.Race(longPressGesture, tapGesture)}>

--- a/packages/design-system/pan-to-close/pan-to-close.tsx
+++ b/packages/design-system/pan-to-close/pan-to-close.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback } from "react";
+import { FC } from "react";
 
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import Animated, {
@@ -46,21 +46,20 @@ export const PanToClose: FC<PanToCloseProps> = ({
       ],
     };
   });
-
-  const snapToPoint = useCallback(
-    (y: number) => {
-      "worklet";
-      transY.value = withSpring(y, SPRING_CONFIG, () => {
-        if (y !== 0) {
-          if (propOnClose) runOnJS(propOnClose)();
-          setTimeout(() => {
-            transY.value = 0;
-          }, closeDuration);
-        }
-      });
-    },
-    [transY, propOnClose, closeDuration]
-  );
+  const onClose = () => {
+    propOnClose();
+    setTimeout(() => {
+      transY.value = 0;
+    }, closeDuration);
+  };
+  const snapToPoint = (y: number) => {
+    "worklet";
+    transY.value = withSpring(y, SPRING_CONFIG, () => {
+      if (y !== 0) {
+        runOnJS(onClose)();
+      }
+    });
+  };
   const panGesture = Gesture.Pan()
     .onStart(({ velocityY, velocityX }) => {
       panIsVertical.value = Math.abs(velocityY) >= Math.abs(velocityX);

--- a/packages/design-system/pan-to-close/pan-to-close.tsx
+++ b/packages/design-system/pan-to-close/pan-to-close.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react";
+import { FC, useCallback } from "react";
 
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import Animated, {
@@ -46,20 +46,21 @@ export const PanToClose: FC<PanToCloseProps> = ({
       ],
     };
   });
-  const onClose = () => {
-    propOnClose();
-    setTimeout(() => {
-      transY.value = 0;
-    }, closeDuration);
-  };
-  const snapToPoint = (y: number) => {
-    "worklet";
-    transY.value = withSpring(y, SPRING_CONFIG, () => {
-      if (y !== 0) {
-        runOnJS(onClose)();
-      }
-    });
-  };
+
+  const snapToPoint = useCallback(
+    (y: number) => {
+      "worklet";
+      transY.value = withSpring(y, SPRING_CONFIG, () => {
+        if (y !== 0) {
+          if (propOnClose) runOnJS(propOnClose)();
+          setTimeout(() => {
+            transY.value = 0;
+          }, closeDuration);
+        }
+      });
+    },
+    [transY, propOnClose, closeDuration]
+  );
   const panGesture = Gesture.Pan()
     .onStart(({ velocityY, velocityX }) => {
       panIsVertical.value = Math.abs(velocityY) >= Math.abs(velocityX);

--- a/packages/design-system/pan-to-close/pan-to-close.tsx
+++ b/packages/design-system/pan-to-close/pan-to-close.tsx
@@ -83,7 +83,8 @@ export const PanToClose: FC<PanToCloseProps> = ({
       } else {
         snapToPoint(isSwipeDown || !isPanEnough ? 0 : endOffsetY);
       }
-    });
+    })
+    .runOnJS(true);
   if (!panCloseDirection) return null;
   if (disable) return children;
   return (

--- a/packages/design-system/pinch-to-zoom/pinch-to-zoom.tsx
+++ b/packages/design-system/pinch-to-zoom/pinch-to-zoom.tsx
@@ -127,7 +127,8 @@ export function PinchToZoom(props: PinchToZoomProps) {
         panTranslateY.value = 0;
 
         if (onPinchEnd) runOnJS(onPinchEnd)();
-      });
+      })
+      .runOnJS(true);
 
     return pinch;
 

--- a/packages/design-system/pinch-to-zoom/pinch-to-zoom.tsx
+++ b/packages/design-system/pinch-to-zoom/pinch-to-zoom.tsx
@@ -71,10 +71,10 @@ export function PinchToZoom(props: PinchToZoomProps) {
         }
 
         if (e.numberOfPointers === 1) {
-          translationX.value =
-            prevTranslationX.value + e.focalX - offsetFromFocalX.value;
-          translationY.value =
-            prevTranslationY.value + e.focalY - offsetFromFocalY.value;
+          // translationX.value =
+          //   prevTranslationX.value + e.focalX - offsetFromFocalX.value;
+          // translationY.value =
+          //   prevTranslationY.value + e.focalY - offsetFromFocalY.value;
           isPinching.value = false;
         } else if (e.numberOfPointers === 2) {
           const newScale = prevScale.value * e.scale;
@@ -97,15 +97,13 @@ export function PinchToZoom(props: PinchToZoomProps) {
           if (isPinching.value) {
             // translate the image to the focal point as we're zooming
             translationX.value =
-              prevTranslationX.value +
               -1 *
-                ((scale.value - offsetScale.value) *
-                  (originX.value - viewWidth.value / 2));
+              ((scale.value - offsetScale.value) *
+                (originX.value - viewWidth.value / 2));
             translationY.value =
-              prevTranslationY.value +
               -1 *
-                ((scale.value - offsetScale.value) *
-                  (originY.value - viewHeight.value / 2));
+              ((scale.value - offsetScale.value) *
+                (originY.value - viewHeight.value / 2));
           }
         }
       })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3146,9 +3146,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@coinbase/wallet-mobile-sdk@npm:^1.0.5":
-  version: 1.0.5
-  resolution: "@coinbase/wallet-mobile-sdk@npm:1.0.5"
+"@coinbase/wallet-mobile-sdk@npm:1.0.6":
+  version: 1.0.6
+  resolution: "@coinbase/wallet-mobile-sdk@npm:1.0.6"
   dependencies:
     "@coinbase/wallet-sdk": ^3.5.1
     "@metamask/safe-event-emitter": 2.0.0
@@ -3160,7 +3160,7 @@ __metadata:
     expo: "*"
     react: "*"
     react-native: "*"
-  checksum: 7cb719eca3f90a2adb1400ae2d5376f83afb9f300f1887e90c778a9c53d615bbe4b879c42ce04dab394537f9c7c7205882ae282fa8df45f370bac2aa5874774e
+  checksum: 15110c2e9e6e07ec8fb915cd55758c2aa7d02eefdff253d634abc174524b2e8a87a8c97566f533b59b97f89acbf8ff5062305f2f1520773e933b9075cae99bfd
   languageName: node
   linkType: hard
 
@@ -7966,7 +7966,7 @@ __metadata:
     "@babel/runtime": ^7.18.9
     "@bacons/link-assets": ^1.1.0
     "@capsizecss/core": ^3.1.0
-    "@coinbase/wallet-mobile-sdk": ^1.0.5
+    "@coinbase/wallet-mobile-sdk": 1.0.6
     "@ethersproject/shims": ^5.7.0
     "@expo/xcpretty": ^4.2.2
     "@gorhom/bottom-sheet": 4.4.5
@@ -18648,7 +18648,7 @@ __metadata:
   dependencies:
     bn.js: ^4.11.8
     ethereumjs-util: ^6.0.0
-  checksum: ae074be0bb012857ab5d3ae644d1163b908a48dd724b7d2567cfde309dc72222d460438f2411936a70dc949dc604ce1ef7118f7273bd525815579143c907e336
+  checksum: 03127d09960e5f8a44167463faf25b2894db2f746376dbb8195b789ed11762f93db9c574eaa7c498c400063508e9dfc1c80de2edf5f0e1406b25c87d860ff2f1
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -18648,7 +18648,7 @@ __metadata:
   dependencies:
     bn.js: ^4.11.8
     ethereumjs-util: ^6.0.0
-  checksum: 03127d09960e5f8a44167463faf25b2894db2f746376dbb8195b789ed11762f93db9c574eaa7c498c400063508e9dfc1c80de2edf5f0e1406b25c87d860ff2f1
+  checksum: ae074be0bb012857ab5d3ae644d1163b908a48dd724b7d2567cfde309dc72222d460438f2411936a70dc949dc604ce1ef7118f7273bd525815579143c907e336
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Why
- We get a crash when doing reload via dev menu. The stack trace of crash looks same when we apply codepush updates and do ExpoUpdates.reloadAsync.
- Also fixes crash caused by coinbase sdk due to failing assertion.

# How

Follows this [comment](https://github.com/software-mansion/react-native-gesture-handler/issues/2319#issuecomment-1375255933). This would make all the callback passed in gesture handler run on JS thread. Right now this seems to be a good tradeoff, we're mostly setting shared values in callbacks so this should not be a big issue. Best solution would be to migrate to v3 once it's stable enough.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->



<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
- Run the app, do cmd+d and press reload. App should not crash
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
