### PR TITLE
fix: navigate drop slug

### DIFF
--- a/packages/app/navigation/root-stack-navigator.tsx
+++ b/packages/app/navigation/root-stack-navigator.tsx
@@ -74,11 +74,20 @@ export function RootStackNavigator() {
           name="search"
           component={SearchScreen}
           options={{
-            animation: "none",
+            animation: "fade",
+            animationDuration: 200,
           }}
         />
-        <Stack.Screen name="nft" component={NftScreen} />
-        <Stack.Screen name="dropSlug" component={NftScreen} />
+        <Stack.Screen
+          name="nft"
+          component={NftScreen}
+          getId={({ params }) => Object.values(params).join("-")}
+        />
+        <Stack.Screen
+          name="dropSlug"
+          component={NftScreen}
+          getId={({ params }) => Object.values(params).join("-")}
+        />
       </Stack.Group>
 
       {/* Screens accessible in most of the navigators */}

--- a/packages/app/navigation/types.ts
+++ b/packages/app/navigation/types.ts
@@ -62,7 +62,14 @@ type BottomTabNavigatorParams = {
   notificationsTab: NavigatorScreenParams<NotificationsStackParams>;
   profileTab: NavigatorScreenParams<ProfileStackParams>;
 };
-
+type SwipeListParams = {
+  profileId?: string;
+  initialScrollIndex?: number;
+  collectionId?: number;
+  sortType?: string;
+  tabType?: string;
+  type: string;
+};
 type RootStackNavigatorParams = {
   bottomTabs: BottomTabNavigatorParams;
   profile: ProfileStackParams["profile"];
@@ -72,20 +79,15 @@ type RootStackNavigatorParams = {
   blockedList: undefined;
   dropMusic: undefined;
   dropFree: undefined;
-  dropSlug: undefined;
+  dropSlug: SwipeListParams & {
+    dropSlug?: string;
+  };
   dropEvent: undefined;
   dropPrivate: undefined;
   dropUpdate: undefined;
   search: undefined;
-  swipeList: {
-    profileId?: string;
-    initialScrollIndex?: number;
-    collectionId?: number;
-    sortType?: string;
-    tabType?: string;
-    type: string;
-  };
-  nft: undefined;
+  swipeList: SwipeListParams;
+  nft: SwipeListParams;
   login: undefined;
   comments: undefined;
   details: undefined;


### PR DESCRIPTION
# Why

Clicking on a creator profile from a drop page on native does not let me open the profile’s drops. 
reported from https://showtime-rq88331.slack.com/archives/C02PXGK3V8D/p1683486707110039
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Add an ID to the DropSlug screen to prevent the screen from not changing when parameters have been updated.
# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

https://user-images.githubusercontent.com/37520667/236757106-711634c8-0dc9-4a57-bb4e-f8ce19bf3621.mp4

