### PR TITLE
feat: add support for eas-updates from background

### DIFF
--- a/apps/expo/App.tsx
+++ b/apps/expo/App.tsx
@@ -8,6 +8,7 @@ import * as Notifications from "expo-notifications";
 import { AvoidSoftInput } from "react-native-avoid-softinput";
 import { enableFreeze, enableScreens } from "react-native-screens";
 
+import { useExpoUpdate } from "app/hooks/use-expo-update";
 import { growthbook } from "app/lib/growthbook";
 import { Logger } from "app/lib/logger";
 import { Sentry } from "app/lib/sentry";
@@ -51,6 +52,9 @@ LogBox.ignoreLogs([
 ]);
 
 function App() {
+  // check for updates as early as possible
+  useExpoUpdate();
+
   const [notification, setNotification] =
     useState<Notifications.Notification | null>(null);
 

--- a/packages/app/hooks/use-expo-update.tsx
+++ b/packages/app/hooks/use-expo-update.tsx
@@ -74,7 +74,7 @@ export function useExpoUpdate() {
     } else if (
       // check if its been 30 minutes since the last check and the app was backgrounded
       appBackgrounded.current &&
-      differenceInMinutes(new Date(), appBackgrounded.current) > 30
+      differenceInMinutes(new Date(), appBackgrounded.current) > 15
     ) {
       checkUpdate(true);
     }

--- a/packages/app/hooks/use-expo-update.tsx
+++ b/packages/app/hooks/use-expo-update.tsx
@@ -1,5 +1,7 @@
-import { useEffect, useCallback } from "react";
+import { useEffect, useCallback, useRef } from "react";
+import { Platform } from "react-native";
 
+import { differenceInMinutes } from "date-fns";
 import * as Updates from "expo-updates";
 
 import { useSnackbar } from "@showtime-xyz/universal.snackbar";
@@ -7,45 +9,44 @@ import { useSnackbar } from "@showtime-xyz/universal.snackbar";
 import { usePlatformBottomHeight } from "app/hooks/use-platform-bottom-height";
 import { captureException } from "app/lib/sentry";
 
-// import { MMKV } from "react-native-mmkv";
-
-/**
- * store key
- */
-// const store = new MMKV();
-// const BACKGROUND_START_TIME_KEY = "backgroundStartTime";
-// const LAST_SHOW_UPDATE_KEY = "lastShowUpdateTime";
-
-/**
- * update constant
- */
-// const CHECK_UPDATE_FREQUENCY = 1; // days
-// const SWITCH_TO_FOREGROUND_INTERVAL = 300; // seconds
+import { useIsForeground } from "./use-is-foreground";
 
 export function useExpoUpdate() {
   const bottom = usePlatformBottomHeight();
-  // const isForeground = useIsForeground();
+  const isForeground = useIsForeground();
   const snackbar = useSnackbar();
+  const appBackgrounded = useRef<Date | null>(null);
+  const lastUpdateCheck = useRef<Date | null>(null);
+
   const checkUpdate = useCallback(
     async (isAutoUpdate = false) => {
       try {
         const update = await Updates.checkForUpdateAsync();
-        if (!update.isAvailable) return;
+
+        if (!update.isAvailable) {
+          return;
+        }
+
         const result = await Updates.fetchUpdateAsync();
-        if (result.isNew) {
-          if (isAutoUpdate) {
-            await Updates.reloadAsync();
-          } else {
-            snackbar?.show({
-              text: "New update available 🎉",
-              bottom,
-              action: {
-                text: "Reload",
-                onPress: async () => await Updates.reloadAsync(),
-              },
-              hideAfter: 5000,
-            });
-          }
+
+        if (!result.isNew) {
+          return;
+        }
+
+        if (isAutoUpdate) {
+          await Updates.reloadAsync();
+        } else {
+          snackbar?.show({
+            text: "New update available 🎉",
+            bottom,
+            preset: "explore",
+            action: {
+              text: "Reload",
+              onPress: Updates.reloadAsync,
+            },
+            disableGestureToClose: true,
+            hideAfter: 30000, // 30 seconds
+          });
         }
       } catch (error) {
         captureException(error);
@@ -57,33 +58,27 @@ export function useExpoUpdate() {
   );
 
   useEffect(() => {
-    // const now = new Date();
-    // const currentHours = now.getHours();
-    checkUpdate(true);
-    // if (isForeground) {
-    //   if (__DEV__) return;
-    //   if (Platform.OS !== "ios") return;
-    //   const lastUpdateTime = store.getString(LAST_SHOW_UPDATE_KEY);
-    //   const diffDays = lastUpdateTime
-    //     ? differenceInDays(now, Date.parse(lastUpdateTime))
-    //     : 0;
+    // dont run on web or dev mode
+    if (__DEV__ || Platform.OS === "web") return;
 
-    //   // check update frequency, avoid prompting for updates multiple times a day.
-    //   if (diffDays < CHECK_UPDATE_FREQUENCY) return;
+    // this fires when the app is backgrounded or in inactive state (app switcher)
+    // will be skipped on first run
+    if (!isForeground) {
+      appBackgrounded.current = new Date();
+      return;
+    }
 
-    //   const startTime = store.getString(BACKGROUND_START_TIME_KEY);
-    //   const diffSeconds = startTime
-    //     ? differenceInSeconds(now, Date.parse(startTime))
-    //     : 0;
+    // check if its the first time running, so its cold start
+    if (!lastUpdateCheck.current) {
+      checkUpdate(true);
+    } else if (
+      // check if its been 30 minutes since the last check and the app was backgrounded
+      appBackgrounded.current &&
+      differenceInMinutes(new Date(), appBackgrounded.current) > 30
+    ) {
+      checkUpdate(true);
+    }
 
-    //   // only display update when after 5 minutes in background.
-    //   if (diffSeconds < SWITCH_TO_FOREGROUND_INTERVAL) return;
-    //   // if between 3am and 5am, will auto-update.
-    //   const currentHours = now.getHours();
-
-    //   checkUpdate(currentHours > 3 && currentHours < 5);
-    // } else {
-    //   store.set(BACKGROUND_START_TIME_KEY, now.toISOString());
-    // }
-  }, [checkUpdate]);
+    lastUpdateCheck.current = new Date();
+  }, [checkUpdate, isForeground]);
 }

--- a/packages/app/navigation/bottom-tab-navigator.tsx
+++ b/packages/app/navigation/bottom-tab-navigator.tsx
@@ -3,7 +3,6 @@ import { useWindowDimensions } from "react-native";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import dynamic from "next/dynamic";
 
-import { useExpoUpdate } from "app/hooks/use-expo-update";
 import { useUser } from "app/hooks/use-user";
 
 import { BottomTabbar } from "./bottom-tab-bar";
@@ -27,8 +26,6 @@ const BottomTab = createBottomTabNavigator();
 export function BottomTabNavigator() {
   const { width } = useWindowDimensions();
   const { user } = useUser();
-
-  useExpoUpdate();
 
   return (
     <BottomTab.Navigator


### PR DESCRIPTION
# Why

Our app currently only updates during a cold boot, never when transitioning from the background to the foreground. Given that many users, especially those on iOS, tend not to kill apps, we are potentially missing out on over-the-air updates.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Added some checks. We agreed not showing a Snack and just update. The App must have been backgrounded at least 15min though.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
