### PR TITLE
fix: add status api in star drops

### DIFF
--- a/packages/app/components/checkout/checkout-claim-form.tsx
+++ b/packages/app/components/checkout/checkout-claim-form.tsx
@@ -206,7 +206,7 @@ const CheckoutFormLayout = ({
         ?.confirmCardPayment(clientSecret, {
           payment_method: savedPaymentMethodId,
         })
-        .then(async () => {
+        .then(async (res) => {
           router.push(
             {
               pathname: router.pathname,
@@ -215,6 +215,7 @@ const CheckoutFormLayout = ({
                 contractAddress:
                   edition?.creator_airdrop_edition.contract_address,
                 checkoutReturnForPaidNFTModal: true,
+                paymentIntentId: res.paymentIntent?.id,
               },
             },
             router.asPath,

--- a/packages/app/components/checkout/checkout-paid-nft.tsx
+++ b/packages/app/components/checkout/checkout-paid-nft.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useState, useEffect } from "react";
+import { useCallback, useState, useRef } from "react";
 
 import { Alert } from "@showtime-xyz/universal.alert";
 import { Button } from "@showtime-xyz/universal.button";
+import { useEffectOnce } from "@showtime-xyz/universal.hooks";
 import { useRouter } from "@showtime-xyz/universal.router";
 import Spinner from "@showtime-xyz/universal.spinner";
 import { Text } from "@showtime-xyz/universal.text";
@@ -79,15 +80,15 @@ export const CheckoutPaidNFT = () => {
           );
           setErrorMsg(error?.response?.data?.error?.message);
         }
-        setIsLoading(false);
       })
       .finally(() => {
         setIsLoading(false);
       });
   }, [editionId, router, contractAddress]);
-  useEffect(() => {
+
+  useEffectOnce(() => {
     getClaimPaymentsIntent();
-  }, [getClaimPaymentsIntent]);
+  });
 
   if (isLoading) {
     return (


### PR DESCRIPTION
# Why
- Poll status API before claiming the drop.

### Claim can happen after below cases. Tested below cases.
- 409 in /start API - User already paid but didn't claim - **Don't Poll**
- Hard redirect/refresh by stripe - **Poll**
- By selecting default card - no hard redirects - **Poll**

Tested above flow, there is surely some opportunity to clean things up, but pushing this for now to unblock backend.

