### PR TITLE
fix: exclude unread check from owned channels

### DIFF
--- a/packages/app/components/creator-channels/channels.web.tsx
+++ b/packages/app/components/creator-channels/channels.web.tsx
@@ -137,7 +137,7 @@ const CreatorChannelsListItem = memo(
                 <Text
                   tw={[
                     "text-[13px] ",
-                    !item?.read
+                    !item?.read && item.itemType !== "owned"
                       ? "font-semibold text-black dark:text-white"
                       : "text-gray-500 dark:text-gray-300",
                   ]}


### PR DESCRIPTION
# Why

Backend doesn't return unread for owned channels, so we add the check only for joined channels, not owned ones.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
