### PR TITLE
feat: implement Shift-Enter / Enter Submit support by default for Message-Box

### DIFF
--- a/packages/app/components/creator-channels/messages.tsx
+++ b/packages/app/components/creator-channels/messages.tsx
@@ -793,7 +793,8 @@ const MessageInput = ({
 
       return Promise.resolve();
     },
-    [channelId, listRef, sendMessage, sendMessageCallback]
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [channelId, sendMessage, sendMessageCallback]
   );
 
   return (

--- a/packages/design-system/text-input/index.tsx
+++ b/packages/design-system/text-input/index.tsx
@@ -1,5 +1,9 @@
 import { ComponentProps, forwardRef } from "react";
-import { TextInput as ReactNativeTextInput } from "react-native";
+import {
+  TextInput as ReactNativeTextInput,
+  NativeSyntheticEvent,
+  TextInputKeyPressEventData,
+} from "react-native";
 
 import { styled } from "@showtime-xyz/universal.tailwind";
 import type { TW } from "@showtime-xyz/universal.tailwind";
@@ -22,4 +26,4 @@ const TextInput = forwardRef<typeof ReactNativeTextInput, TextInputProps>(
 
 TextInput.displayName = "TextInput";
 
-export { TextInput };
+export { TextInput, NativeSyntheticEvent, TextInputKeyPressEventData };


### PR DESCRIPTION
# Why
Now, pressing the 'Enter' key will submit our creator channels and comment box forms on the web. However, pressing 'Shift + Enter' will create a new line.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
Added a prop and a listener. Defaults to true.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
