### PR TITLE
fix: only apply EAS updates instantly on iOS and exclude android

### DIFF
--- a/packages/app/hooks/use-expo-update.tsx
+++ b/packages/app/hooks/use-expo-update.tsx
@@ -26,8 +26,11 @@ export function useExpoUpdate() {
       if (!result.isNew) {
         return;
       }
-
-      await Updates.reloadAsync();
+      // for now, we won't auto reload on android because it causes a crash due to reanimated
+      // since we've downloaded the update, it will be applied on next restart
+      if (Platform.OS === "ios") {
+        await Updates.reloadAsync();
+      }
     } catch (error) {
       captureException(error);
     }


### PR DESCRIPTION
# Why

Since Android updates crash when the runtime reloads, I've excluded it for Android. This change will still download the newest update but will only apply it after the next app reload.

While this is not the ideal solution I am looking for, our first-time app crash rate is so extremely high on Android that we need to take this path.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
