### PR TITLE
fix: wrong link color in feed text

### DIFF
--- a/packages/app/components/feed-item/details.tsx
+++ b/packages/app/components/feed-item/details.tsx
@@ -34,7 +34,7 @@ export const NFTDetails = ({ nft, edition, detail }: NFTDetailsProps) => {
             limitLineBreaks(
               cleanUserTextInput(removeTags(nft?.token_description))
             ),
-            "text-13 font-bold text-gray-100"
+            "text-13 font-bold text-white"
           )
         : "",
     [nft?.token_description]


### PR DESCRIPTION
# Why

Tag/Link Color in Feed was wrong

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
