### PR TITLE
feat: redirect notification taps to notifcation tab

### DIFF
--- a/apps/expo/App.tsx
+++ b/apps/expo/App.tsx
@@ -1,10 +1,9 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { AppState, LogBox } from "react-native";
 
 import { configure as configureWalletMobileSDK } from "@coinbase/wallet-mobile-sdk";
 import { Audio, InterruptionModeIOS, InterruptionModeAndroid } from "expo-av";
 import { Image } from "expo-image";
-import * as Notifications from "expo-notifications";
 import { AvoidSoftInput } from "react-native-avoid-softinput";
 import { enableFreeze, enableScreens } from "react-native-screens";
 
@@ -55,55 +54,8 @@ function App() {
   // check for updates as early as possible
   useExpoUpdate();
 
-  const [notification, setNotification] =
-    useState<Notifications.Notification | null>(null);
-
-  useEffect(() => {
-    AvoidSoftInput.setEnabled(true);
-
-    return () => {
-      AvoidSoftInput.setEnabled(false);
-    };
-  }, []);
-
-  useEffect(() => {
-    // Load feature definitions from API
-    fetch(process.env.GROWTHBOOK_FEATURES_ENDPOINT)
-      .then((res) => res.json())
-      .then((json) => {
-        growthbook.setFeatures(json.features);
-      });
-  }, []);
-
-  useEffect(() => {
-    let shouldShowNotification = true;
-    if (notification) {
-      // TODO:
-      // const content = notification?.request?.content?.data?.body?.path;
-      // const currentScreen = '';
-      // const destinationScreen = '';
-      // Don't show if already on the same screen as the destination screen
-      // shouldShowNotification = currentScreen !== destinationScreen;
-    }
-
-    // priority: AndroidNotificationPriority.HIGH,
-    Notifications.setNotificationHandler({
-      handleNotification: async () => ({
-        shouldShowAlert: shouldShowNotification,
-        shouldPlaySound: shouldShowNotification,
-        shouldSetBadge: false, // shouldShowNotification
-      }),
-    });
-  }, [notification]);
-
   // Handle push notifications
   useEffect(() => {
-    // Handle notifications that are received while the app is open.
-    const notificationListener = Notifications.addNotificationReceivedListener(
-      (notification) => {
-        setNotification(notification);
-      }
-    );
     // a memory warning listener for free up FastImage Cache
     const memoryWarningSubscription = AppState.addEventListener(
       "memoryWarning",
@@ -120,26 +72,25 @@ function App() {
       }
     );
     return () => {
-      Notifications.removeNotificationSubscription(notificationListener);
       memoryWarningSubscription.remove();
     };
   }, []);
 
-  // Listeners registered by this method will be called whenever a user interacts with a notification (eg. taps on it).
   useEffect(() => {
-    const responseListener =
-      Notifications.addNotificationResponseReceivedListener((response) => {
-        // const content =
-        //   Platform.OS === "ios"
-        //     ? response?.notification?.request?.content?.data?.body?.path
-        //     : response?.notification?.request?.content?.data?.path;
-        // Notifications.dismissNotificationAsync(
-        //   response?.notification?.request?.identifier
-        // );
-        // Notifications.setBadgeCountAsync(0);
-      });
+    AvoidSoftInput.setEnabled(true);
 
-    return () => Notifications.removeNotificationSubscription(responseListener);
+    return () => {
+      AvoidSoftInput.setEnabled(false);
+    };
+  }, []);
+
+  useEffect(() => {
+    // Load feature definitions from API
+    fetch(process.env.GROWTHBOOK_FEATURES_ENDPOINT)
+      .then((res) => res.json())
+      .then((json) => {
+        growthbook.setFeatures(json.features);
+      });
   }, []);
 
   return (

--- a/packages/app/hooks/use-handle-notification.tsx
+++ b/packages/app/hooks/use-handle-notification.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from "react";
+
+import * as Notifications from "expo-notifications";
+
+import { useRouter } from "@showtime-xyz/universal.router";
+
+export function useHandleNotification() {
+  const router = useRouter();
+  const [notification, setNotification] =
+    useState<Notifications.Notification | null>(null);
+
+  useEffect(() => {
+    let shouldShowNotification = true;
+    if (notification) {
+      // TODO:
+      // const content = notification?.request?.content?.data?.body?.path;
+      // const currentScreen = '';
+      // const destinationScreen = '';
+      // Don't show if already on the same screen as the destination screen
+      // shouldShowNotification = currentScreen !== destinationScreen;
+    }
+
+    // priority: AndroidNotificationPriority.HIGH,
+    Notifications.setNotificationHandler({
+      handleNotification: async () => ({
+        shouldShowAlert: shouldShowNotification,
+        shouldPlaySound: shouldShowNotification,
+        shouldSetBadge: false, // shouldShowNotification
+      }),
+    });
+  }, [notification]);
+
+  // Handle push notifications
+  useEffect(() => {
+    // Handle notifications that are received while the app is open.
+    const notificationListener = Notifications.addNotificationReceivedListener(
+      (notification) => {
+        setNotification(notification);
+      }
+    );
+
+    return () => {
+      Notifications.removeNotificationSubscription(notificationListener);
+    };
+  }, []);
+
+  // Listeners registered by this method will be called whenever a user interacts with a notification (eg. taps on it).
+  useEffect(() => {
+    const responseListener =
+      Notifications.addNotificationResponseReceivedListener((response) => {
+        router.push("/notifications");
+        // const content =
+        //   Platform.OS === "ios"
+        //     ? response?.notification?.request?.content?.data?.body?.path
+        //     : response?.notification?.request?.content?.data?.path;
+        // Notifications.dismissNotificationAsync(
+        //   response?.notification?.request?.identifier
+        // );
+        // Notifications.setBadgeCountAsync(0);
+      });
+
+    return () => Notifications.removeNotificationSubscription(responseListener);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}

--- a/packages/app/navigation/root-stack-navigator.tsx
+++ b/packages/app/navigation/root-stack-navigator.tsx
@@ -7,6 +7,7 @@ import { useSafeAreaInsets } from "@showtime-xyz/universal.safe-area";
 import { Text } from "@showtime-xyz/universal.text";
 
 import { Messages } from "app/components/creator-channels/messages";
+import { useHandleNotification } from "app/hooks/use-handle-notification";
 import { useNetWorkConnection } from "app/hooks/use-network-connection";
 import { screenOptions } from "app/navigation/navigator-screen-options";
 import { AppleMusicAuthNativeWebViewScreen } from "app/screens/apple-music-auth-native-webview";
@@ -57,7 +58,7 @@ const Stack = createStackNavigator<RootStackNavigatorParams>();
 export function RootStackNavigator() {
   const { top: safeAreaTop } = useSafeAreaInsets();
   useNetWorkConnection();
-
+  useHandleNotification();
   const isDark = useIsDarkMode();
 
   return (


### PR DESCRIPTION
# Why

Right now, taps on notifications do not react. This simple fix redirects to the notifications tab for now until we have actionable metadata.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Created a custom hook and moved logic from App.tsx to RootNavigator, because `useRouter` needs to be available.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
