### PR TITLE
fix: add a primary wallet check for OG users to prevent breaking claim flow

### DIFF
--- a/packages/app/components/claim/claim-button-simplified.tsx
+++ b/packages/app/components/claim/claim-button-simplified.tsx
@@ -1,4 +1,4 @@
-import { useContext, useMemo, memo, useCallback } from "react";
+import { useContext, useMemo, memo } from "react";
 import { StyleProp, ViewStyle } from "react-native";
 
 import { useIsDarkMode } from "@showtime-xyz/universal.hooks";
@@ -10,11 +10,7 @@ import { Text } from "@showtime-xyz/universal.text";
 import { ClaimContext } from "app/context/claim-context";
 import { useClaimDrop } from "app/hooks/use-claim-drop";
 import { CreatorEditionResponse } from "app/hooks/use-creator-collection-detail";
-import { useRedirectToClaimDrop } from "app/hooks/use-redirect-to-claim-drop";
 
-import { toast } from "design-system/toast";
-
-import { ClaimType } from "./claim-form";
 import { ClaimPaidNFTButton } from "./claim-paid-nft-button";
 import { ClaimStatus, getClaimStatus } from "./claim-status";
 

--- a/packages/app/components/claim/util.ts
+++ b/packages/app/components/claim/util.ts
@@ -1,0 +1,30 @@
+import { useCallback } from "react";
+
+import { Alert } from "@showtime-xyz/universal.alert";
+import { useRouter } from "@showtime-xyz/universal.router";
+
+const usePrimaryWalletAlert = () => {
+  const router = useRouter();
+  const showPrimaryWalletAlert = useCallback(() => {
+    Alert.alert(
+      "Choose a primary wallet",
+      "Please choose which wallet will receive your drop. You only have to do this once.",
+      [
+        {
+          text: "Cancel",
+          style: "cancel",
+        },
+        {
+          text: "Choose wallet",
+          onPress: async () => {
+            router.push("/settings");
+          },
+        },
+      ]
+    );
+  }, [router]);
+
+  return showPrimaryWalletAlert;
+};
+
+export default usePrimaryWalletAlert;

--- a/packages/app/hooks/api-hooks.ts
+++ b/packages/app/hooks/api-hooks.ts
@@ -308,7 +308,7 @@ export const useMyInfo = () => {
     {
       revalidateOnMount: false,
       revalidateIfStale: false,
-      dedupingInterval: 30000,
+      dedupingInterval: 5000,
       focusThrottleInterval: 30000,
     }
   );

--- a/packages/app/hooks/use-claim-drop.ts
+++ b/packages/app/hooks/use-claim-drop.ts
@@ -1,6 +1,7 @@
 import { useContext } from "react";
 
 import { ClaimType } from "app/components/claim/claim-form";
+import usePrimaryWalletAlert from "app/components/claim/util";
 import { ClaimContext } from "app/context/claim-context";
 import { Analytics, EVENTS } from "app/lib/analytics";
 
@@ -23,6 +24,7 @@ export const useClaimDrop = (edition?: CreatorEditionResponse) => {
   const isLoading = isAppleMusicDropMutating || isSpotifyDropMutating;
   const { state: claimStates, dispatch } = useContext(ClaimContext);
   const { data: user, follow } = useMyInfo();
+  const showPrimaryWalletAlert = usePrimaryWalletAlert();
 
   const handleClaimNFT = async (
     claimType?: "spotify" | "appleMusic" | null
@@ -53,6 +55,12 @@ export const useClaimDrop = (edition?: CreatorEditionResponse) => {
       toast("Please wait for the previous collect to complete.");
       return;
     }
+
+    if (user?.data?.profile?.primary_wallet === null) {
+      showPrimaryWalletAlert();
+      return;
+    }
+
     // The claimType parameter is specifically for the Spotify or Apple Music claim button.
     if (claimType === "spotify") {
       Analytics.track(EVENTS.SPOTIFY_SAVE_PRESSED_BEFORE_LOGIN);

--- a/packages/app/hooks/use-redirect-to-channel-unlocked-screen.ts
+++ b/packages/app/hooks/use-redirect-to-channel-unlocked-screen.ts
@@ -1,29 +1,33 @@
+import { useCallback } from "react";
 import { Platform } from "react-native";
 
 import { useRouter } from "@showtime-xyz/universal.router";
 
 export const useRedirectToChannelUnlocked = () => {
   const router = useRouter();
-  const redirectToChannelUnlocked = async (contractAddress?: string) => {
-    const as = `/channels/${contractAddress}/unlocked`;
-    router.push(
-      Platform.select({
-        native: as,
-        web: {
-          pathname: router.pathname,
-          query: {
-            ...router.query,
-            contractAddress,
-            unlockedChannelModal: true,
-          },
-        } as any,
-      }),
-      Platform.select({ native: as, web: router.asPath }),
-      {
-        shallow: true,
-      }
-    );
-  };
+  const redirectToChannelUnlocked = useCallback(
+    async (contractAddress?: string) => {
+      const as = `/channels/${contractAddress}/unlocked`;
+      router.push(
+        Platform.select({
+          native: as,
+          web: {
+            pathname: router.pathname,
+            query: {
+              ...router.query,
+              contractAddress,
+              unlockedChannelModal: true,
+            },
+          } as any,
+        }),
+        Platform.select({ native: as, web: router.asPath }),
+        {
+          shallow: true,
+        }
+      );
+    },
+    [router]
+  );
 
   return redirectToChannelUnlocked;
 };


### PR DESCRIPTION
# Why

We have OG users who haven't been online for some time. Some of them don't have a primary wallet set, which we require for both paid and free music NFTs.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Added a check to our buttons to show an alert when there is no primary wallet.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
