### PR TITLE
fix: rainbow unsupported error

### DIFF
--- a/packages/app/providers/wallet-provider.tsx
+++ b/packages/app/providers/wallet-provider.tsx
@@ -29,13 +29,7 @@ export const providerMetadata: IProviderMetadata = {
 export const sessionParams = {
   namespaces: {
     eip155: {
-      methods: [
-        "eth_sendTransaction",
-        "eth_signTransaction",
-        "eth_sign",
-        "personal_sign",
-        "eth_signTypedData",
-      ],
+      methods: ["personal_sign"],
       chains: ["eip155:1"],
       events: ["chainChanged", "accountsChanged"],
       rpcMap: {},


### PR DESCRIPTION
# Why
Fix: rainbow wallet unsupported method error
