### PR TITLE
fix(android): some screens can show up with opacity

### DIFF
--- a/packages/app/navigation/root-stack-navigator.tsx
+++ b/packages/app/navigation/root-stack-navigator.tsx
@@ -62,7 +62,7 @@ export function RootStackNavigator() {
         screenOptions={{
           headerShown: false,
           fullScreenGestureEnabled: true,
-          animation: Platform.OS === "android" ? "fade_from_bottom" : "default",
+          animationDuration: 400,
         }}
       >
         <Stack.Screen
@@ -74,7 +74,7 @@ export function RootStackNavigator() {
           name="search"
           component={SearchScreen}
           options={{
-            animation: "fade",
+            animation: Platform.OS === "android" ? "fade_from_bottom" : "fade",
             animationDuration: 200,
           }}
         />

--- a/packages/app/navigation/root-stack-navigator.tsx
+++ b/packages/app/navigation/root-stack-navigator.tsx
@@ -62,7 +62,7 @@ export function RootStackNavigator() {
         screenOptions={{
           headerShown: false,
           fullScreenGestureEnabled: true,
-          animationDuration: 400,
+          animation: Platform.OS === "android" ? "fade_from_bottom" : "default",
         }}
       >
         <Stack.Screen
@@ -70,14 +70,7 @@ export function RootStackNavigator() {
           component={ProfileScreen}
           getId={({ params }) => params?.username}
         />
-        <Stack.Screen
-          name="search"
-          component={SearchScreen}
-          options={{
-            animation: "fade",
-            animationDuration: 200,
-          }}
-        />
+        <Stack.Screen name="search" component={SearchScreen} />
         <Stack.Screen
           name="nft"
           component={NftScreen}

--- a/packages/app/navigation/root-stack-navigator.tsx
+++ b/packages/app/navigation/root-stack-navigator.tsx
@@ -62,7 +62,7 @@ export function RootStackNavigator() {
         screenOptions={{
           headerShown: false,
           fullScreenGestureEnabled: true,
-          animationDuration: 400,
+          animation: Platform.OS === "android" ? "fade_from_bottom" : "default",
         }}
       >
         <Stack.Screen

--- a/packages/app/navigation/root-stack-navigator.tsx
+++ b/packages/app/navigation/root-stack-navigator.tsx
@@ -62,6 +62,7 @@ export function RootStackNavigator() {
         screenOptions={{
           headerShown: false,
           fullScreenGestureEnabled: true,
+          animationDuration: Platform.OS === "ios" ? 400 : 350,
           animation: Platform.OS === "android" ? "fade_from_bottom" : "default",
         }}
       >

--- a/packages/app/navigation/root-stack-navigator.tsx
+++ b/packages/app/navigation/root-stack-navigator.tsx
@@ -70,7 +70,14 @@ export function RootStackNavigator() {
           component={ProfileScreen}
           getId={({ params }) => params?.username}
         />
-        <Stack.Screen name="search" component={SearchScreen} />
+        <Stack.Screen
+          name="search"
+          component={SearchScreen}
+          options={{
+            animation: "fade",
+            animationDuration: 200,
+          }}
+        />
         <Stack.Screen
           name="nft"
           component={NftScreen}


### PR DESCRIPTION
# Why
Some screens show up with opacity > 0. I think it has to do with rn-screens + when headerShown is false + fade animation. The animation of screen transition gets stuck. Changing to animation to something else fixes the issue. Right now changed it to `fade_from_bottom`. This PR adds a quick solution. I am trying to create a minimal repro to know the root cause. 

https://github.com/showtime-xyz/showtime-frontend/assets/23293248/5d6d864a-b976-478c-a570-c9a09cbb3066

<!--



Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
