### PR TITLE
feat: kill claim modal for pre-save drop

### DIFF
--- a/packages/app/components/claim/claim-button-simplified.tsx
+++ b/packages/app/components/claim/claim-button-simplified.tsx
@@ -8,6 +8,7 @@ import { colors } from "@showtime-xyz/universal.tailwind";
 import { Text } from "@showtime-xyz/universal.text";
 
 import { ClaimContext } from "app/context/claim-context";
+import { useClaimDrop } from "app/hooks/use-claim-drop";
 import { CreatorEditionResponse } from "app/hooks/use-creator-collection-detail";
 import { useRedirectToClaimDrop } from "app/hooks/use-redirect-to-claim-drop";
 
@@ -27,12 +28,8 @@ type ClaimButtonProps = {
 export const ClaimButtonSimplified = memo(
   ({ edition, tw = "", loading, ...rest }: ClaimButtonProps) => {
     const isDark = useIsDarkMode();
-    const redirectToClaimDrop = useRedirectToClaimDrop();
-    const {
-      state: claimStates,
-      dispatch,
-      contractAddress,
-    } = useContext(ClaimContext);
+    const { state: claimStates, contractAddress } = useContext(ClaimContext);
+    const { handleClaimNFT } = useClaimDrop(edition);
     const isPaidGated = edition?.gating_type === "paid_nft";
     const isProgress = useMemo(() => {
       return (
@@ -46,32 +43,6 @@ export const ClaimButtonSimplified = memo(
       contractAddress,
       edition?.creator_airdrop_edition.contract_address,
     ]);
-
-    const handleCollectPress = useCallback(
-      (type: ClaimType) => {
-        if (
-          claimStates.status === "loading" &&
-          claimStates.signaturePrompt === false
-        ) {
-          toast("Please wait for the previous collect to complete.");
-          return;
-        }
-        dispatch({ type: "initial" });
-        if (edition) {
-          redirectToClaimDrop(
-            edition.creator_airdrop_edition.contract_address,
-            type
-          );
-        }
-      },
-      [
-        claimStates.signaturePrompt,
-        claimStates.status,
-        dispatch,
-        edition,
-        redirectToClaimDrop,
-      ]
-    );
 
     const status = useMemo(() => getClaimStatus(edition), [edition]);
 
@@ -138,28 +109,6 @@ export const ClaimButtonSimplified = memo(
       [status, isProgress]
     );
 
-    const onPress = useCallback(() => {
-      let type: ClaimType = "free";
-      if (edition?.gating_type === "spotify_save") {
-        type = "spotify";
-      } else if (edition?.gating_type === "multi_provider_music_presave") {
-        type = edition?.creator_spotify_id ? "spotify" : "appleMusic";
-      } else if (edition?.gating_type === "multi_provider_music_save") {
-        type = edition?.spotify_track_url ? "spotify" : "appleMusic";
-      } else if (
-        edition?.gating_type === "music_presave" ||
-        edition?.gating_type === "spotify_presave"
-      ) {
-        type = "spotify";
-      }
-      handleCollectPress(type);
-    }, [
-      edition?.creator_spotify_id,
-      edition?.gating_type,
-      edition?.spotify_track_url,
-      handleCollectPress,
-    ]);
-
     if (loading) {
       return <Skeleton width={96} height={24} radius={999} show tw={tw} />;
     }
@@ -176,7 +125,7 @@ export const ClaimButtonSimplified = memo(
       <PressableHover
         tw={["h-6 w-24 items-center justify-center rounded-full", tw]}
         disabled={disabled}
-        onPress={onPress}
+        onPress={handleClaimNFT}
         style={{
           backgroundColor: buttonBgColor,
         }}

--- a/packages/app/components/claim/claim-button-simplified.tsx
+++ b/packages/app/components/claim/claim-button-simplified.tsx
@@ -125,7 +125,7 @@ export const ClaimButtonSimplified = memo(
       <PressableHover
         tw={["h-6 w-24 items-center justify-center rounded-full", tw]}
         disabled={disabled}
-        onPress={handleClaimNFT}
+        onPress={() => handleClaimNFT()}
         style={{
           backgroundColor: buttonBgColor,
         }}

--- a/packages/app/components/claim/claim-button.tsx
+++ b/packages/app/components/claim/claim-button.tsx
@@ -20,20 +20,17 @@ import { View } from "@showtime-xyz/universal.view";
 import { ButtonGoldLinearGradient } from "app/components/gold-gradient";
 import { ClaimContext } from "app/context/claim-context";
 import { useAppleMusicGatedClaim } from "app/hooks/use-apple-music-gated-claim";
+import { useClaimDrop } from "app/hooks/use-claim-drop";
 import { CreatorEditionResponse } from "app/hooks/use-creator-collection-detail";
 import { useRedirectToChannelUnlocked } from "app/hooks/use-redirect-to-channel-unlocked-screen";
-import { useRedirectToClaimDrop } from "app/hooks/use-redirect-to-claim-drop";
 import { useRedirectToRaffleResult } from "app/hooks/use-redirect-to-raffle-result";
 import { useSpotifyGatedClaim } from "app/hooks/use-spotify-gated-claim";
 import { useUser } from "app/hooks/use-user";
-import { Analytics, EVENTS } from "app/lib/analytics";
 import { NFT } from "app/types";
 
 import { LABEL_SIZE_TW } from "design-system/button/constants";
 import { ThreeDotsAnimation } from "design-system/three-dots";
-import { toast } from "design-system/toast";
 
-import { ClaimType } from "./claim-form";
 import { ClaimPaidNFTButton } from "./claim-paid-nft-button";
 import { ClaimStatus, getClaimStatus } from "./claim-status";
 
@@ -55,21 +52,18 @@ export const ClaimButton = ({
 }: ClaimButtonProps) => {
   const isDarkMode = useIsDarkMode();
   const isDark = theme === "dark" || (theme === "light" ? false : isDarkMode);
-  const { claimAppleMusicGatedDrop, isMutating: isAppleMusicCollectLoading } =
-    useAppleMusicGatedClaim(edition.creator_airdrop_edition);
-  const redirectToClaimDrop = useRedirectToClaimDrop();
+  const { isMutating: isAppleMusicCollectLoading } = useAppleMusicGatedClaim(
+    edition.creator_airdrop_edition
+  );
   const redirectToRaffleResult = useRedirectToRaffleResult();
-  const {
-    state: claimStates,
-    dispatch,
-    contractAddress,
-  } = useContext(ClaimContext);
+  const { state: claimStates, contractAddress } = useContext(ClaimContext);
   const isProgress =
     claimStates.status === "loading" &&
     claimStates.signaturePrompt === false &&
     contractAddress === edition.creator_airdrop_edition.contract_address;
-  const { claimSpotifyGatedDrop, isMutating: isSpotifyCollectLoading } =
-    useSpotifyGatedClaim(edition.creator_airdrop_edition);
+  const { isMutating: isSpotifyCollectLoading } = useSpotifyGatedClaim(
+    edition.creator_airdrop_edition
+  );
   const { isAuthenticated, user } = useUser();
   const isSelf =
     user?.data?.profile.profile_id ===
@@ -79,39 +73,7 @@ export const ClaimButton = ({
   const handleRaffleResultPress = () => {
     redirectToRaffleResult(edition.creator_airdrop_edition.contract_address);
   };
-
-  const handleCollectPress = (type: ClaimType) => {
-    if (
-      claimStates.status === "loading" &&
-      claimStates.signaturePrompt === false
-    ) {
-      toast("Please wait for the previous collect to complete.");
-      return;
-    }
-    dispatch({ type: "initial" });
-
-    if (
-      (edition.gating_type === "spotify_presave" ||
-        edition.gating_type === "spotify_save" ||
-        edition?.gating_type === "music_presave" ||
-        edition.gating_type === "multi_provider_music_save" ||
-        edition.gating_type === "multi_provider_music_presave") &&
-      !isAuthenticated
-    ) {
-      if (type === "spotify") {
-        Analytics.track(EVENTS.SPOTIFY_SAVE_PRESSED_BEFORE_LOGIN);
-        claimSpotifyGatedDrop({});
-      } else if (type === "appleMusic") {
-        Analytics.track(EVENTS.APPLE_MUSIC_SAVE_PRESSED_BEFORE_LOGIN);
-        claimAppleMusicGatedDrop({});
-      }
-    } else {
-      redirectToClaimDrop(
-        edition.creator_airdrop_edition.contract_address,
-        type
-      );
-    }
-  };
+  const { handleClaimNFT } = useClaimDrop(edition);
 
   const status = getClaimStatus(edition);
   const isRaffleDrop = edition?.raffles && edition.raffles?.length > 0;
@@ -266,7 +228,7 @@ export const ClaimButton = ({
     );
   } else if (edition?.gating_type === "spotify_save") {
     return (
-      <Button {...buttonProps} onPress={() => handleCollectPress("spotify")}>
+      <Button {...buttonProps} onPress={handleClaimNFT}>
         <>
           <Spotify
             color={isDark ? colors.black : colors.white}
@@ -288,7 +250,7 @@ export const ClaimButton = ({
         {edition.creator_apple_music_id ? (
           <Button
             {...buttonProps}
-            onPress={() => handleCollectPress("appleMusic")}
+            onPress={handleClaimNFT}
             tw="grow flex-row items-center justify-center bg-black dark:bg-white"
             disabled={isAppleMusicCollectLoading}
           >
@@ -307,7 +269,7 @@ export const ClaimButton = ({
             <View tw="w-2" />
             <Button
               {...buttonProps}
-              onPress={() => handleCollectPress("spotify")}
+              onPress={handleClaimNFT}
               tw="grow flex-row justify-center"
               disabled={isSpotifyCollectLoading}
             >
@@ -336,7 +298,7 @@ export const ClaimButton = ({
         {edition?.apple_music_track_url ? (
           <Button
             {...buttonProps}
-            onPress={() => handleCollectPress("appleMusic")}
+            onPress={handleClaimNFT}
             tw="grow flex-row items-center justify-center bg-black dark:bg-white"
             disabled={isAppleMusicCollectLoading}
           >
@@ -355,7 +317,7 @@ export const ClaimButton = ({
             <View tw="w-2" />
             <Button
               {...buttonProps}
-              onPress={() => handleCollectPress("spotify")}
+              onPress={handleClaimNFT}
               tw="grow flex-row justify-center"
               disabled={isSpotifyCollectLoading}
             >
@@ -383,7 +345,7 @@ export const ClaimButton = ({
     edition?.gating_type === "spotify_presave"
   ) {
     return (
-      <Button {...buttonProps} onPress={() => handleCollectPress("spotify")}>
+      <Button {...buttonProps} onPress={handleClaimNFT}>
         <>
           <Spotify
             color={isDark ? colors.black : colors.white}
@@ -414,12 +376,7 @@ export const ClaimButton = ({
   }
 
   return (
-    <Button
-      {...buttonProps}
-      onPress={() => {
-        handleCollectPress("free");
-      }}
-    >
+    <Button {...buttonProps} onPress={handleClaimNFT}>
       Collect
     </Button>
   );

--- a/packages/app/components/claim/claim-button.tsx
+++ b/packages/app/components/claim/claim-button.tsx
@@ -228,7 +228,7 @@ export const ClaimButton = ({
     );
   } else if (edition?.gating_type === "spotify_save") {
     return (
-      <Button {...buttonProps} onPress={handleClaimNFT}>
+      <Button {...buttonProps} onPress={() => handleClaimNFT("spotify")}>
         <>
           <Spotify
             color={isDark ? colors.black : colors.white}
@@ -250,7 +250,7 @@ export const ClaimButton = ({
         {edition.creator_apple_music_id ? (
           <Button
             {...buttonProps}
-            onPress={handleClaimNFT}
+            onPress={() => handleClaimNFT("appleMusic")}
             tw="grow flex-row items-center justify-center bg-black dark:bg-white"
             disabled={isAppleMusicCollectLoading}
           >
@@ -269,7 +269,7 @@ export const ClaimButton = ({
             <View tw="w-2" />
             <Button
               {...buttonProps}
-              onPress={handleClaimNFT}
+              onPress={() => handleClaimNFT("spotify")}
               tw="grow flex-row justify-center"
               disabled={isSpotifyCollectLoading}
             >
@@ -298,7 +298,7 @@ export const ClaimButton = ({
         {edition?.apple_music_track_url ? (
           <Button
             {...buttonProps}
-            onPress={handleClaimNFT}
+            onPress={() => handleClaimNFT("appleMusic")}
             tw="grow flex-row items-center justify-center bg-black dark:bg-white"
             disabled={isAppleMusicCollectLoading}
           >
@@ -317,7 +317,7 @@ export const ClaimButton = ({
             <View tw="w-2" />
             <Button
               {...buttonProps}
-              onPress={handleClaimNFT}
+              onPress={() => handleClaimNFT("spotify")}
               tw="grow flex-row justify-center"
               disabled={isSpotifyCollectLoading}
             >
@@ -345,7 +345,7 @@ export const ClaimButton = ({
     edition?.gating_type === "spotify_presave"
   ) {
     return (
-      <Button {...buttonProps} onPress={handleClaimNFT}>
+      <Button {...buttonProps} onPress={() => handleClaimNFT("spotify")}>
         <>
           <Spotify
             color={isDark ? colors.black : colors.white}
@@ -376,7 +376,12 @@ export const ClaimButton = ({
   }
 
   return (
-    <Button {...buttonProps} onPress={handleClaimNFT}>
+    <Button
+      {...buttonProps}
+      onPress={() => {
+        handleClaimNFT();
+      }}
+    >
       Collect
     </Button>
   );

--- a/packages/app/components/home/claim-button-iconic.tsx
+++ b/packages/app/components/home/claim-button-iconic.tsx
@@ -209,7 +209,7 @@ export function ClaimButtonIconic({
 
   return (
     <FeedSocialButton
-      onPress={handleClaimNFT}
+      onPress={() => handleClaimNFT()}
       text={
         <>
           <Text

--- a/packages/app/hooks/api-hooks.ts
+++ b/packages/app/hooks/api-hooks.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from "react";
 
-import useSWR, { useSWRConfig } from "swr";
+import useSWR from "swr";
 
 import { Analytics, EVENTS } from "app/lib/analytics";
 import { axios } from "app/lib/axios";
@@ -314,10 +314,10 @@ export const useMyInfo = () => {
   );
 
   const follow = useCallback(
-    async (profileId: number) => {
+    async (profileId: number | undefined) => {
       await loginPromise();
 
-      if (data) {
+      if (data && profileId) {
         mutate(
           {
             data: {

--- a/packages/app/hooks/use-apple-music-gated-claim.ts
+++ b/packages/app/hooks/use-apple-music-gated-claim.ts
@@ -19,7 +19,9 @@ import { useSaveAppleMusicToken } from "./use-save-apple-music-token";
 import { useStableCallback } from "./use-stable-callback";
 import { useUser } from "./use-user";
 
-export const useAppleMusicGatedClaim = (edition: IEdition) => {
+export const useAppleMusicGatedClaim = (
+  edition: IEdition | null | undefined
+) => {
   const user = useUser();
   const Alert = useAlert();
   const { claimNFT } = useClaimNFT(edition);
@@ -59,7 +61,7 @@ export const useAppleMusicGatedClaim = (edition: IEdition) => {
             url: "/v1/apple_music/gate",
             data: {
               token: appleMusicToken,
-              edition_address: edition.contract_address,
+              edition_address: edition?.contract_address,
             },
             method: "POST",
           });
@@ -81,7 +83,6 @@ export const useAppleMusicGatedClaim = (edition: IEdition) => {
     } catch (error: any) {
       Logger.error("claimAppleMusicGatedDrop failed", error);
       Alert.alert("Something went wrong", formatAPIErrorMessage(error));
-      throw error;
     }
   });
 

--- a/packages/app/hooks/use-claim-drop.ts
+++ b/packages/app/hooks/use-claim-drop.ts
@@ -1,0 +1,89 @@
+import { useContext } from "react";
+
+import { ClaimType } from "app/components/claim/claim-form";
+import { ClaimContext } from "app/context/claim-context";
+import { Analytics, EVENTS } from "app/lib/analytics";
+
+import { toast } from "design-system/toast";
+
+import { useMyInfo } from "./api-hooks";
+import { useAppleMusicGatedClaim } from "./use-apple-music-gated-claim";
+import { useClaimNFT } from "./use-claim-nft";
+import { CreatorEditionResponse } from "./use-creator-collection-detail";
+import { useRedirectToClaimDrop } from "./use-redirect-to-claim-drop";
+import { useSpotifyGatedClaim } from "./use-spotify-gated-claim";
+
+export const useClaimDrop = (edition?: CreatorEditionResponse) => {
+  const { claimNFT } = useClaimNFT(edition?.creator_airdrop_edition);
+  const { claimSpotifyGatedDrop, isMutating: isSpotifyDropMutating } =
+    useSpotifyGatedClaim(edition?.creator_airdrop_edition);
+  const { claimAppleMusicGatedDrop, isMutating: isAppleMusicDropMutating } =
+    useAppleMusicGatedClaim(edition?.creator_airdrop_edition);
+  const redirectToClaimDrop = useRedirectToClaimDrop();
+  const isLoading = isAppleMusicDropMutating || isSpotifyDropMutating;
+  const { state: claimStates, dispatch } = useContext(ClaimContext);
+  const { data: user, follow } = useMyInfo();
+
+  const handleClaimNFT = async () => {
+    let success: boolean | undefined | void = false;
+    let type: ClaimType = "free";
+    if (isLoading) {
+      toast("Please wait a moment to claim your drop.");
+      return;
+    }
+    if (
+      claimStates.status === "loading" &&
+      claimStates.signaturePrompt === false
+    ) {
+      toast("Please wait for the previous collect to complete.");
+      return;
+    }
+    dispatch({ type: "initial" });
+    if (
+      user?.data?.profile.profile_id !==
+      edition?.creator_airdrop_edition.owner_profile_id
+    ) {
+      follow(edition?.creator_airdrop_edition.owner_profile_id);
+    }
+
+    if (
+      claimStates.status === "loading" &&
+      claimStates.signaturePrompt === false
+    ) {
+      toast("Please wait for the previous collect to complete.");
+      return;
+    }
+    if (
+      edition?.gating_type === "multi_provider_music_save" ||
+      edition?.gating_type === "multi_provider_music_presave"
+    ) {
+      if (edition?.spotify_track_url) {
+        Analytics.track(EVENTS.SPOTIFY_SAVE_PRESSED_BEFORE_LOGIN);
+        success = await claimSpotifyGatedDrop({});
+      } else {
+        Analytics.track(EVENTS.APPLE_MUSIC_SAVE_PRESSED_BEFORE_LOGIN);
+        success = await claimAppleMusicGatedDrop({});
+      }
+    } else if (
+      edition?.gating_type === "spotify_save" ||
+      edition?.gating_type === "spotify_presave" ||
+      edition?.gating_type === "music_presave"
+    ) {
+      Analytics.track(EVENTS.SPOTIFY_SAVE_PRESSED_BEFORE_LOGIN);
+      success = await claimSpotifyGatedDrop({});
+    } else if (
+      edition?.gating_type === "password" ||
+      edition?.gating_type === "location" ||
+      edition?.gating_type === "multi"
+    ) {
+      redirectToClaimDrop(
+        edition?.creator_airdrop_edition.contract_address,
+        type
+      );
+    } else {
+      success = await claimNFT({});
+    }
+  };
+
+  return { handleClaimNFT };
+};

--- a/packages/app/hooks/use-claim-drop.ts
+++ b/packages/app/hooks/use-claim-drop.ts
@@ -24,9 +24,9 @@ export const useClaimDrop = (edition?: CreatorEditionResponse) => {
   const { state: claimStates, dispatch } = useContext(ClaimContext);
   const { data: user, follow } = useMyInfo();
 
-  const handleClaimNFT = async () => {
-    let success: boolean | undefined | void = false;
-    let type: ClaimType = "free";
+  const handleClaimNFT = async (
+    claimType?: "spotify" | "appleMusic" | null
+  ) => {
     if (isLoading) {
       toast("Please wait a moment to claim your drop.");
       return;
@@ -53,16 +53,23 @@ export const useClaimDrop = (edition?: CreatorEditionResponse) => {
       toast("Please wait for the previous collect to complete.");
       return;
     }
-    if (
+    // The claimType parameter is specifically for the Spotify or Apple Music claim button.
+    if (claimType === "spotify") {
+      Analytics.track(EVENTS.SPOTIFY_SAVE_PRESSED_BEFORE_LOGIN);
+      await claimSpotifyGatedDrop({});
+    } else if (claimType === "appleMusic") {
+      Analytics.track(EVENTS.APPLE_MUSIC_SAVE_PRESSED_BEFORE_LOGIN);
+      await claimAppleMusicGatedDrop({});
+    } else if (
       edition?.gating_type === "multi_provider_music_save" ||
       edition?.gating_type === "multi_provider_music_presave"
     ) {
       if (edition?.spotify_track_url) {
         Analytics.track(EVENTS.SPOTIFY_SAVE_PRESSED_BEFORE_LOGIN);
-        success = await claimSpotifyGatedDrop({});
+        await claimSpotifyGatedDrop({});
       } else {
         Analytics.track(EVENTS.APPLE_MUSIC_SAVE_PRESSED_BEFORE_LOGIN);
-        success = await claimAppleMusicGatedDrop({});
+        await claimAppleMusicGatedDrop({});
       }
     } else if (
       edition?.gating_type === "spotify_save" ||
@@ -70,7 +77,7 @@ export const useClaimDrop = (edition?: CreatorEditionResponse) => {
       edition?.gating_type === "music_presave"
     ) {
       Analytics.track(EVENTS.SPOTIFY_SAVE_PRESSED_BEFORE_LOGIN);
-      success = await claimSpotifyGatedDrop({});
+      await claimSpotifyGatedDrop({});
     } else if (
       edition?.gating_type === "password" ||
       edition?.gating_type === "location" ||
@@ -78,10 +85,10 @@ export const useClaimDrop = (edition?: CreatorEditionResponse) => {
     ) {
       redirectToClaimDrop(
         edition?.creator_airdrop_edition.contract_address,
-        type
+        "free"
       );
     } else {
-      success = await claimNFT({});
+      await claimNFT({});
     }
   };
 

--- a/packages/app/hooks/use-spotify-gated-claim.ts
+++ b/packages/app/hooks/use-spotify-gated-claim.ts
@@ -18,7 +18,7 @@ import { useSaveSpotifyToken } from "./use-save-spotify-token";
 import { useStableCallback } from "./use-stable-callback";
 import { useUser } from "./use-user";
 
-export const useSpotifyGatedClaim = (edition: IEdition) => {
+export const useSpotifyGatedClaim = (edition: IEdition | null | undefined) => {
   const user = useUser();
   const { claimNFT } = useClaimNFT(edition);
   const Alert = useAlert();
@@ -48,7 +48,7 @@ export const useSpotifyGatedClaim = (edition: IEdition) => {
               data: {
                 code: spotifyToken.code,
                 redirect_uri: spotifyToken.redirectUri,
-                edition_address: edition.contract_address,
+                edition_address: edition?.contract_address,
               },
               method: "POST",
             });


### PR DESCRIPTION
# Why

As Alex said, we want to remove the claim modal to reduce unnecessary clicks for users. 



# How

Moving all claim button logic into the `useClaimDrop` hooks.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
https://github.com/showtime-xyz/showtime-frontend/assets/37520667/2f5cd37d-66e6-46fc-a683-ced77c33558c