### PR TITLE
feat: support optimized thumbnails

### DIFF
--- a/apps/next/src/pages/nft/[chainName]/[contractAddress]/[tokenId]/index.tsx
+++ b/apps/next/src/pages/nft/[chainName]/[contractAddress]/[tokenId]/index.tsx
@@ -23,6 +23,7 @@ export async function getServerSideProps(context) {
     const imageUrl = getMediaUrl({
       nft,
       stillPreview: nft?.mime_type?.startsWith("video"),
+      optimized: true,
     });
 
     if (nft) {

--- a/apps/next/src/pages/profile/[username]/[dropSlug].tsx
+++ b/apps/next/src/pages/profile/[username]/[dropSlug].tsx
@@ -22,6 +22,7 @@ export async function getServerSideProps(context) {
     const imageUrl = getMediaUrl({
       nft,
       stillPreview: nft?.mime_type?.startsWith("video"),
+      optimized: true,
     });
 
     if (nft) {

--- a/packages/app/components/feed-item/feed-item.tsx
+++ b/packages/app/components/feed-item/feed-item.tsx
@@ -38,7 +38,6 @@ import { useCreatorCollectionDetail } from "app/hooks/use-creator-collection-det
 import { useNFTDetailByTokenId } from "app/hooks/use-nft-detail-by-token-id";
 import { usePlatformBottomHeight } from "app/hooks/use-platform-bottom-height";
 import { useUser } from "app/hooks/use-user";
-import { useHeaderHeight } from "app/lib/react-navigation/elements";
 import type { NFT } from "app/types";
 import { getMediaUrl } from "app/utilities";
 

--- a/packages/app/components/media/grid-media.tsx
+++ b/packages/app/components/media/grid-media.tsx
@@ -46,7 +46,12 @@ function GridMediaImpl({
     [item]
   );
   const mediaStillPreviewUri = useMemo(
-    () => getMediaUrl({ nft: item, stillPreview: true }),
+    () =>
+      getMediaUrl({
+        nft: item,
+        stillPreview: true,
+        optimized: true,
+      }),
     [item]
   );
   const contentWidth = useContentWidth();

--- a/packages/app/components/media/list-media.tsx
+++ b/packages/app/components/media/list-media.tsx
@@ -40,7 +40,13 @@ function ListMediaImpl({
   );
 
   const mediaStillPreviewUri = useMemo(
-    () => getMediaUrl({ nft: item, stillPreview: true, animated: false }),
+    () =>
+      getMediaUrl({
+        nft: item,
+        stillPreview: true,
+        animated: false,
+        optimized: true,
+      }),
     [item]
   );
 

--- a/packages/app/types.ts
+++ b/packages/app/types.ts
@@ -10,6 +10,7 @@ export type BunnyVideoUrls = {
   original?: string | null;
   preview_animation?: string | null;
   thumbnail?: string | null;
+  optimized_thumbnail?: string | null;
   [key: string]: string | null | undefined;
 };
 

--- a/packages/app/utilities.ts
+++ b/packages/app/utilities.ts
@@ -187,12 +187,21 @@ const buildCdnUrl = (nft: NFT, stillPreview?: boolean) => {
   }`;
 };
 
-const getVideoOrGifUrl = (nft: NFT, animated?: boolean) => {
+const getVideoOrGifUrl = (
+  nft: NFT,
+  animated?: boolean,
+  optimized?: boolean
+) => {
+  // we have two sets of thumbnails, one from the first frame, and one from the middle (optimize)
+  const bunnyThumbUrl = optimized
+    ? nft?.video_urls?.optimized_thumbnail
+    : nft?.video_urls?.thumbnail;
+
   return animated
     ? nft?.video_urls?.preview_animation ??
-        nft?.video_urls?.thumbnail ??
+        bunnyThumbUrl ??
         nft?.cloudinary_thumbnail_url
-    : nft?.video_urls?.thumbnail ?? nft?.cloudinary_thumbnail_url;
+    : bunnyThumbUrl ?? nft?.cloudinary_thumbnail_url;
 };
 
 const getAvailableVideoUrl = (nft: NFT, stillPreview: boolean) => {
@@ -217,10 +226,12 @@ export const getMediaUrl = ({
   nft,
   stillPreview,
   animated,
+  optimized,
 }: {
   nft?: NFT;
   stillPreview: boolean;
   animated?: boolean;
+  optimized?: boolean;
 }) => {
   if (!nft || (!nft.chain_name && !nft.contract_address && !nft.token_id)) {
     console.warn("NFT is missing fields to get media URL");
@@ -234,7 +245,7 @@ export const getMediaUrl = ({
     stillPreview &&
     (nft?.mime_type?.startsWith("video") || nft?.mime_type === "image/gif")
   ) {
-    const url = getVideoOrGifUrl(nft, animated);
+    const url = getVideoOrGifUrl(nft, animated, optimized);
     cdnUrl = url ?? cdnUrl;
     cdnUrl = cdnUrl.replace(
       "https://storage.googleapis.com/showtime-cdn/cdnv2",


### PR DESCRIPTION
# Why

A lot of video stills are black since the first frame is fading or dark, resulting in strange-looking Lists and Grids.
Bunny creates 6 thumbnails for each video, so we're going to introduce a new key in lists, graph-images, and grids.
However, we still depend on the first frame for the video placeholders because they work best in most cases.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Use the new optimized_thumbnail (only for Bunny URLs)

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
