### PR TITLE
Fix/undefined search results

### DIFF
--- a/packages/app/components/header/header-center.tsx
+++ b/packages/app/components/header/header-center.tsx
@@ -26,9 +26,11 @@ const SearchInHeader = () => {
 
   // since the search returns weird results with "undefined" in the list, we filter them out
   const filteredData = useMemo(
-    () => data?.filter((item) => item.name && item.username !== "undefined"),
+    () => data?.filter((item) => item.username),
     [data]
   );
+
+  console.log(data);
 
   useEffect(() => {
     if (term !== "" && term.length > 1) {

--- a/packages/app/components/header/header-center.tsx
+++ b/packages/app/components/header/header-center.tsx
@@ -26,11 +26,9 @@ const SearchInHeader = () => {
 
   // since the search returns weird results with "undefined" in the list, we filter them out
   const filteredData = useMemo(
-    () => data?.filter((item) => item.username),
+    () => data?.filter((item) => item.username || item.address),
     [data]
   );
-
-  console.log(data);
 
   useEffect(() => {
     if (term !== "" && term.length > 1) {

--- a/packages/app/components/header/header-center.tsx
+++ b/packages/app/components/header/header-center.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, useMemo } from "react";
 import { Platform, TextInput } from "react-native";
 
 import * as Popover from "@radix-ui/react-popover";
@@ -24,8 +24,14 @@ const SearchInHeader = () => {
   const { loading, data } = useSearch(term);
   const inputRef = useRef<TextInput>();
 
+  // since the search returns weird results with "undefined" in the list, we filter them out
+  const filteredData = useMemo(
+    () => data?.filter((item) => item.name && item.username !== "undefined"),
+    [data]
+  );
+
   useEffect(() => {
-    if (term !== "") {
+    if (term !== "" && term.length > 1) {
       setIsOpen(true);
     } else {
       setIsOpen(false);
@@ -106,7 +112,7 @@ const SearchInHeader = () => {
           {data ? (
             <InfiniteScrollList
               useWindowScroll={false}
-              data={data}
+              data={filteredData}
               renderItem={renderItem}
               keyboardShouldPersistTaps="handled"
               estimatedItemSize={64}

--- a/packages/app/components/search/index.tsx
+++ b/packages/app/components/search/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState, useEffect } from "react";
+import { useCallback, useRef, useState, useEffect, useMemo } from "react";
 import { Keyboard, Platform, TextInput } from "react-native";
 
 import { ListRenderItemInfo } from "@shopify/flash-list";
@@ -39,6 +39,12 @@ export const Search = () => {
   const Separator = useCallback(
     () => <View tw="h-[1px] bg-gray-200 dark:bg-gray-800" />,
     []
+  );
+
+  // since the search returns weird results with "undefined" in the list, we filter them out
+  const filteredData = useMemo(
+    () => data?.filter((item) => item.name && item.username !== "undefined"),
+    [data]
   );
 
   useEffect(() => {
@@ -128,7 +134,7 @@ export const Search = () => {
       </View>
       {data ? (
         <InfiniteScrollList
-          data={data}
+          data={filteredData}
           renderItem={renderItem}
           ItemSeparatorComponent={Separator}
           keyboardShouldPersistTaps="handled"

--- a/packages/app/components/search/index.tsx
+++ b/packages/app/components/search/index.tsx
@@ -43,7 +43,7 @@ export const Search = () => {
 
   // since the search returns weird results with "undefined" in the list, we filter them out
   const filteredData = useMemo(
-    () => data?.filter((item) => item.name && item.username !== "undefined"),
+    () => data?.filter((item) => item.username),
     [data]
   );
 

--- a/packages/app/components/search/index.tsx
+++ b/packages/app/components/search/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState, useEffect, useMemo } from "react";
+import { useCallback, useRef, useState, useEffect, useMemo, memo } from "react";
 import { Keyboard, Platform, TextInput } from "react-native";
 
 import { ListRenderItemInfo } from "@shopify/flash-list";
@@ -36,14 +36,10 @@ export const Search = () => {
   const [term, setTerm] = useState("");
   const { loading, data } = useSearch(term);
   const inputRef = useRef<TextInput>();
-  const Separator = useCallback(
-    () => <View tw="h-[1px] bg-gray-200 dark:bg-gray-800" />,
-    []
-  );
 
   // since the search returns weird results with "undefined" in the list, we filter them out
   const filteredData = useMemo(
-    () => data?.filter((item) => item.username),
+    () => data?.filter((item) => item.username || item.address),
     [data]
   );
 
@@ -136,9 +132,8 @@ export const Search = () => {
         <InfiniteScrollList
           data={filteredData}
           renderItem={renderItem}
-          ItemSeparatorComponent={Separator}
           keyboardShouldPersistTaps="handled"
-          estimatedItemSize={64}
+          estimatedItemSize={55}
           {...keyboardDismissProp}
         />
       ) : loading && term && term.length > 1 ? (
@@ -148,68 +143,66 @@ export const Search = () => {
   );
 };
 
-export const SearchItem = ({
-  item,
-  onPress,
-}: {
-  item: SearchResponseItem;
-  onPress?: () => void;
-}) => {
-  return (
-    <Link
-      href={`/@${item.username ?? item.address0}`}
-      onPress={onPress}
-      tw="p-4 duration-150 hover:bg-gray-100 dark:hover:bg-gray-800"
-    >
-      <View tw="flex-row items-center justify-between">
-        <View tw="flex-row">
-          <View tw="mr-2 h-8 w-8 rounded-full bg-gray-200">
-            {item.img_url && (
-              <Image
-                source={{ uri: item.img_url }}
-                tw="rounded-full"
-                width={32}
-                height={32}
-                alt={item.username ?? item.address0}
-              />
-            )}
-          </View>
-          <View tw="mr-1 justify-center">
-            {item.name ? (
-              <>
+export const SearchItem = memo(
+  ({ item, onPress }: { item: SearchResponseItem; onPress?: () => void }) => {
+    return (
+      <Link
+        href={`/@${item.username ?? item.address}`}
+        onPress={onPress}
+        tw="px-4 py-3 duration-150 hover:bg-gray-100 dark:hover:bg-gray-800"
+      >
+        <View tw="flex-row items-center justify-between">
+          <View tw="flex-row">
+            <View tw="mr-2 h-8 w-8 rounded-full bg-gray-200">
+              {item.img_url && (
+                <Image
+                  source={{ uri: item.img_url }}
+                  tw="rounded-full"
+                  width={32}
+                  height={32}
+                  alt={item.username ?? item.address}
+                />
+              )}
+            </View>
+            <View tw="mr-1 justify-center">
+              {item.name ? (
+                <>
+                  <Text
+                    tw="text-sm font-semibold text-gray-600 dark:text-gray-300"
+                    numberOfLines={1}
+                  >
+                    {item.name}
+                  </Text>
+                  <View tw="h-1" />
+                </>
+              ) : null}
+
+              <View tw="flex-row items-center">
                 <Text
-                  tw="text-sm font-semibold text-gray-600 dark:text-gray-300"
+                  tw="text-sm font-semibold text-gray-900 dark:text-white"
                   numberOfLines={1}
                 >
-                  {item.name}
+                  {item.username ? (
+                    <>@{item.username}</>
+                  ) : (
+                    <>{formatAddressShort(item.address)}</>
+                  )}
                 </Text>
-                <View tw="h-1" />
-              </>
-            ) : null}
-
-            <View tw="flex-row items-center">
-              <Text
-                tw="text-sm font-semibold text-gray-900 dark:text-white"
-                numberOfLines={1}
-              >
-                {item.username ? (
-                  <>@{item.username}</>
-                ) : (
-                  <>{formatAddressShort(item.address0)}</>
+                {Boolean(item.verified) && (
+                  <View tw="ml-1">
+                    <VerificationBadge size={14} />
+                  </View>
                 )}
-              </Text>
-              {Boolean(item.verified) && (
-                <View tw="ml-1">
-                  <VerificationBadge size={14} />
-                </View>
-              )}
+              </View>
             </View>
           </View>
         </View>
-      </View>
-    </Link>
-  );
-};
+      </Link>
+    );
+  }
+);
+
+SearchItem.displayName = "SearchItem";
 
 export const SearchItemSkeleton = () => {
   return (

--- a/packages/app/components/search/index.tsx
+++ b/packages/app/components/search/index.tsx
@@ -141,7 +141,7 @@ export const Search = () => {
           estimatedItemSize={64}
           {...keyboardDismissProp}
         />
-      ) : loading && term ? (
+      ) : loading && term && term.length > 1 ? (
         <SearchItemSkeleton />
       ) : null}
     </>

--- a/packages/app/hooks/api/use-search.ts
+++ b/packages/app/hooks/api/use-search.ts
@@ -9,7 +9,7 @@ export type SearchResponseItem = {
   username: string;
   verified: boolean;
   img_url: string;
-  address0: string;
+  address: string;
 };
 
 type SearchResponse = {


### PR DESCRIPTION
# Why

The search returns items named _null_ and usernames as _undefined_, making it impossible to display a profile. All of those profiles ended up redirecting to "@undefined". Currently, we can only show results when a username was set.

Additionally, when typing a single letter, a skeleton would appear, while the search function only reacted after entering 2 characters. I have also fixed this issue.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Added a little memoized data transformer to automatically filter items without username.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->


| Before                                                                                                             | After                                                                                                           |
| ------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
| ![Bildschirmfoto 2023-06-12 um 18 43 04](https://github.com/showtime-xyz/showtime-frontend/assets/504909/3636634d-8bfa-44e6-8be6-8156ccd6043d) | ![Bildschirmfoto 2023-06-12 um 18 56 35](https://github.com/showtime-xyz/showtime-frontend/assets/504909/26827762-bcac-4730-b1cc-5eceab5dd060) |

