### PR TITLE
fix: add react-native-svg to resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
     "eth-block-tracker": "4.4.3",
     "next": "^13.4.1",
     "react-native-mmkv": "2.8.0",
-    "react-native-screens": "3.20.0"
+    "react-native-screens": "3.20.0",
+    "react-native-svg": "13.9.0"
   },
   "react-native": {
     "zlib": "browserify-zlib",

--- a/yarn.lock
+++ b/yarn.lock
@@ -29019,16 +29019,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-svg@npm:9.6.4":
-  version: 9.6.4
-  resolution: "react-native-svg@npm:9.6.4"
-  peerDependencies:
-    react: "*"
-    react-native: ">=0.50.0"
-  checksum: 6b62cf6dc6b6e1f434d643d4b1de8d01469f3ab50985e79b1c3a77c743cb5e830b04b7765dd791af7cdcce1245ebc8dba86380ee6c6849532ba9d4d2be8fc532
-  languageName: node
-  linkType: hard
-
 "react-native-swipe-gestures@npm:^1.0.5":
   version: 1.0.5
   resolution: "react-native-swipe-gestures@npm:1.0.5"


### PR DESCRIPTION
# Why

Our current version 115 crashes because of walletconnect - had to add a resolution for react-native-svg to prevent duplicate versions.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
