### PR TITLE
fix: native redirection on star drops

### DIFF
--- a/packages/app/components/drop/common/select-drop-type.tsx
+++ b/packages/app/components/drop/common/select-drop-type.tsx
@@ -49,10 +49,14 @@ export const SelectDropType = (props: { handleNextStep: any }) => {
         <View tw="rounded-3xl border-[1px] border-yellow-300 p-4">
           <Pressable
             onPress={() => {
+              const as = `/payouts/setup`;
+              if (Platform.OS !== "web") {
+                router.pop();
+              }
               if (onboardingStatus.status === "not_onboarded") {
                 router.push(
                   Platform.select({
-                    native: `/payouts/setup`,
+                    native: as,
                     web: {
                       pathname: router.pathname,
                       query: {
@@ -61,7 +65,10 @@ export const SelectDropType = (props: { handleNextStep: any }) => {
                       },
                     } as any,
                   }),
-                  router.asPath,
+                  Platform.select({
+                    native: as,
+                    web: router.asPath,
+                  }),
                   { shallow: true }
                 );
               } else if (Platform.OS !== "web") {

--- a/packages/app/components/drop/drop-star/drop-star.tsx
+++ b/packages/app/components/drop/drop-star/drop-star.tsx
@@ -41,9 +41,9 @@ import { View } from "@showtime-xyz/universal.view";
 
 import { BottomSheetScrollView } from "app/components/bottom-sheet-scroll-view";
 import { useOnboardingStatus } from "app/components/payouts/hooks/use-onboarding-status";
+import { PayoutSettings } from "app/components/payouts/payout-settings";
 import { payoutsRedirectOrigin } from "app/components/payouts/payouts-setup";
 import { Preview } from "app/components/preview";
-import { PayoutSettings } from "app/components/settings/tabs/payouts";
 import { MAX_FILE_SIZE, UseDropNFT, useDropNFT } from "app/hooks/use-drop-nft";
 import { usePersistForm } from "app/hooks/use-persist-form";
 import { useWallet } from "app/hooks/use-wallet";

--- a/packages/app/components/payouts/payouts-setup.tsx
+++ b/packages/app/components/payouts/payouts-setup.tsx
@@ -191,6 +191,7 @@ const CompleteStripeFlow = () => {
 
   const selectedCountryCode = watch("countryCode");
   const onboardingCreator = useOnBoardCreator();
+  const router = useRouter();
 
   const onSubmit = async (data: any) => {
     const res = await onboardingCreator.trigger({
@@ -203,6 +204,7 @@ const CompleteStripeFlow = () => {
     if (Platform.OS === "web") {
       window.location.href = res.url;
     } else {
+      router.pop();
       Linking.openURL(res.url);
     }
   };


### PR DESCRIPTION
# Why
- Tapping star drop does nothing on native.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- router `as` prop was broken. 
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
Tapping star drop should show payout setup or create star drop form on native
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
