### PR TITLE
fix: do not show switch network popup

### DIFF
--- a/packages/app/providers/wallet-provider.web.tsx
+++ b/packages/app/providers/wallet-provider.web.tsx
@@ -4,12 +4,15 @@ import {
   connectorsForWallets,
 } from "@rainbow-me/rainbowkit";
 import { configureChains, WagmiConfig, createConfig } from "wagmi";
-import { polygon, polygonMumbai, mainnet } from "wagmi/chains";
+import * as allChains from "wagmi/chains";
 import { alchemyProvider } from "wagmi/providers/alchemy";
 import { publicProvider } from "wagmi/providers/public";
 
+// @ts-ignore
+const allChainsArray = Object.keys(allChains).map((key) => allChains[key]);
+
 const { chains, publicClient, webSocketPublicClient } = configureChains(
-  [mainnet, polygon, polygonMumbai],
+  allChainsArray,
   [
     publicProvider(),
     alchemyProvider({ apiKey: process.env.NEXT_PUBLIC_ALCHEMY_API_KEY }),


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Resolves - https://showtime-rq88331.slack.com/archives/C02PXGK3V8D/p1689876398632069

Connecting a wallet shows switch network option in wallet. We can prevent it by supporting all chains. We only care about the user wallet and signature, not about the chain since we don't do direct smart contract transactions. 

<!--
How did you build this feature or fix this bug and why?
-->
