### PR TITLE
fix: lightbox crash

### DIFF
--- a/packages/design-system/light-box/light-box.tsx
+++ b/packages/design-system/light-box/light-box.tsx
@@ -8,7 +8,6 @@ import Animated, {
   useAnimatedRef,
   useAnimatedStyle,
   useSharedValue,
-  runOnUI,
 } from "react-native-reanimated";
 
 import { AnimationParams, useLightBox } from "./provider";
@@ -95,17 +94,12 @@ export const LightBox: React.FC<LightBoxProps> = ({
 
   const tapGesture = Gesture.Tap().onEnd((_, success) => {
     if (!success) return;
-    runOnUI(() => {
-      "worklet";
-      const measurements = measure(animatedRef);
-      if (measurements) {
-        width.value = measurements.width;
-        height.value = measurements.height;
-        x.value = measurements.pageX;
-        y.value = measurements.pageY - nativeHeaderHeight;
-        runOnJS(handlePress)();
-      }
-    })();
+    const measurements = measure(animatedRef);
+    width.value = measurements!.width;
+    height.value = measurements!.height;
+    x.value = measurements!.pageX;
+    y.value = measurements!.pageY - nativeHeaderHeight;
+    runOnJS(handlePress)();
   });
   const longPressGesture = Gesture.LongPress()
     .enabled(!!onLongPress)


### PR DESCRIPTION
# Why 

Currently, the app will crash if you press on the profile picture due to an issue with the lightbox component.

https://github.com/showtime-xyz/showtime-frontend/assets/37520667/d6323fed-ebdd-44ce-9971-aeefaba742c2



# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
