### PR TITLE
feat: add support for unread messages in channels list

### DIFF
--- a/packages/app/components/creator-channels/channels.web.tsx
+++ b/packages/app/components/creator-channels/channels.web.tsx
@@ -93,6 +93,7 @@ const CreatorChannelsListItem = memo(
       <Pressable
         onPress={() => {
           router.push(`/channels/${item.id}`);
+          item.read = true;
         }}
         style={{ width: "100%" }}
       >
@@ -136,7 +137,7 @@ const CreatorChannelsListItem = memo(
                 <Text
                   tw={[
                     "text-[13px] ",
-                    item?.unread
+                    !item?.read
                       ? "font-semibold text-black dark:text-white"
                       : "text-gray-500 dark:text-gray-300",
                   ]}

--- a/packages/app/components/creator-channels/types.ts
+++ b/packages/app/components/creator-channels/types.ts
@@ -62,7 +62,7 @@ export type CreatorChannelsListItemProps = {
   created_at: string;
   updated_at: string;
   latest_message: ChannelLatestMessage;
-  unread: boolean;
+  read: boolean;
   owner: ChannelProfile;
   member_count: number;
   itemType?: "creator" | "owned";


### PR DESCRIPTION
# Why
Currently, we had no way to distinguish between read and unread inside our channel messages.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Adds a bold text status for unread messages (API value).

Nice to have: A useful feature could be scrolling to the latest unread message, as the messages endpoint provides a return a boolean for each individual message. However, since the data is paginated, it can be challenging to locate unread messages in older list entries.

FYI: this PR don't add any orange bubble to the menu, as the endpoint for this is not ready yet. We'll have to address this later.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
