### PR TITLE
fix: poll every 2 hours and not every minute

### DIFF
--- a/packages/app/lib/apple-music-auth/apple-music-auth.ts
+++ b/packages/app/lib/apple-music-auth/apple-music-auth.ts
@@ -23,7 +23,7 @@ export const initialiseAppleMusic = async () => {
       },
     });
 
-    // TODO: increment this expiration from backend
-    await delay(60 * 1000);
+    // 2 hours validity
+    await delay(2 * 60 * 60 * 1000);
   }
 };


### PR DESCRIPTION
# Why

We don't need to poll the token every minute, it's enough to check for it every two hours
https://showtime-rq88331.slack.com/archives/C02QD3J7DJM/p1684427015334339

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Increased timeout duration.

@intergalacticspacehighway, we currently don't have a check for hard reloads, which means returning users or a reload would still trigger polling. Should we consider storing the token inside localStorage/MMKV and perform a validity check before initiating the polling? The response is a JWT, and we already have implemented logic for this with our AuthToken.

https://github.com/showtime-xyz/showtime-frontend/blob/9e5dde54b7ee88176f31873f9f979a162e1d2c73/packages/app/hooks/auth/use-access-token-manager.ts#L63-L77

WDYT? I think reducing every impactful request is a good thing. If you agree, feel free to add it to the PR.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
