### PR TITLE
fix: profile on web is fully freezing with 12 elements

### DIFF
--- a/packages/app/components/card/card.tsx
+++ b/packages/app/components/card/card.tsx
@@ -14,10 +14,10 @@ import { useIsDarkMode } from "@showtime-xyz/universal.hooks";
 import { Pressable, PressableProps } from "@showtime-xyz/universal.pressable";
 import { Skeleton } from "@showtime-xyz/universal.skeleton";
 import { colors } from "@showtime-xyz/universal.tailwind";
+import { Text } from "@showtime-xyz/universal.text";
 import { View } from "@showtime-xyz/universal.view";
 
 import { Creator } from "app/components/card/rows/elements/creator";
-import { Title } from "app/components/card/rows/title";
 import { Social } from "app/components/card/social";
 import { ErrorBoundary } from "app/components/error-boundary";
 import { ClaimedBy } from "app/components/feed-item/claimed-by";
@@ -230,7 +230,14 @@ const CardLargeScreen = ({
           // @ts-ignore
           dataset={{ testId: "nft-card-title-link" }}
         >
-          <Title title={nft.token_name} cardMaxWidth={cardMaxWidth} />
+          <View tw={"px-4 pb-1 pt-4"}>
+            <Text
+              tw="inline-block overflow-ellipsis whitespace-nowrap text-lg font-bold !leading-8 text-black dark:text-white"
+              numberOfLines={1}
+            >
+              {nft.token_name}
+            </Text>
+          </View>
         </RouteComponent>
         <View tw="flex-row justify-between px-4 py-2">
           <Social nft={nft} />

--- a/packages/app/components/profile/profile.web.tsx
+++ b/packages/app/components/profile/profile.web.tsx
@@ -337,6 +337,7 @@ const Profile = ({ username }: ProfileScreenProps) => {
                 style={{
                   height: screenHeight - bottomBarHeight,
                 }}
+                overscan={9}
                 ListEmptyComponent={ListEmptyComponent}
                 ListFooterComponent={ListFooterComponent}
                 onEndReached={fetchMore}


### PR DESCRIPTION
# Why

Seems like our Tooltip title is causing some serious slowdowns in our web profiles.
This removes the tooltip for now.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
