### PR TITLE
fix copy exteeds

### DIFF
--- a/packages/app/components/claim/claim-button.tsx
+++ b/packages/app/components/claim/claim-button.tsx
@@ -179,7 +179,7 @@ export const ClaimButton = ({
       <Button {...buttonProps} onPress={handleRaffleResultPress}>
         <>
           <Text tw={["font-semibold text-white", LABEL_SIZE_TW[size]]}>
-            Announce your raffle
+            {isPaidGated ? "Announce" : "Announce your raffle"}
           </Text>
         </>
       </Button>

--- a/packages/app/components/claim/claim-button.tsx
+++ b/packages/app/components/claim/claim-button.tsx
@@ -179,7 +179,7 @@ export const ClaimButton = ({
       <Button {...buttonProps} onPress={handleRaffleResultPress}>
         <>
           <Text tw={["font-semibold text-white", LABEL_SIZE_TW[size]]}>
-            {isPaidGated ? "Announce" : "Announce your raffle"}
+            {isPaidGated ? "Announce winner" : "Announce your raffle"}
           </Text>
         </>
       </Button>


### PR DESCRIPTION
# Why

The 'Announce Your Raffle' copy is broken when the drop is paid gating because the other side has a 'View Channel' button.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
--> 
![image](https://github.com/showtime-xyz/showtime-frontend/assets/37520667/a62fbad1-0c04-450e-8cc4-265ad7bfd50e)

# How

<!--
How did you build this feature or fix this bug and why?
-->
Make the copy shorter when it is a paid drop. 
# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
