### PR TITLE
Fix/lock html scroll

### DIFF
--- a/apps/next/src/pages/_document.tsx
+++ b/apps/next/src/pages/_document.tsx
@@ -22,7 +22,7 @@ class Document extends NextDocument {
           <meta charSet="UTF-8" />
           <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
         </Head>
-        <body className="!max-w-screen !mr-0">
+        <body>
           <Main />
           <NextScript />
         </body>

--- a/apps/next/src/styles/styles.css
+++ b/apps/next/src/styles/styles.css
@@ -108,21 +108,17 @@ html {
   /* Prevent text size change on orientation change https://gist.github.com/tfausak/2222823#file-ios-8-web-app-html-L138 */
   -webkit-text-size-adjust: 100%;
   height: 100%;
-  overflow-y: scroll !important;
-  overscroll-behavior-y: none;
-}
-
-body {
-  display: flex;
-  overflow-y: visible;
+  overflow-y: scroll;
   overscroll-behavior-y: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   -ms-overflow-style: scrollbar;
-  width: unset !important;
-  height: 100%;
-  padding-right: 0 !important;
+}
+
+body {
+  display: flex;
+  overflow-y: visible;
 }
 
 /* Hide scrollbar for Chrome, Safari and Opera */

--- a/packages/design-system/alert/alert-container.web.tsx
+++ b/packages/design-system/alert/alert-container.web.tsx
@@ -4,12 +4,14 @@ import { Platform, Modal } from "react-native";
 import * as Portal from "@radix-ui/react-portal";
 import { RemoveScrollBar } from "react-remove-scroll-bar";
 
+import { useLockHtmlScroll } from "@showtime-xyz/universal.hooks";
 import { View } from "@showtime-xyz/universal.view";
 
 import { Alert } from "./alert";
 import { AlertContainerProps } from "./alert-container";
 
 export const AlertContainer = ({ show, ...rest }: AlertContainerProps) => {
+  useLockHtmlScroll(show);
   return (
     <Portal.Root>
       <Modal
@@ -18,7 +20,6 @@ export const AlertContainer = ({ show, ...rest }: AlertContainerProps) => {
         visible={show}
         statusBarTranslucent
       >
-        {Platform.OS === "web" && <RemoveScrollBar />}
         <View tw="animate-fade-in absolute inset-0 bg-black bg-opacity-60" />
         <View tw="h-full w-full items-center justify-center">
           <View tw="animate-bounce-in w-4/5 max-w-xs rounded-2xl bg-white p-4 dark:bg-gray-900">

--- a/packages/design-system/bottom-sheet/bottom-sheet.tsx
+++ b/packages/design-system/bottom-sheet/bottom-sheet.tsx
@@ -19,7 +19,7 @@ import {
 } from "@gorhom/bottom-sheet";
 
 import { useIsDarkMode } from "@showtime-xyz/universal.hooks";
-import { useLockBodyScroll } from "@showtime-xyz/universal.hooks";
+import { useLockHtmlScroll } from "@showtime-xyz/universal.hooks";
 import { useSafeAreaInsets } from "@showtime-xyz/universal.safe-area";
 import { styled, colors } from "@showtime-xyz/universal.tailwind";
 import type { TW } from "@showtime-xyz/universal.tailwind";
@@ -45,7 +45,7 @@ export const BottomSheet = (props: BottomSheetProps) => {
     bodyStyle,
   } = props;
 
-  useLockBodyScroll(visible);
+  useLockHtmlScroll(visible);
   const bottomSheetModalRef = useRef<BottomSheetModal>(null);
   const { bottom: safeAreaBottom } = useSafeAreaInsets();
   const isDark = useIsDarkMode();

--- a/packages/design-system/hooks/index.ts
+++ b/packages/design-system/hooks/index.ts
@@ -243,38 +243,6 @@ export function useWebClientRect<T>(ele: React.RefObject<T>) {
   ];
 }
 
-export function useLockBodyScroll(isLocked = true) {
-  const [isMounted, setIsMounted] = useState(false);
-
-  useIsomorphicLayoutEffect(() => {
-    if (typeof window !== "undefined" && window.document) {
-      setIsMounted(true);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (
-      typeof window !== "undefined" &&
-      window.document &&
-      isMounted &&
-      isLocked
-    ) {
-      document.body.classList.add("no-scroll");
-    }
-
-    return () => {
-      if (
-        typeof window !== "undefined" &&
-        window.document &&
-        isMounted &&
-        isLocked
-      ) {
-        document.body.classList.remove("no-scroll");
-      }
-    };
-  }, [isMounted, isLocked]);
-}
-
 export function useEffectOnce(effect: EffectCallback) {
   useEffect(effect, []);
 }

--- a/packages/design-system/hooks/index.ts
+++ b/packages/design-system/hooks/index.ts
@@ -14,6 +14,8 @@ import { useSharedValue } from "react-native-reanimated";
 import { useColorScheme } from "@showtime-xyz/universal.color-scheme";
 import { getScrollParent } from "@showtime-xyz/universal.utils";
 
+export { useLockHtmlScroll } from "./use-lock-html-scroll";
+
 export const useIsomorphicLayoutEffect =
   typeof window !== "undefined" ? useLayoutEffect : useEffect;
 

--- a/packages/design-system/hooks/use-lock-html-scroll.tsx
+++ b/packages/design-system/hooks/use-lock-html-scroll.tsx
@@ -1,0 +1,1 @@
+export function useLockHtmlScroll(isLocked = true) {}

--- a/packages/design-system/hooks/use-lock-html-scroll.web.tsx
+++ b/packages/design-system/hooks/use-lock-html-scroll.web.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState, useMemo } from "react";
+
+import { getGapWidth } from "react-remove-scroll-bar";
+
+import { useIsomorphicLayoutEffect } from "./index";
+
+export function useLockHtmlScroll(isLocked = true) {
+  const [isMounted, setIsMounted] = useState(false);
+  const gap = useMemo(() => getGapWidth("padding"), []);
+
+  useIsomorphicLayoutEffect(() => {
+    if (typeof window !== "undefined" && window.document) {
+      setIsMounted(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (
+      typeof window !== "undefined" &&
+      window.document &&
+      isMounted &&
+      isLocked
+    ) {
+      document.documentElement.classList.add("no-scroll");
+      document.documentElement.style.paddingRight = `${gap.gap}px`;
+    }
+
+    return () => {
+      if (
+        typeof window !== "undefined" &&
+        window.document &&
+        isMounted &&
+        isLocked
+      ) {
+        document.documentElement.classList.remove("no-scroll");
+        document.documentElement.style.paddingRight = `0px`;
+      }
+    };
+  }, [isMounted, isLocked, gap.gap]);
+}

--- a/packages/design-system/light-box/provider.web.tsx
+++ b/packages/design-system/light-box/provider.web.tsx
@@ -2,8 +2,8 @@ import React, { createContext, useContext, useMemo, useState } from "react";
 import { Modal } from "react-native";
 
 import { useEscapeKeydown } from "@radix-ui/react-use-escape-keydown";
-import { RemoveScrollBar } from "react-remove-scroll-bar";
 
+import { useLockHtmlScroll } from "@showtime-xyz/universal.hooks";
 import { Close } from "@showtime-xyz/universal.icon";
 import { Pressable } from "@showtime-xyz/universal.pressable";
 import { colors } from "@showtime-xyz/universal.tailwind";
@@ -49,7 +49,7 @@ export const LightBoxProvider: React.FC<{ children: JSX.Element }> = ({
     setVisible(false);
     setImageElement(null);
   };
-
+  useLockHtmlScroll(visible);
   return (
     <LightBoxContext.Provider value={value}>
       {children}
@@ -59,7 +59,6 @@ export const LightBoxProvider: React.FC<{ children: JSX.Element }> = ({
         statusBarTranslucent
         animationType="fade"
       >
-        <RemoveScrollBar />
         <View tw="flex-1 items-center justify-center">
           <div
             onClick={onClose}

--- a/packages/design-system/modal/modal.backdrop.web.tsx
+++ b/packages/design-system/modal/modal.backdrop.web.tsx
@@ -1,7 +1,8 @@
 import { memo, forwardRef, useCallback } from "react";
 
 import { useEscapeKeydown } from "@radix-ui/react-use-escape-keydown";
-import { RemoveScrollBar } from "react-remove-scroll-bar";
+
+import { useLockHtmlScroll } from "@showtime-xyz/universal.hooks";
 
 import type { ModalBackdropProps } from "./types";
 
@@ -23,16 +24,14 @@ const ModalBackdropComponent = forwardRef<any, ModalBackdropProps>(
       event.preventDefault();
       return onCloseMethod();
     });
+    useLockHtmlScroll();
     return (
-      <>
-        <RemoveScrollBar />
-        <div
-          ref={ref}
-          className={BACKDROP_TW.join(" ")}
-          onClick={onCloseMethod}
-          onTouchEnd={onClose}
-        />
-      </>
+      <div
+        ref={ref}
+        className={BACKDROP_TW.join(" ")}
+        onClick={onCloseMethod}
+        onTouchEnd={onClose}
+      />
     );
   }
 );


### PR DESCRIPTION
# Why

Due to enabling windowScroll, which by default uses HTML as the scrolling container, we encountered some issues with locked scrolling. This PR is meant to fix it. 

https://github.com/showtime-xyz/showtime-frontend/assets/37520667/8ad7ebdd-664b-4e83-8a88-5fb2dac5a794


# How

Add a `useLockHtmlScroll` hook and use it instead of `<RemoveScrollBar/>` and `useLockHtmlScroll`. 

# Test Plan

https://github.com/showtime-xyz/showtime-frontend/assets/37520667/7f3e4fb3-c6e0-4a71-99ad-1c553baa1b1c


