### PR TITLE
fix: modal can't open when on url

### DIFF
--- a/packages/design-system/checkbox/index.tsx
+++ b/packages/design-system/checkbox/index.tsx
@@ -99,16 +99,6 @@ export const Checkbox = ({
           </Svg>
         </MotiView>
       </Animated.View>
-      {Platform.OS === "web" && (
-        <input
-          disabled={disabled}
-          type="checkbox"
-          id={id}
-          hidden
-          onChange={handleChange}
-          checked={checked}
-        />
-      )}
     </Pressable>
   );
 };

--- a/packages/design-system/modal-screen/with-modal-screen.web.tsx
+++ b/packages/design-system/modal-screen/with-modal-screen.web.tsx
@@ -71,15 +71,15 @@ function withModalScreen<P extends object>(
       if (
         !isLayouted.current &&
         (router.pathname === matchingPathname ||
-          Boolean(router.query[matchingQueryParam as any]))
+          Boolean(router.query[matchingQueryParam]))
       ) {
         isLayouted.current = true;
         setVisible(true);
-      } else if (isLayouted.current) {
+      } else if (isLayouted.current && router.pathname !== matchingPathname) {
         isLayouted.current = false;
         setVisible(false);
       }
-    }, [router]);
+    }, [router.pathname, router.query]);
 
     return (
       <ModalScreenContext.Provider value={contextValues}>


### PR DESCRIPTION
# Why

I found that if you access this https://showtime.xyz/drop, the modal doesn't open.

# How

Update the close logic for the modal on the web. 

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
