### PR TITLE
feat: support mousewheel control

### DIFF
--- a/apps/next/package.json
+++ b/apps/next/package.json
@@ -70,7 +70,7 @@
     "resize-observer-polyfill": "^1.5.1",
     "screenfull": "^6.0.2",
     "setimmediate": "^1.0.5",
-    "swiper": "^8.4.7",
+    "swiper": "^9.3.2",
     "swr": "^2.1.3",
     "wagmi": "^0.12.10",
     "web3modal": "^1.9.12"

--- a/packages/app/components/swipe-list.web.tsx
+++ b/packages/app/components/swipe-list.web.tsx
@@ -1,15 +1,8 @@
-import {
-  useCallback,
-  useMemo,
-  useRef,
-  createContext,
-  useState,
-  useEffect,
-} from "react";
+import { useCallback, useMemo, useRef, createContext, useState } from "react";
 import { useWindowDimensions } from "react-native";
 
 import { useSharedValue } from "react-native-reanimated";
-import { Virtual, Keyboard } from "swiper";
+import { Virtual, Keyboard, Mousewheel } from "swiper";
 import type { Swiper as SwiperClass } from "swiper";
 import "swiper/css";
 import "swiper/css/virtual";
@@ -119,7 +112,7 @@ export const SwipeList = ({
         <SwiperActiveIndexContext.Provider value={activeIndex}>
           <ViewabilityItemsContext.Provider value={visibleItems}>
             <Swiper
-              modules={[Virtual, Keyboard]}
+              modules={[Virtual, Keyboard, Mousewheel]}
               height={windowHeight}
               width={windowWidth}
               keyboard
@@ -131,6 +124,9 @@ export const SwipeList = ({
               threshold={isMobileWeb() ? 0 : 25}
               noSwiping
               noSwipingClass="swiper-no-swiping"
+              mousewheel={{
+                noMousewheelClass: "swiper-no-swiping",
+              }}
             >
               {data.map((item, index) => (
                 <SwiperSlide key={item.nft_id} virtualIndex={index}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8225,7 +8225,7 @@ __metadata:
     resize-observer-polyfill: ^1.5.1
     screenfull: ^6.0.2
     setimmediate: ^1.0.5
-    swiper: ^8.4.7
+    swiper: ^9.3.2
     swr: ^2.1.3
     tailwindcss: ^3.3.1
     wagmi: ^0.12.10
@@ -17230,15 +17230,6 @@ __metadata:
   version: 0.1.2
   resolution: "dom-walk@npm:0.1.2"
   checksum: 19eb0ce9c6de39d5e231530685248545d9cd2bd97b2cb3486e0bfc0f2a393a9addddfd5557463a932b52fdfcf68ad2a619020cd2c74a5fe46fbecaa8e80872f3
-  languageName: node
-  linkType: hard
-
-"dom7@npm:^4.0.4":
-  version: 4.0.6
-  resolution: "dom7@npm:4.0.6"
-  dependencies:
-    ssr-window: ^4.0.0
-  checksum: 616a68cbae59eaea2e717ada5855346f0ffa4ac10ab96713bb42b90efabce367213c3c491c4bf5502d177b0865c63d8abd298cc8e12bdda171340c853d6b515a
   languageName: node
   linkType: hard
 
@@ -31389,7 +31380,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ssr-window@npm:^4.0.0, ssr-window@npm:^4.0.2":
+"ssr-window@npm:^4.0.2":
   version: 4.0.2
   resolution: "ssr-window@npm:4.0.2"
   checksum: df182600927f4f3225224cf8c02338ea637c9750519505bbfb9a9236741a2a7ec088386fb948bca7b447b8303d9109e7dc7672e3de041c79ac2a0e03665af7d2
@@ -32112,13 +32103,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"swiper@npm:^8.4.7":
-  version: 8.4.7
-  resolution: "swiper@npm:8.4.7"
+"swiper@npm:^9.3.2":
+  version: 9.3.2
+  resolution: "swiper@npm:9.3.2"
   dependencies:
-    dom7: ^4.0.4
     ssr-window: ^4.0.2
-  checksum: c52be6105e12984ba024f8cb4c0627919d4069172c0021ed7c5743c3709b5a814dd50d134813ea4f7019048be6ff9dda96db8f1adf38e317c8bb285574fcd006
+  checksum: 9ccb6a0ef67d71ac780d7d1f3b2c2daf6f1846d3df8810aff6dcb8501c87b7769540a869cdd83eb902e5278396e5379cb32d9ed397234f7700ef55f0209f4592
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Why

We can now enable mouse control for SwipeList since Swiper.js [v9.3.2](https://github.com/nolimits4web/swiper/releases/tag/v9.3.2) already supports the `noMousewheelClass` parameter.

# How

Use the `noMousewheelClass` parameter to disable scrollable areas and avoid conflicts.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
Go to Swierlist on the web and try using the mouse wheel to switch between items. 

https://github.com/showtime-xyz/showtime-frontend/assets/37520667/c738c697-8ddb-4ff5-8a41-f90003935177

