### PR TITLE
Claim status sold out if claim count is greater than edition size

### DIFF
--- a/packages/app/components/claim/claim-button.tsx
+++ b/packages/app/components/claim/claim-button.tsx
@@ -43,8 +43,7 @@ export enum ClaimStatus {
 export const getClaimStatus = (edition?: CreatorEditionResponse) => {
   if (!edition) return undefined;
   if (
-    edition.total_claimed_count ===
-    edition.creator_airdrop_edition?.edition_size
+    edition.total_claimed_count >= edition.creator_airdrop_edition?.edition_size
   )
     return ClaimStatus.Soldout;
 


### PR DESCRIPTION
# Why

Looks like there was a race condition and we ended up getting more claimers than the edition size. We weren't checking the edition size on the backend (lmao i goofed) so the sold out message on the button allowed claiming because we were checking equality. This should catch that case now.

# How

Change `===` to `>=`

# Test Plan

Yes
