### PR TITLE
fix: optimize image quality

### DIFF
--- a/packages/app/components/feed-item/feed-item.md.tsx
+++ b/packages/app/components/feed-item/feed-item.md.tsx
@@ -343,6 +343,7 @@ export const FeedItemMD = memo<FeedItemProps>(function FeedItemMD({
                   }}
                   resizeMode={ResizeMode.CONTAIN}
                   optimizedWidth={1200}
+                  quality={80}
                 />
               </FeedItemTapGesture>
               <NSFWGate nftId={nft.nft_id} show={nft.nsfw} />

--- a/packages/app/components/media/grid-media.tsx
+++ b/packages/app/components/media/grid-media.tsx
@@ -79,7 +79,7 @@ function GridMediaImpl({
       item?.mime_type !== "image/gif" ? (
         <Image
           source={{
-            uri: `${mediaUri}?optimizer=image&width=300&quality=70`,
+            uri: `${mediaUri}?optimizer=image&width=300&quality=70&sharpen=true`,
           }}
           recyclingKey={mediaUri}
           blurhash={item?.blurhash}
@@ -103,7 +103,7 @@ function GridMediaImpl({
           )}
           <Image
             source={{
-              uri: `${mediaStillPreviewUri}?&optimizer=image&width=300&quality=70`,
+              uri: `${mediaStillPreviewUri}?&optimizer=image&width=300&quality=70&sharpen=true`,
             }}
             recyclingKey={mediaUri}
             data-test-id={Platform.select({ web: "nft-card-media" })}

--- a/packages/app/components/media/list-media.tsx
+++ b/packages/app/components/media/list-media.tsx
@@ -56,7 +56,7 @@ function ListMediaImpl({
       item?.mime_type !== "image/gif" ? (
         <Image
           source={{
-            uri: `${mediaUri}?optimizer=image&width=${optimizedWidth}&quality=70`,
+            uri: `${mediaUri}?optimizer=image&width=${optimizedWidth}&quality=70&sharpen=true`,
           }}
           recyclingKey={mediaUri}
           blurhash={item?.blurhash}
@@ -73,7 +73,7 @@ function ListMediaImpl({
       item?.mime_type === "image/gif" ? (
         <Image
           source={{
-            uri: `${mediaStillPreviewUri}?&optimizer=image&width=${optimizedWidth}&quality=70`,
+            uri: `${mediaStillPreviewUri}?&optimizer=image&width=${optimizedWidth}&quality=70&sharpen=true`,
           }}
           recyclingKey={mediaUri}
           blurhash={item?.blurhash}

--- a/packages/app/components/media/media.tsx
+++ b/packages/app/components/media/media.tsx
@@ -36,6 +36,7 @@ type Props = {
   optimizedWidth?: number;
   loading?: "eager" | "lazy";
   withVideoBackdrop?: boolean;
+  quality?: number;
 };
 
 function MediaImplementation({
@@ -49,6 +50,7 @@ function MediaImplementation({
   edition,
   videoRef,
   optimizedWidth = 800,
+  quality = 70,
   loading = "lazy",
   withVideoBackdrop = false,
 }: Props) {
@@ -90,7 +92,7 @@ function MediaImplementation({
         >
           <Image
             source={{
-              uri: `${mediaUri}?optimizer=image&width=${optimizedWidth}&quality=70`,
+              uri: `${mediaUri}?optimizer=image&width=${optimizedWidth}&quality=${quality}&sharpen=true`,
             }}
             recyclingKey={mediaUri}
             blurhash={item?.blurhash}
@@ -123,7 +125,7 @@ function MediaImplementation({
               uri: mediaUri,
             }}
             posterSource={{
-              uri: `${mediaStillPreviewUri}?&optimizer=image&width=${optimizedWidth}&quality=70`,
+              uri: `${mediaStillPreviewUri}?&optimizer=image&width=${optimizedWidth}&quality=${quality}&sharpen=true`,
             }}
             width={width}
             height={height}


### PR DESCRIPTION
# Why

Some users are not very happy with our image quality. After checking I could agree that our quality on web is not the best.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Bunny offers a feature called 'sharpen', which utilizes a different algorithm (albeit a bit slower for the initial generation due to the use of bicubic transformation) to produce sharper and less fragmented images. I also increased web quality from 70 to 80.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
