### PR TITLE
Fix/star drop close modal

### DIFF
--- a/packages/app/components/drop/drop-star/drop-star.tsx
+++ b/packages/app/components/drop/drop-star/drop-star.tsx
@@ -28,7 +28,6 @@ import {
   Clock,
   Close,
 } from "@showtime-xyz/universal.icon";
-import { useModalScreenContext } from "@showtime-xyz/universal.modal-screen";
 import { ModalSheet } from "@showtime-xyz/universal.modal-sheet";
 import { Pressable } from "@showtime-xyz/universal.pressable";
 import { useRouter } from "@showtime-xyz/universal.router";
@@ -72,7 +71,6 @@ type CreateDropStep =
 
 export const DropStar = () => {
   const [step, setStep] = useState<CreateDropStep>("media");
-  const modalContext = useModalScreenContext();
   const onboardinStatus = useOnboardingStatus();
   const {
     control,
@@ -164,7 +162,7 @@ export const DropStar = () => {
   if (onboardinStatus.status === "loading") {
     return (
       <Layout
-        onBackPress={() => modalContext?.pop()}
+        onBackPress={() => router?.pop()}
         closeIcon
         title="Complete payout info"
       >
@@ -178,7 +176,7 @@ export const DropStar = () => {
   if (onboardinStatus.status === "processing") {
     return (
       <Layout
-        onBackPress={() => modalContext?.pop()}
+        onBackPress={() => router?.pop()}
         closeIcon
         title="Come back later"
       >
@@ -200,7 +198,7 @@ export const DropStar = () => {
           <Button
             tw="w-full"
             onPress={() => {
-              modalContext?.pop();
+              router.pop();
             }}
           >
             Okay
@@ -246,7 +244,7 @@ export const DropStar = () => {
         key={step}
       >
         <Layout
-          onBackPress={() => modalContext?.pop()}
+          onBackPress={() => router?.pop()}
           closeIcon
           title="Congrats! Now share it ✦"
           headerShown={false}

--- a/packages/app/components/drop/drop-star/drop-star.tsx
+++ b/packages/app/components/drop/drop-star/drop-star.tsx
@@ -28,6 +28,7 @@ import {
   Clock,
   Close,
 } from "@showtime-xyz/universal.icon";
+import { useModalScreenContext } from "@showtime-xyz/universal.modal-screen";
 import { ModalSheet } from "@showtime-xyz/universal.modal-sheet";
 import { Pressable } from "@showtime-xyz/universal.pressable";
 import { useRouter } from "@showtime-xyz/universal.router";
@@ -93,7 +94,10 @@ export const DropStar = () => {
 
   const file = getValues("file");
   const { state, dropNFT, reset: resetDropState } = useDropNFT();
+  const bottomSheetContext = useModalScreenContext();
   const router = useRouter();
+  const closeModal =
+    Platform.OS === "android" ? bottomSheetContext?.pop : router.pop;
 
   const { clearStorage } = usePersistForm(MUSIC_DROP_FORM_DATA_KEY, {
     watch,
@@ -162,7 +166,7 @@ export const DropStar = () => {
   if (onboardinStatus.status === "loading") {
     return (
       <Layout
-        onBackPress={() => router?.pop()}
+        onBackPress={() => closeModal?.()}
         closeIcon
         title="Complete payout info"
       >
@@ -176,7 +180,7 @@ export const DropStar = () => {
   if (onboardinStatus.status === "processing") {
     return (
       <Layout
-        onBackPress={() => router?.pop()}
+        onBackPress={() => closeModal?.()}
         closeIcon
         title="Come back later"
       >
@@ -198,7 +202,7 @@ export const DropStar = () => {
           <Button
             tw="w-full"
             onPress={() => {
-              router.pop();
+              closeModal?.();
             }}
           >
             Okay
@@ -211,7 +215,7 @@ export const DropStar = () => {
   if (onboardinStatus.status === "not_onboarded") {
     return (
       <Layout
-        onBackPress={() => router.pop()}
+        onBackPress={() => closeModal?.pop()}
         closeIcon
         title="Payment processing details"
       >
@@ -244,7 +248,7 @@ export const DropStar = () => {
         key={step}
       >
         <Layout
-          onBackPress={() => router?.pop()}
+          onBackPress={() => closeModal?.pop()}
           closeIcon
           title="Congrats! Now share it ✦"
           headerShown={false}

--- a/packages/app/components/payouts/payouts-setup.tsx
+++ b/packages/app/components/payouts/payouts-setup.tsx
@@ -9,7 +9,6 @@ import { Fieldset } from "@showtime-xyz/universal.fieldset";
 import { useIsDarkMode } from "@showtime-xyz/universal.hooks";
 import { ArrowLeft, Clock, Close } from "@showtime-xyz/universal.icon";
 import { Image } from "@showtime-xyz/universal.image";
-import { useModalScreenContext } from "@showtime-xyz/universal.modal-screen";
 import { Pressable } from "@showtime-xyz/universal.pressable";
 import { useRouter } from "@showtime-xyz/universal.router";
 import { useSafeAreaInsets } from "@showtime-xyz/universal.safe-area";
@@ -30,7 +29,6 @@ export const payoutsRedirectOrigin = `${
 }`;
 
 export const PayoutsSetup = () => {
-  const modalContext = useModalScreenContext();
   const onboardinStatus = useOnboardingStatus();
 
   const router = useRouter();
@@ -39,7 +37,7 @@ export const PayoutsSetup = () => {
   if (onboardinStatus.status === "loading") {
     return (
       <Layout
-        onBackPress={() => modalContext?.pop()}
+        onBackPress={() => router?.pop()}
         closeIcon
         title="Complete payout info"
       >
@@ -53,7 +51,7 @@ export const PayoutsSetup = () => {
   if (onboardinStatus.status === "onboarded") {
     return (
       <Layout
-        onBackPress={() => modalContext?.pop()}
+        onBackPress={() => router?.pop()}
         closeIcon
         title="You're approved"
       >
@@ -78,7 +76,7 @@ export const PayoutsSetup = () => {
   if (onboardinStatus.status === "processing") {
     return (
       <Layout
-        onBackPress={() => modalContext?.pop()}
+        onBackPress={() => router?.pop()}
         closeIcon
         title="Come back later"
       >

--- a/packages/app/components/payouts/payouts-setup.tsx
+++ b/packages/app/components/payouts/payouts-setup.tsx
@@ -9,6 +9,7 @@ import { Fieldset } from "@showtime-xyz/universal.fieldset";
 import { useIsDarkMode } from "@showtime-xyz/universal.hooks";
 import { ArrowLeft, Clock, Close } from "@showtime-xyz/universal.icon";
 import { Image } from "@showtime-xyz/universal.image";
+import { useModalScreenContext } from "@showtime-xyz/universal.modal-screen";
 import { Pressable } from "@showtime-xyz/universal.pressable";
 import { useRouter } from "@showtime-xyz/universal.router";
 import { useSafeAreaInsets } from "@showtime-xyz/universal.safe-area";
@@ -31,13 +32,17 @@ export const payoutsRedirectOrigin = `${
 export const PayoutsSetup = () => {
   const onboardinStatus = useOnboardingStatus();
 
+  const bottomSheetContext = useModalScreenContext();
   const router = useRouter();
   const isDark = useIsDarkMode();
+
+  const closeModal =
+    Platform.OS === "android" ? bottomSheetContext?.pop : router.pop;
 
   if (onboardinStatus.status === "loading") {
     return (
       <Layout
-        onBackPress={() => router?.pop()}
+        onBackPress={() => closeModal?.()}
         closeIcon
         title="Complete payout info"
       >
@@ -51,7 +56,7 @@ export const PayoutsSetup = () => {
   if (onboardinStatus.status === "onboarded") {
     return (
       <Layout
-        onBackPress={() => router?.pop()}
+        onBackPress={() => closeModal?.()}
         closeIcon
         title="You're approved"
       >
@@ -76,7 +81,7 @@ export const PayoutsSetup = () => {
   if (onboardinStatus.status === "processing") {
     return (
       <Layout
-        onBackPress={() => router?.pop()}
+        onBackPress={() => closeModal?.()}
         closeIcon
         title="Come back later"
       >
@@ -98,7 +103,7 @@ export const PayoutsSetup = () => {
           <Button
             tw="w-full"
             onPress={() => {
-              modalContext?.pop();
+              closeModal?.();
             }}
           >
             Okay
@@ -111,7 +116,7 @@ export const PayoutsSetup = () => {
   if (onboardinStatus.status === "not_onboarded") {
     return (
       <Layout
-        onBackPress={() => router.pop()}
+        onBackPress={() => closeModal?.()}
         closeIcon
         title="Payment processing details"
       >

--- a/packages/app/navigation/root-stack-navigator.tsx
+++ b/packages/app/navigation/root-stack-navigator.tsx
@@ -248,16 +248,8 @@ export function RootStackNavigator() {
           component={DropExplanationScreen}
         />
 
-        <Stack.Screen
-          name="dropStar"
-          component={DropStarScreen}
-          options={{ gestureEnabled: false }}
-        />
-        <Stack.Screen
-          name="payoutsSetup"
-          component={PayoutsSetupScreen}
-          options={{ gestureEnabled: false }}
-        />
+        <Stack.Screen name="dropStar" component={DropStarScreen} />
+        <Stack.Screen name="payoutsSetup" component={PayoutsSetupScreen} />
         <Stack.Screen name="claim" component={ClaimScreen} />
         <Stack.Screen name="qrCodeShare" component={QRCodeShareScreen} />
         <Stack.Screen name="dropImageShare" component={DropImageShareScreen} />

--- a/packages/app/screens/drop-star.tsx
+++ b/packages/app/screens/drop-star.tsx
@@ -10,6 +10,4 @@ export const DropStarScreen = withModalScreen(DropStar, {
   disableBackdropPress: true,
   snapPoints: ["100%"],
   headerShown: false,
-  enableContentPanningGesture: false,
-  enableHandlePanningGesture: false,
 });

--- a/packages/app/screens/payouts/setup.tsx
+++ b/packages/app/screens/payouts/setup.tsx
@@ -10,6 +10,4 @@ export const PayoutsSetupScreen = withModalScreen(PayoutsSetup, {
   disableBackdropPress: true,
   snapPoints: ["100%"],
   headerShown: false,
-  enableContentPanningGesture: false,
-  enableHandlePanningGesture: false,
 });


### PR DESCRIPTION
# Why
- Star drop form close button doesn't work on native.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
- Replace modalContext.pop with router.pop as we're using native modal on iOS. On Android, it uses modalContext.pop. We can revisit the internal modal to handle such a case. Pushing this right now.
<!--
How did you build this feature or fix this bug and why?
-->


<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
