### PR TITLE
Feat/improve drop preview share

### DIFF
--- a/packages/app/components/drop/drop-view-share.tsx
+++ b/packages/app/components/drop/drop-view-share.tsx
@@ -19,6 +19,7 @@ import {
 } from "app/components/social-buttons";
 import { useCreatorCollectionDetail } from "app/hooks/use-creator-collection-detail";
 import { useNFTDetailByTokenId } from "app/hooks/use-nft-detail-by-token-id";
+import { useRedirectDropImageShareScreen } from "app/hooks/use-redirect-to-drop-image-share-screen";
 import { getNFTSlug, getNFTURL } from "app/hooks/use-share-nft";
 import { createParam } from "app/navigation/use-param";
 import { getTwitterIntent } from "app/utilities";
@@ -44,7 +45,7 @@ export const DropViewShare = memo(function DropViewShare({
   const { data: edition } = useCreatorCollectionDetail(contractAddress);
   const viewRef = useRef(null);
   const { shareImageToIG } = useShareImage(viewRef);
-
+  const redirectDropImageShareScreen = useRedirectDropImageShareScreen();
   const router = useRouter();
   const { data } = useNFTDetailByTokenId({
     chainName: edition?.chain_name,
@@ -107,7 +108,12 @@ export const DropViewShare = memo(function DropViewShare({
           <InstagramButton
             tw="mt-4"
             theme={isPaidNFT ? "light" : undefined}
-            onPress={shareImageToIG}
+            onPress={() =>
+              redirectDropImageShareScreen(
+                contractAddress ?? "0xcd59916706368f23c7409f7addb8714a9c093445",
+                "Instagram"
+              )
+            }
           />
           <CopyLinkButton
             tw="mt-4"

--- a/packages/app/components/drop/drop-view-share.tsx
+++ b/packages/app/components/drop/drop-view-share.tsx
@@ -43,8 +43,6 @@ export const DropViewShare = memo(function DropViewShare({
 }: DropPreviewShareProps) {
   const isDark = useIsDarkMode();
   const { data: edition } = useCreatorCollectionDetail(contractAddress);
-  const viewRef = useRef(null);
-  const { shareImageToIG } = useShareImage(viewRef);
   const redirectDropImageShareScreen = useRedirectDropImageShareScreen();
   const router = useRouter();
   const { data } = useNFTDetailByTokenId({
@@ -95,7 +93,6 @@ export const DropViewShare = memo(function DropViewShare({
           buttonProps={{ variant: "primary" }}
           isPaidNFT={isPaidNFT}
           {...rest}
-          ref={viewRef}
         />
         <View
           tw="w-full flex-1 self-center px-4 py-4 sm:max-w-[332px]"

--- a/packages/app/components/qr-code/qr-code-modal.tsx
+++ b/packages/app/components/qr-code/qr-code-modal.tsx
@@ -295,7 +295,7 @@ export const DropImageShare = (props?: QRCodeModalProps) => {
           default:
             return;
         }
-      }, 800);
+      }, 600);
     }
   }, [
     shareType,

--- a/packages/app/components/qr-code/qr-code-modal.tsx
+++ b/packages/app/components/qr-code/qr-code-modal.tsx
@@ -1,7 +1,21 @@
-import { useRef, useMemo, useCallback, useEffect, Suspense } from "react";
-import { Dimensions, Linking, Platform, View as RNView } from "react-native";
+import {
+  useRef,
+  useMemo,
+  useCallback,
+  useEffect,
+  Suspense,
+  useState,
+} from "react";
+import {
+  Dimensions,
+  Linking,
+  Platform,
+  View as RNView,
+  StyleSheet,
+} from "react-native";
 
 import * as Clipboard from "expo-clipboard";
+import Reanimated, { Layout, FadeIn, FadeOut } from "react-native-reanimated";
 
 import { Avatar } from "@showtime-xyz/universal.avatar";
 import { BottomSheetModalProvider } from "@showtime-xyz/universal.bottom-sheet";
@@ -46,8 +60,17 @@ import { BgGoldLinearGradient } from "../gold-gradient";
 import { contentGatingType } from "../tooltips";
 
 const { width: windowWidth } = Dimensions.get("window");
+
+export type DropImageShareType =
+  | "Twitter"
+  | "Instagram"
+  | "Link"
+  | "Save"
+  | "More";
+
 type QRCodeModalParams = {
   contractAddress?: string | undefined;
+  shareType?: DropImageShareType;
 };
 const { useParam } = createParam<QRCodeModalParams>();
 
@@ -88,6 +111,8 @@ const QRCodeSkeleton = ({ size = 375 }) => {
 export const DropImageShare = (props?: QRCodeModalProps) => {
   const { contractAddress: contractAddressProp } = props ?? {};
   const [contractAddress] = useParam("contractAddress");
+  const [shareType] = useParam("shareType");
+  const [isLoading, setIsLoading] = useState(false);
   const modalScreenContext = useModalScreenContext();
 
   const { data: edition, loading: isLoadingCollection } =
@@ -123,7 +148,11 @@ export const DropImageShare = (props?: QRCodeModalProps) => {
   useEffect(() => {
     modalScreenContext?.setTitle("Congrats! Now share it ✦");
   }, [modalScreenContext]);
-
+  useEffect(() => {
+    if (shareType) {
+      setIsLoading(true);
+    }
+  }, [shareType]);
   const size = Platform.OS === "web" ? 276 : windowWidth - 32 - 32 - 32;
   const mediaUri = getMediaUrl({
     nft,
@@ -242,6 +271,40 @@ export const DropImageShare = (props?: QRCodeModalProps) => {
       </View>
     );
   }, [edition?.gating_type, imageColors.iconColor]);
+
+  const onImageLoad = useCallback(() => {
+    if (shareType) {
+      setIsLoading(false);
+      setTimeout(() => {
+        switch (shareType) {
+          case "Twitter":
+            shareWithTwitterIntent();
+            break;
+          case "Instagram":
+            shareImageToIG();
+            break;
+          case "Link":
+            onCopyLink();
+            break;
+          case "Save":
+            downloadToLocal();
+            break;
+          case "More":
+            shareOpenMore();
+            break;
+          default:
+            return;
+        }
+      }, 800);
+    }
+  }, [
+    shareType,
+    shareWithTwitterIntent,
+    shareImageToIG,
+    onCopyLink,
+    downloadToLocal,
+    shareOpenMore,
+  ]);
   if (isLoadingCollection || isLoadingNFT) {
     return <QRCodeSkeleton size={size} />;
   }
@@ -315,6 +378,7 @@ export const DropImageShare = (props?: QRCodeModalProps) => {
                             resizeMode={"cover"}
                             style={{ height: "100%", width: "100%" }}
                             transition={200}
+                            onLoad={onImageLoad}
                           />
                         )}
                         <ContentType />
@@ -358,6 +422,23 @@ export const DropImageShare = (props?: QRCodeModalProps) => {
                 </Pressable>
               ))}
           </View>
+          {isLoading ? (
+            <Reanimated.View
+              style={[
+                StyleSheet.absoluteFillObject,
+                {
+                  alignItems: "center",
+                  justifyContent: "center",
+                  backgroundColor: "rgba(0,0,0,0.4)",
+                },
+              ]}
+              layout={Layout.duration(100)}
+              entering={FadeIn}
+              exiting={FadeOut}
+            >
+              <Spinner />
+            </Reanimated.View>
+          ) : null}
         </View>
       </Suspense>
     </ErrorBoundary>

--- a/packages/app/components/share/use-share-image.tsx
+++ b/packages/app/components/share/use-share-image.tsx
@@ -92,12 +92,12 @@ export const useShareImage = (viewRef: any) => {
       url,
       filename: `Unlocked-Channel-Share-${new Date().valueOf()}`,
       social: Social.Instagram,
-    }).catch((err) => {});
+    }).catch((err) => {
+      Logger.error(err);
+    });
   }, [getViewShot, prepareShareToIG]);
 
   const downloadToLocal = useCallback(async () => {
-    console.log(viewRef.current);
-
     if (Platform.OS === "web") {
       const dataUrl = await domtoimage.toPng(viewRef.current as Node, {
         quality: 1,

--- a/packages/app/components/share/use-share-image.tsx
+++ b/packages/app/components/share/use-share-image.tsx
@@ -71,6 +71,7 @@ export const useShareImage = (viewRef: any) => {
   );
 
   const shareImageToIG = useCallback(async () => {
+    if (Platform.OS === "web") return;
     const url = await getViewShot();
 
     if (!url) {
@@ -125,6 +126,7 @@ export const useShareImage = (viewRef: any) => {
   }, [checkPhotosPermission, getViewShot, viewRef]);
 
   const shareOpenMore = useCallback(async () => {
+    if (Platform.OS === "web") return;
     const url = await getViewShot();
     try {
       const ShareResponse = await Share.open({

--- a/packages/app/hooks/use-redirect-to-drop-image-share-screen.ts
+++ b/packages/app/hooks/use-redirect-to-drop-image-share-screen.ts
@@ -2,12 +2,15 @@ import { Platform } from "react-native";
 
 import { useRouter } from "@showtime-xyz/universal.router";
 
+import { DropImageShareType } from "app/components/qr-code/qr-code-modal";
+
 export const useRedirectDropImageShareScreen = () => {
   const router = useRouter();
   const redirectToDropImageShareScreen = (
-    contractAddress: string | null | undefined
+    contractAddress: string | null | undefined,
+    shareType?: DropImageShareType
   ) => {
-    const as = `/drop-image-share/${contractAddress}`;
+    const as = `/drop-image-share/${contractAddress}?shareType=${shareType}`;
     router.push(
       Platform.select({
         native: as,
@@ -17,6 +20,7 @@ export const useRedirectDropImageShareScreen = () => {
             ...router.query,
             contractAddress: contractAddress,
             dropImageShareModal: true,
+            shareType,
           },
         } as any,
       }),

--- a/packages/app/screens/drop.tsx
+++ b/packages/app/screens/drop.tsx
@@ -1,3 +1,5 @@
+import { Platform } from "react-native";
+
 import { withModalScreen } from "@showtime-xyz/universal.modal-screen";
 
 import { CreateDropSteps } from "app/components/drop/create-drop-steps/create-drop-steps";
@@ -7,7 +9,13 @@ export const DropScreen = withModalScreen(CreateDropSteps, {
   matchingPathname: "/drop",
   matchingQueryParam: "dropModal",
   tw: "w-full",
-  snapPoints: ["78%", "100%"],
+  snapPoints: [
+    Platform.select({
+      ios: 528,
+      default: 500,
+    }),
+    "100%",
+  ],
   useNativeModal: false,
   headerShown: false,
 });


### PR DESCRIPTION
# Why
regrading this [thread](https://showtime-xyz.slack.com/archives/C02PXGK3V8D/p1692039078415309), when a drop is created, it will be redirected to the drop image share screen when clicking `Share on Instagram` button. 

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

https://github.com/showtime-xyz/showtime-frontend/assets/37520667/6ffc9f07-8836-4f5e-bcca-b622ab605cbd



# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
