### PR TITLE
fix: uncheck icon size incorrect

### DIFF
--- a/packages/app/components/claim/claim-form.tsx
+++ b/packages/app/components/claim/claim-form.tsx
@@ -320,7 +320,7 @@ export const ClaimForm = ({
                     {user.data.profile.has_apple_music_token ? (
                       <CheckIcon />
                     ) : (
-                      <View tw="rounded-full border-[1px] border-gray-800 p-3 dark:border-gray-100" />
+                      <View tw="h-5 w-5 rounded-full border-[1px] border-gray-800 dark:border-gray-100" />
                     )}
                     <Text tw="ml-1 text-gray-900 dark:text-gray-100">
                       Connect your Apple Music account
@@ -344,7 +344,7 @@ export const ClaimForm = ({
                     {user.data.profile.has_spotify_token ? (
                       <CheckIcon />
                     ) : (
-                      <View tw="rounded-full border-[1px] border-gray-800 p-3 dark:border-gray-100" />
+                      <View tw="h-5 w-5 rounded-full border-[1px] border-gray-800 dark:border-gray-100" />
                     )}
                     <Text tw="ml-1 text-gray-900 dark:text-gray-100">
                       Connect your Spotify account


### PR DESCRIPTION
# Why 

fix uncheck icon size incorrect.  

## Before  

![CleanShot 2023-05-04 at 6 42 09](https://user-images.githubusercontent.com/37520667/236182049-268a99a4-5a18-4c0f-a341-586344bf86c3.png)

## After 
![CleanShot 2023-05-04 at 6 41 56](https://user-images.githubusercontent.com/37520667/236182056-5b582503-b679-4a73-914b-3a02a54a1743.png)

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
