### PR TITLE
fix: tapping light box crashing app

### DIFF
--- a/packages/design-system/light-box/light-box.tsx
+++ b/packages/design-system/light-box/light-box.tsx
@@ -8,6 +8,7 @@ import Animated, {
   useAnimatedRef,
   useAnimatedStyle,
   useSharedValue,
+  runOnUI,
 } from "react-native-reanimated";
 
 import { AnimationParams, useLightBox } from "./provider";
@@ -95,12 +96,15 @@ export const LightBox: React.FC<LightBoxProps> = ({
   const tapGesture = Gesture.Tap()
     .onEnd((_, success) => {
       if (!success) return;
-      const measurements = measure(animatedRef);
-      width.value = measurements!.width;
-      height.value = measurements!.height;
-      x.value = measurements!.pageX;
-      y.value = measurements!.pageY - nativeHeaderHeight;
-      runOnJS(handlePress)();
+      runOnUI(() => {
+        "worklet";
+        const measurements = measure(animatedRef);
+        width.value = measurements!.width;
+        height.value = measurements!.height;
+        x.value = measurements!.pageX;
+        y.value = measurements!.pageY - nativeHeaderHeight;
+        runOnJS(handlePress)();
+      })();
     })
     .runOnJS(true);
   const longPressGesture = Gesture.LongPress()


### PR DESCRIPTION
# Why
Tapping lightbox in profile is crashing the app. Caused by https://github.com/showtime-xyz/showtime-frontend/pull/2158 changes
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
gesture handler is using measure function from reanimated, so we need to wrap it in runOnUI.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
Tapping user profile picture should not crash the app
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
