### PR TITLE
Fix/usd price conversion drops

### DIFF
--- a/packages/app/components/checkout/checkout-claim-form.tsx
+++ b/packages/app/components/checkout/checkout-claim-form.tsx
@@ -362,7 +362,8 @@ const CheckoutFormLayout = ({
               Terms & Conditions
             </TextLink>{" "}
             and understand that you are purchasing a non-refundable digital
-            item.
+            item. Final currency depends on creator bank. USD price may be
+            estimated with latest rates. Currency fees may apply.
           </Text>
         </View>
 
@@ -388,8 +389,8 @@ const CheckoutFormLayout = ({
             </Text>
           ) : (
             `Collect to unlock - ${getCurrencyPrice(
-              edition.currency,
-              edition.price
+              edition.usd_price ? "USD" : edition.currency,
+              edition.usd_price ?? edition.price
             )}`
           )}
         </Button>

--- a/packages/app/components/claim/claim-paid-nft-button.tsx
+++ b/packages/app/components/claim/claim-paid-nft-button.tsx
@@ -54,7 +54,10 @@ const GoldButton = memo(function GoldButton({
   ...rest
 }: GoldButtonProps) {
   const router = useRouter();
-  const price = getCurrencyPrice(edition?.currency, edition?.price);
+  const price = getCurrencyPrice(
+    edition?.usd_price ? "USD" : edition?.currency,
+    edition?.usd_price ?? edition?.price
+  );
   const editionId = edition?.creator_airdrop_edition.id;
   const contractAddress = edition?.creator_airdrop_edition.contract_address;
   const iconSize = size === "small" ? 20 : 24;

--- a/packages/app/components/feed-item/details.tsx
+++ b/packages/app/components/feed-item/details.tsx
@@ -114,6 +114,7 @@ export const NFTDetails = ({
                 <CollectToUnlockContentTooltip
                   creatorUsername={nft?.creator_username}
                   price={edition?.price}
+                  usd_price={edition?.usd_price}
                   currency={edition?.currency}
                   theme="dark"
                 />

--- a/packages/app/components/feed-item/feed-item.md.tsx
+++ b/packages/app/components/feed-item/feed-item.md.tsx
@@ -215,6 +215,7 @@ export const FeedItemMD = memo<FeedItemProps>(function FeedItemMD({
                 <CollectToUnlockContentTooltip
                   creatorUsername={nft?.creator_username}
                   price={edition?.price}
+                  usd_price={edition?.usd_price}
                   currency={edition?.currency}
                 />
               </View>

--- a/packages/app/components/tooltips/collect-to-unlock-content-tooltip.tsx
+++ b/packages/app/components/tooltips/collect-to-unlock-content-tooltip.tsx
@@ -5,7 +5,7 @@ import { Image } from "@showtime-xyz/universal.image";
 import { Text } from "@showtime-xyz/universal.text";
 import { View } from "@showtime-xyz/universal.view";
 
-import { getCurrencyPrice, getCreatorEarnedMoney } from "app/utilities";
+import { getCreatorEarnedMoney } from "app/utilities";
 
 import { ButtonGoldLinearGradient } from "../gold-gradient";
 import { ContentTooltip } from "./content-tooltip";
@@ -13,6 +13,7 @@ import { ContentTooltip } from "./content-tooltip";
 type ContentTypeTooltipProps = {
   creatorUsername?: string;
   price?: number;
+  usd_price?: number;
   theme?: "dark" | "light";
   currency?: string;
 };
@@ -20,6 +21,7 @@ type ContentTypeTooltipProps = {
 export const CollectToUnlockContentTooltip = ({
   creatorUsername,
   price,
+  usd_price,
   currency,
 }: ContentTypeTooltipProps) => {
   return (
@@ -68,7 +70,12 @@ export const CollectToUnlockContentTooltip = ({
                 {creatorUsername ? `@${creatorUsername}` : "Creator"}
               </Text>
               {` will make about ${
-                price ? `${getCreatorEarnedMoney(currency, price)}` : "money"
+                price
+                  ? `${getCreatorEarnedMoney(
+                      usd_price ? "USD" : currency,
+                      usd_price ?? price
+                    )}`
+                  : "money"
               }`}
             </Text>
           </View>

--- a/packages/app/hooks/use-creator-collection-detail.ts
+++ b/packages/app/hooks/use-creator-collection-detail.ts
@@ -41,6 +41,7 @@ export type CreatorEditionResponse = {
   is_editable?: boolean;
   is_onchain?: boolean;
   price?: number;
+  usd_price?: number;
   currency?: string;
 };
 


### PR DESCRIPTION
# Why

This PR adds the output of USD if `usd_price` is available and fallback to the provided one if `null` (rare case that should not happen)

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
