### PR TITLE
fix: add title to links for transparency

### DIFF
--- a/packages/app/lib/linkify.tsx
+++ b/packages/app/lib/linkify.tsx
@@ -33,6 +33,7 @@ export const linkifyDescription = (text?: string, tw?: TW) => {
             href={match.toLowerCase()}
             key={match + i}
             target="_blank"
+            title={urlText}
             tw={[
               "text-13 font-bold text-gray-900 dark:text-gray-100",
               tw ? (Array.isArray(tw) ? tw.join(" ") : tw) : "",
@@ -58,6 +59,7 @@ export const linkifyDescription = (text?: string, tw?: TW) => {
           href={`/@${match}`}
           key={match + i}
           target="_blank"
+          title="Open profile"
           tw={[
             "text-13 font-bold text-gray-900 dark:text-gray-100",
             tw ? (Array.isArray(tw) ? tw.join(" ") : tw) : "",


### PR DESCRIPTION
# Why

Since links can be shortened, we should print the "title" for more transparency when hovering over it

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
