### PR TITLE
feat: opt-in for large m2 builder

### DIFF
--- a/apps/expo/eas.json
+++ b/apps/expo/eas.json
@@ -4,11 +4,13 @@
       "channel": "production",
       "distribution": "store",
       "ios": {
-        "image": "latest"
+        "image": "latest",
+        "resourceClass": "large"
       },
       "android": {
         "buildType": "app-bundle",
-        "image": "latest"
+        "image": "latest",
+        "resourceClass": "large"
       },
       "env": {
         "STAGE": "production",
@@ -23,11 +25,13 @@
       "channel": "staging",
       "distribution": "internal",
       "ios": {
-        "image": "latest"
+        "image": "latest",
+        "resourceClass": "large"
       },
       "android": {
         "buildType": "apk",
-        "image": "latest"
+        "image": "latest",
+        "resourceClass": "large"
       },
       "env": {
         "STAGE": "staging",
@@ -42,10 +46,12 @@
       "developmentClient": true,
       "distribution": "internal",
       "ios": {
-        "image": "latest"
+        "image": "latest",
+        "resourceClass": "large"
       },
       "android": {
-        "image": "latest"
+        "image": "latest",
+        "resourceClass": "large"
       },
       "env": {
         "STAGE": "development"
@@ -58,10 +64,12 @@
     "simulator": {
       "ios": {
         "simulator": true,
-        "image": "latest"
+        "image": "latest",
+        "resourceClass": "large"
       },
       "android": {
-        "image": "latest"
+        "image": "latest",
+        "resourceClass": "large"
       },
       "env": {
         "STAGE": "staging"


### PR DESCRIPTION
# Why

Opt in for the faster M2 builds on EAS. This partially supersedes #1964 
(as learned at app.js conf)

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
