### PR TITLE
Fix/dedupe requests and refetches

### DIFF
--- a/packages/app/hooks/api-hooks.ts
+++ b/packages/app/hooks/api-hooks.ts
@@ -115,7 +115,8 @@ export const useTrendingNFTS = ({
     fetcher,
     {
       revalidateIfStale: false,
-      focusThrottleInterval: 200000,
+      focusThrottleInterval: 20000,
+      dedupingInterval: 20000,
     }
   );
   const newData = useMemo(() => {
@@ -140,7 +141,7 @@ export const useUserProfile = ({ address }: { address?: string | null }) => {
     data?: UserProfile;
   }>(queryKey, fetcher, {
     revalidateIfStale: false,
-    focusThrottleInterval: 200000,
+    focusThrottleInterval: 20000,
   });
 
   const { data: myInfoData } = useMyInfo();
@@ -307,6 +308,8 @@ export const useMyInfo = () => {
     {
       revalidateOnMount: false,
       revalidateIfStale: false,
+      dedupingInterval: 30000,
+      focusThrottleInterval: 30000,
     }
   );
 

--- a/packages/app/hooks/api/use-search.ts
+++ b/packages/app/hooks/api/use-search.ts
@@ -20,7 +20,7 @@ export const useSearch = (term: string) => {
   const debouncedSearch = useDebounce(term, 200);
   const { data, error } = useSWR<SearchResponse>(
     term.length >= 2 && debouncedSearch
-      ? "/v2/search?q=" + debouncedSearch
+      ? "/v2/search/?q=" + debouncedSearch
       : null,
     fetcher
   );

--- a/packages/app/hooks/use-creator-collection-detail.ts
+++ b/packages/app/hooks/use-creator-collection-detail.ts
@@ -46,7 +46,11 @@ export function useCreatorCollectionDetail(editionAddress?: string) {
       ? "/v1/creator-airdrops/edition?edition_address=" + editionAddress
       : null,
     fetcher,
-    { focusThrottleInterval: 300000, revalidateIfStale: false }
+    {
+      focusThrottleInterval: 30000,
+      revalidateIfStale: false,
+      dedupingInterval: 30000,
+    }
   );
 
   return {

--- a/packages/app/hooks/use-infinite-list-query.ts
+++ b/packages/app/hooks/use-infinite-list-query.ts
@@ -42,6 +42,8 @@ export const useInfiniteListQuerySWR = <T>(
       // suspense: true,
       refreshInterval,
       revalidateOnMount: true,
+      dedupingInterval: 30000,
+      focusThrottleInterval: 30000,
     });
 
   const isRefreshingSWR = isValidating && data && data.length === size;

--- a/packages/app/hooks/use-nft-detail-by-token-id.ts
+++ b/packages/app/hooks/use-nft-detail-by-token-id.ts
@@ -42,7 +42,8 @@ export const useNFTDetailByTokenId = (params: UseNFTDetailByTokenIdParams) => {
     (url) => axios({ url, method: "GET" }),
     {
       revalidateIfStale: false,
-      focusThrottleInterval: 300000,
+      focusThrottleInterval: 30000,
+      dedupingInterval: 30000,
     }
     // { suspense: true }
   );

--- a/packages/app/hooks/use-nft-details.ts
+++ b/packages/app/hooks/use-nft-details.ts
@@ -12,7 +12,11 @@ export function useNFTDetails(nftId?: number) {
   const { data, error, mutate } = useSWR<NFTDetailsPayload>(
     nftId ? "/v2/nft_detail/" + nftId : null,
     fetcher,
-    { focusThrottleInterval: 300000, revalidateIfStale: false }
+    {
+      focusThrottleInterval: 30000,
+      revalidateIfStale: false,
+      dedupingInterval: 30000,
+    }
   );
 
   return {


### PR DESCRIPTION
# Why

Most of our SWR hooks are over-reactive and refetch way too often. I increased the delays and deduping intervals to reduce the big amount of refetching

Furthermore, I fixed an issue with search, where 1 search input would create 4 requests due to an redirecting issue

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
