### PR TITLE
Add chain id's for base!

### DIFF
--- a/packages/app/lib/constants.ts
+++ b/packages/app/lib/constants.ts
@@ -136,6 +136,8 @@ export const CHAIN_IDENTIFIERS = {
   tezos: "NetXdQprcVkpaWU",
   polygon: 137,
   mumbai: 80001,
+  base: 8453,
+  base_goerli: 84531,
 };
 
 // static height can improve tabs list initial rendering


### PR DESCRIPTION
# Why

In order to support nfts created on Base, we need to pass the appropriate chain id's along with the nft details api calls. When testing against the backend locally, it appears that the base_goerli chain name was setting undefined as the chain id, which resulted in a 404.

# How

Set the appropriate chain ids for base mainnet and goerli testnet

NOTE: We will need to update the chain explorer url builders to also support base!

# Test Plan

Tested locally and will test in staging once backend is deployed