### PR TITLE
fix: clear input on edit message

### DIFF
--- a/packages/app/components/creator-channels/messages.tsx
+++ b/packages/app/components/creator-channels/messages.tsx
@@ -776,6 +776,7 @@ const MessageInput = ({
           }}
           onSubmit={async (text: string) => {
             if (channelId) {
+              inputRef.current?.reset();
               enableLayoutAnimations(false);
               listRef.current?.prepareForLayoutAnimationRender();
               await sendMessage.trigger({
@@ -783,8 +784,6 @@ const MessageInput = ({
                 message: text,
                 callback: sendMessageCallback,
               });
-
-              inputRef.current?.reset();
               requestAnimationFrame(() => {
                 enableLayoutAnimations(true);
 
@@ -798,7 +797,7 @@ const MessageInput = ({
 
             return Promise.resolve();
           }}
-          submitting={sendMessage.isMutating}
+          submitting={editMessages.isMutating || sendMessage.isMutating}
           tw="bg-white dark:bg-black"
           submitButton={
             editMessage ? (
@@ -819,15 +818,16 @@ const MessageInput = ({
                     disabled={editMessages.isMutating || !editMessage}
                     iconOnly
                     onPress={() => {
+                      const newMessage = inputRef.current?.value;
+                      inputRef.current?.reset();
                       enableLayoutAnimations(true);
                       requestAnimationFrame(() => {
                         editMessages.trigger({
                           messageId: editMessage.id,
-                          message: inputRef.current.value,
+                          message: newMessage,
                           channelId,
                         });
                         setEditMessage(undefined);
-                        inputRef.current?.reset();
                       });
                     }}
                   >

--- a/packages/app/components/creator-channels/messages.tsx
+++ b/packages/app/components/creator-channels/messages.tsx
@@ -819,6 +819,7 @@ const MessageInput = ({
                     iconOnly
                     onPress={() => {
                       const newMessage = inputRef.current?.value;
+                      if (newMessage.trim().length === 0) return;
                       inputRef.current?.reset();
                       enableLayoutAnimations(true);
                       requestAnimationFrame(() => {


### PR DESCRIPTION
# Why
Sometimes fast tap on edit message also sends the message. 

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- Disable submit if edit message is loading and also clear the input on button tap.
<!--
How did you build this feature or fix this bug and why?
-->



<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
