### PR TITLE
fix: bypass username lookup validation

### DIFF
--- a/packages/app/components/edit-profile.tsx
+++ b/packages/app/components/edit-profile.tsx
@@ -113,7 +113,7 @@ export const EditProfile = () => {
   const router = useRouter();
   const { width } = useWindowDimensions();
   const isMdWidth = width >= breakpoints["md"];
-  const { isValid, validate } = useValidateUsername();
+  const { isValid, validate, isLoading } = useValidateUsername();
   const isDark = useIsDarkMode();
   const pickFile = useFilePicker();
   const [cropViewHeight, setCropViewHeight] = useState(400);
@@ -167,7 +167,7 @@ export const EditProfile = () => {
   }, [reset, defaultValues]);
 
   const handleSubmitForm = async (values: typeof defaultValues) => {
-    if (!isValid || !formIsValid) return;
+    if (!isValid || !formIsValid || isLoading) return;
 
     const newValues = {
       name: values.name?.trim() || null,
@@ -554,8 +554,12 @@ export const EditProfile = () => {
           </BottomSheetScrollView>
           <View tw="my-2.5 mb-4 px-4">
             <Button
-              disabled={isSubmitting}
-              tw={isSubmitting || !formIsValid || !isValid ? "opacity-50" : ""}
+              disabled={isSubmitting || !formIsValid || !isValid || isLoading}
+              tw={
+                isSubmitting || !formIsValid || !isValid || isLoading
+                  ? "opacity-50"
+                  : ""
+              }
               onPress={handleSubmit(handleSubmitForm)}
               size="regular"
             >

--- a/packages/app/components/onboarding/select-username.tsx
+++ b/packages/app/components/onboarding/select-username.tsx
@@ -191,7 +191,9 @@ export const SelectUsername = () => {
               : "opacity-100",
           ]}
           size="regular"
-          disabled={!isFormValid || !isValidUsername || isLoading}
+          disabled={
+            !isFormValid || !isValidUsername || isLoading || isSubmitting
+          }
           onPress={handleSubmit(handleSubmitForm)}
         >
           Next

--- a/packages/app/hooks/use-validate-username.ts
+++ b/packages/app/hooks/use-validate-username.ts
@@ -9,6 +9,7 @@ export const useValidateUsername = () => {
   const [isLoading, setIsLoading] = useState(false);
   const { user } = useUser();
   const debounceTimeout = useRef<any>(null);
+  const lastInput = useRef<string | null>(null);
 
   async function validateUsername(value: string) {
     const username = value ? value.trim() : null;
@@ -39,6 +40,10 @@ export const useValidateUsername = () => {
   }
 
   function debouncedValidate(value: string) {
+    if (value !== lastInput.current && !isLoading) {
+      setIsLoading(true);
+    }
+
     if (debounceTimeout.current) {
       clearTimeout(debounceTimeout.current);
     }
@@ -46,6 +51,8 @@ export const useValidateUsername = () => {
     debounceTimeout.current = setTimeout(() => {
       validateUsername(value);
     }, 400);
+
+    lastInput.current = value;
   }
 
   return {


### PR DESCRIPTION
# Why

There was a flaw in the username lookup feature in both EditProfile and Onboarding. If a user typed too quickly, it was possible to bypass the check (because button would turn active on change), which could ultimately lead to an error. This is because the backend would not accept the already-taken username, but the UX would indicate something different

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

The issue we encountered was with the debounced input. Because of the 400ms delay, `isLoading` was only triggered with the debounce, resulting in an odd button/validation state. To resolve this, we stored the last value in a ref and checked if it had changed. We then triggered `setIsLoading` separately from the actual debounced lookup.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
