### PR TITLE
fix: submit on edit would create new message

### DIFF
--- a/packages/app/components/creator-channels/messages.tsx
+++ b/packages/app/components/creator-channels/messages.tsx
@@ -805,6 +805,23 @@ const MessageInput = ({
     [channelId, sendMessage, sendMessageCallback]
   );
 
+  const handleEditMessage = useCallback(async () => {
+    if (!editMessage) return;
+
+    const newMessage = inputRef.current?.value;
+    if (newMessage.trim().length === 0) return;
+    inputRef.current?.reset();
+    enableLayoutAnimations(true);
+    requestAnimationFrame(() => {
+      editMessages.trigger({
+        messageId: editMessage.id,
+        message: newMessage,
+        channelId,
+      });
+      setEditMessage(undefined);
+    });
+  }, [channelId, editMessage, editMessages, setEditMessage]);
+
   return (
     <Animated.View style={[{ position: "absolute", width: "100%" }, style]}>
       {isUserAdmin ? (
@@ -814,7 +831,7 @@ const MessageInput = ({
           textInputProps={{
             maxLength: 2000,
           }}
-          onSubmit={handleSubmit}
+          onSubmit={editMessage ? handleEditMessage : handleSubmit}
           submitting={editMessages.isMutating || sendMessage.isMutating}
           tw="bg-white dark:bg-black"
           submitButton={
@@ -835,20 +852,7 @@ const MessageInput = ({
                   <Button
                     disabled={editMessages.isMutating || !editMessage}
                     iconOnly
-                    onPress={() => {
-                      const newMessage = inputRef.current?.value;
-                      if (newMessage.trim().length === 0) return;
-                      inputRef.current?.reset();
-                      enableLayoutAnimations(true);
-                      requestAnimationFrame(() => {
-                        editMessages.trigger({
-                          messageId: editMessage.id,
-                          message: newMessage,
-                          channelId,
-                        });
-                        setEditMessage(undefined);
-                      });
-                    }}
+                    onPress={handleEditMessage}
                   >
                     <Check width={20} height={20} />
                   </Button>


### PR DESCRIPTION
# Why

Editing a message on Desktop and submitting via ENTER would send a new message instead of editing.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Fixed by swapping the handleSubmit functions

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
