### PR TITLE
feat: support video on home v2(web & iOS only)

### DIFF
--- a/packages/app/components/home/home-item.tsx
+++ b/packages/app/components/home/home-item.tsx
@@ -24,7 +24,9 @@ import { ClaimedBy } from "../feed-item/claimed-by";
 import { NSFWGate } from "../feed-item/nsfw-gate";
 import { FollowButtonSmall } from "../follow-button-small";
 import { ListMedia } from "../media";
+import { MuteButton } from "../mute-button";
 import { NFTDropdown } from "../nft-dropdown";
+import { ItemKeyContext } from "../viewability-tracker-flatlist";
 import { ContentType } from "./content-type";
 import { FeedEngagementIcons } from "./engagement-icons";
 
@@ -75,96 +77,105 @@ export const HomeItem = memo<{ nft: NFT; index: number; mediaSize: number }>(
     );
 
     return (
-      <NativeRouteComponent
-        href={`${getNFTSlug(nft)}?initialScrollItemId=${nft.nft_id}&type=feed`}
-      >
-        <View tw="mb-2 mt-6 px-4 md:px-0">
-          <CreatorOnFeed
-            nft={nft}
-            rightElement={
-              <>
-                <FollowButtonSmall
-                  profileId={nft.creator_id}
-                  name={nft.creator_username}
-                  tw="mr-4"
-                />
-                <NFTDropdown
-                  nft={nft}
-                  edition={edition}
-                  iconSize={20}
-                  iconColor={isDark ? colors.gray[100] : colors.gray[900]}
-                  shouldEnableSharing={false}
-                />
-              </>
-            }
-          />
-          <View
-            tw="mt-3"
-            style={{ maxWidth: isMdWidth ? mediaSize : undefined }}
-          >
-            <RouteComponent
-              as={getNFTSlug(nft)}
-              href={`${getNFTSlug(nft)}?initialScrollItemId=${
-                nft.nft_id
-              }&type=feed`}
+      <ItemKeyContext.Provider value={index}>
+        <NativeRouteComponent
+          href={`${getNFTSlug(nft)}?initialScrollItemId=${
+            nft.nft_id
+          }&type=feed`}
+        >
+          <View tw="mb-2 mt-6 px-4 md:px-0">
+            <CreatorOnFeed
+              nft={nft}
+              rightElement={
+                <>
+                  <FollowButtonSmall
+                    profileId={nft.creator_id}
+                    name={nft.creator_username}
+                    tw="mr-4"
+                  />
+                  <NFTDropdown
+                    nft={nft}
+                    edition={edition}
+                    iconSize={20}
+                    iconColor={isDark ? colors.gray[100] : colors.gray[900]}
+                    shouldEnableSharing={false}
+                  />
+                </>
+              }
+            />
+            <View
+              tw="mt-3"
+              style={{ maxWidth: isMdWidth ? mediaSize : undefined }}
             >
-              <Text tw="text-15 font-bold text-gray-900 dark:text-white">
-                {nft?.token_name}
-              </Text>
-
-              <View tw="h-3" />
-              <Text
-                tw="text-sm text-gray-600 dark:text-gray-400"
-                numberOfLines={5}
-              >
-                {description}
-              </Text>
-            </RouteComponent>
-            <View tw="mt-3 min-h-[20px]">
-              <ClaimedBy
-                claimersList={detailData?.data.item?.multiple_owners_list}
-                avatarSize={18}
-                nft={nft}
-              />
-            </View>
-            <View tw="mt-3 flex-row items-center">
               <RouteComponent
                 as={getNFTSlug(nft)}
                 href={`${getNFTSlug(nft)}?initialScrollItemId=${
                   nft.nft_id
                 }&type=feed`}
               >
-                <View
-                  tw="overflow-hidden rounded-2xl bg-gray-100 dark:bg-gray-900"
-                  style={mediaViewStyle}
+                <Text tw="text-15 font-bold text-gray-900 dark:text-white">
+                  {nft?.token_name}
+                </Text>
+
+                <View tw="h-3" />
+                <Text
+                  tw="text-sm text-gray-600 dark:text-gray-400"
+                  numberOfLines={5}
+                >
+                  {description}
+                </Text>
+              </RouteComponent>
+              <View tw="mt-3 min-h-[20px]">
+                <ClaimedBy
+                  claimersList={detailData?.data.item?.multiple_owners_list}
+                  avatarSize={18}
+                  nft={nft}
+                />
+              </View>
+              <View tw="mt-3 flex-row items-center">
+                <RouteComponent
+                  as={getNFTSlug(nft)}
+                  href={`${getNFTSlug(nft)}?initialScrollItemId=${
+                    nft.nft_id
+                  }&type=feed`}
                 >
                   <View
-                    style={{
-                      width: mediaSize,
-                      height: mediaSize,
-                    }}
+                    tw="overflow-hidden rounded-2xl bg-gray-100 dark:bg-gray-900"
+                    style={mediaViewStyle}
                   >
-                    <ListMedia
-                      item={nft}
-                      optimizedWidth={1000}
-                      loading={index > 0 ? "lazy" : "eager"}
-                    />
-                    <View tw="absolute right-1.5 top-1.5">
-                      <ContentType edition={edition} theme="light" />
+                    <View
+                      style={{
+                        width: mediaSize,
+                        height: mediaSize,
+                      }}
+                    >
+                      <ListMedia
+                        item={nft}
+                        optimizedWidth={1000}
+                        loading={index > 0 ? "lazy" : "eager"}
+                      />
+                      <View tw="absolute right-1.5 top-1.5">
+                        <ContentType edition={edition} theme="light" />
+                      </View>
+                      <NSFWGate
+                        show={nft.nsfw}
+                        nftId={nft.nft_id}
+                        variant="thumbnail"
+                      />
+                      {nft?.mime_type?.includes("video") ? (
+                        <View tw="z-9 absolute bottom-2 right-2">
+                          <MuteButton size={16} />
+                        </View>
+                      ) : null}
                     </View>
-                    <NSFWGate
-                      show={nft.nsfw}
-                      nftId={nft.nft_id}
-                      variant="thumbnail"
-                    />
                   </View>
-                </View>
-              </RouteComponent>
-              <FeedEngagementIcons nft={nft} edition={edition} />
+                </RouteComponent>
+                <FeedEngagementIcons nft={nft} edition={edition} />
+              </View>
             </View>
           </View>
-        </View>
-      </NativeRouteComponent>
+        </NativeRouteComponent>
+      </ItemKeyContext.Provider>
     );
   }
 );

--- a/packages/app/components/home/index.tsx
+++ b/packages/app/components/home/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from "react";
+import { useCallback, useRef, useMemo } from "react";
 import { useWindowDimensions, Platform } from "react-native";
 
 import {
@@ -8,6 +8,8 @@ import {
 import { View } from "@showtime-xyz/universal.view";
 
 import { ErrorBoundary } from "app/components/error-boundary";
+import { VideoConfigContext } from "app/context/video-config-context";
+import { withViewabilityInfiniteScrollList } from "app/hocs/with-viewability-infinite-scroll-list";
 import { useFeed } from "app/hooks/use-feed";
 import { usePlatformBottomHeight } from "app/hooks/use-platform-bottom-height";
 import { useHeaderHeight } from "app/lib/react-navigation/elements";
@@ -21,6 +23,9 @@ import { ListHeaderComponent } from "./header";
 import { HomeItem, HomeItemSketelon } from "./home-item";
 import { PopularCreators } from "./popular-creators";
 import { TrendingCarousel } from "./trending-carousel";
+
+const ViewabilityInfiniteScrollList =
+  withViewabilityInfiniteScrollList(InfiniteScrollList);
 
 export const Home = () => {
   const bottomBarHeight = usePlatformBottomHeight();
@@ -106,41 +111,50 @@ export const Home = () => {
     },
     [feedItemLength]
   );
-
+  const videoConfig = useMemo(
+    () => ({
+      isMuted: true,
+      useNativeControls: false,
+      previewOnly: false,
+    }),
+    []
+  );
   return (
-    <View
-      tw="w-full flex-1 items-center bg-white dark:bg-black"
-      style={{
-        marginBottom: Platform.select({
-          native: bottomBarHeight,
-        }),
-      }}
-    >
-      <View tw="md:max-w-screen-content w-full">
-        <ErrorBoundary>
-          <InfiniteScrollList
-            data={data}
-            renderItem={renderItem}
-            estimatedItemSize={600}
-            drawDistance={Platform.OS === "android" ? height : undefined}
-            preserveScrollPosition
-            ListHeaderComponent={ListHeaderComponent}
-            contentContainerStyle={{
-              paddingTop: Platform.select({
-                android: 0,
-                default: headerHeight,
-              }),
-            }}
-            automaticallyAdjustContentInsets
-            automaticallyAdjustsScrollIndicatorInsets
-            ref={listRef}
-            getItemType={getItemType}
-            ListEmptyComponent={ListEmptyComponent}
-            useWindowScroll
-            style={{ flexGrow: 1 }}
-          />
-        </ErrorBoundary>
+    <VideoConfigContext.Provider value={videoConfig}>
+      <View
+        tw="w-full flex-1 items-center bg-white dark:bg-black"
+        style={{
+          marginBottom: Platform.select({
+            native: bottomBarHeight,
+          }),
+        }}
+      >
+        <View tw="md:max-w-screen-content w-full">
+          <ErrorBoundary>
+            <ViewabilityInfiniteScrollList
+              data={data}
+              renderItem={renderItem}
+              estimatedItemSize={600}
+              drawDistance={Platform.OS === "android" ? height : undefined}
+              preserveScrollPosition
+              ListHeaderComponent={ListHeaderComponent}
+              contentContainerStyle={{
+                paddingTop: Platform.select({
+                  android: 0,
+                  default: headerHeight,
+                }),
+              }}
+              automaticallyAdjustContentInsets
+              automaticallyAdjustsScrollIndicatorInsets
+              ref={listRef}
+              getItemType={getItemType}
+              ListEmptyComponent={ListEmptyComponent}
+              useWindowScroll
+              style={{ flexGrow: 1 }}
+            />
+          </ErrorBoundary>
+        </View>
       </View>
-    </View>
+    </VideoConfigContext.Provider>
   );
 };

--- a/packages/app/components/media/list-media.tsx
+++ b/packages/app/components/media/list-media.tsx
@@ -10,7 +10,7 @@ import { CreatorEditionResponse } from "app/hooks/use-creator-collection-detail"
 import type { NFT } from "app/types";
 import { getMediaUrl } from "app/utilities";
 
-//import { ListVideo } from "design-system/list-video";
+import { ListVideo } from "design-system/list-video";
 
 type Props = {
   item?: NFT & { loading?: boolean };
@@ -28,6 +28,7 @@ function ListMediaImpl({
   resizeMode: propResizeMode,
   optimizedWidth = 300,
   loading = "lazy",
+  isMuted,
 }: Props) {
   const resizeMode = propResizeMode ?? "cover";
 
@@ -68,25 +69,6 @@ function ListMediaImpl({
           transition={200}
         />
       ) : null}
-
-      {item?.mime_type?.startsWith("video") ||
-      item?.mime_type === "image/gif" ? (
-        <Image
-          source={{
-            uri: `${mediaStillPreviewUri}?&optimizer=image&width=${optimizedWidth}&quality=80`,
-          }}
-          recyclingKey={mediaUri}
-          blurhash={item?.blurhash}
-          data-test-id={Platform.select({ web: "nft-card-media" })}
-          resizeMode={resizeMode}
-          alt={item?.token_name}
-          style={{ height: "100%", width: "100%" }}
-          loading={loading}
-          transition={200}
-        />
-      ) : null}
-
-      {/* TODO: Add back once we deliver videos from BunnyCDN
       {item?.mime_type?.startsWith("video") ||
       item?.mime_type === "image/gif" ? (
         <ListVideo
@@ -97,12 +79,11 @@ function ListMediaImpl({
             uri: mediaStillPreviewUri,
           }}
           blurhash={item?.blurhash}
-          isMuted={true}
+          isMuted={isMuted}
           resizeMode={resizeMode as any}
           loading={loading}
         />
       ) : null}
-     */}
     </>
   );
 }

--- a/packages/app/components/mute-button/mute-button.tsx
+++ b/packages/app/components/mute-button/mute-button.tsx
@@ -9,13 +9,18 @@ const hitSlop = { top: 10, bottom: 10, left: 10, right: 10 };
 type MuteButtonProps = {
   onPress?: (state: boolean) => void;
   variant?: "default" | "mobile-web";
+  size?: number;
 };
 export const MuteButton = memo(function MuteButton({
   onPress,
   variant,
+  size: propSize,
 }: MuteButtonProps) {
   const [muted, setMuted] = useMuted();
-  const size = useMemo(() => (variant === "mobile-web" ? 22 : 18), [variant]);
+  const size = useMemo(
+    () => (variant === "mobile-web" ? 22 : propSize ? propSize : 18),
+    [variant, propSize]
+  );
 
   if (Platform.OS !== "web" || (Platform.OS !== "web" && !muted)) return null;
 

--- a/packages/app/components/trending/trending-item.tsx
+++ b/packages/app/components/trending/trending-item.tsx
@@ -98,6 +98,7 @@ export const TrendingItem = memo<TrendingItemProps>(function TrendingItem({
               resizeMode={ResizeMode.COVER}
               optimizedWidth={500}
               loading={index > 0 ? "lazy" : "eager"}
+              isMuted
             />
             <NSFWGate show={nft.nsfw} nftId={nft.nft_id} variant="thumbnail" />
             <View tw="absolute left-0 top-0 h-7 w-7 items-center justify-center rounded-br-2xl rounded-tl-2xl bg-black/50">

--- a/packages/design-system/list-video/index.tsx
+++ b/packages/design-system/list-video/index.tsx
@@ -1,10 +1,15 @@
-import { ComponentProps } from "react";
+import { ComponentProps, useRef } from "react";
 import { Platform } from "react-native";
 
 import { Video as ExpoVideo, ResizeMode } from "expo-av";
 
 import { Image } from "@showtime-xyz/universal.image";
 import type { TW } from "@showtime-xyz/universal.tailwind";
+import { Text } from "@showtime-xyz/universal.text";
+
+import { useVideoConfig } from "app/context/video-config-context";
+import { useViewabilityMount } from "app/hooks/use-viewability-mount";
+import { useMuted } from "app/providers/mute-provider";
 
 type VideoProps = {
   tw?: TW;
@@ -13,8 +18,18 @@ type VideoProps = {
 } & ComponentProps<typeof ExpoVideo>;
 
 export function ListVideo({ posterSource, ...props }: VideoProps) {
+  const videoConfig = useVideoConfig();
+  const videoRef = useRef<ExpoVideo | null>(null);
+  const [muted] = useMuted();
+  const isMuted = props.isMuted ?? muted;
+  const { id } = useViewabilityMount({
+    videoRef,
+    source: props.source,
+    isMuted: isMuted,
+  });
+
   // this is a temporary fix for the video on android due to expo-av performance issues
-  if (Platform.OS === "android") {
+  if (Platform.OS === "android" || videoConfig?.previewOnly) {
     return (
       <Image
         source={posterSource}
@@ -31,14 +46,27 @@ export function ListVideo({ posterSource, ...props }: VideoProps) {
     <>
       <ExpoVideo
         {...props}
+        ref={videoRef}
         style={{ width: "100%", height: "100%" }}
-        useNativeControls={false}
         resizeMode={ResizeMode.COVER}
         posterSource={posterSource}
         shouldPlay={true}
         isMuted={true}
-        isLooping={true}
+        isLooping
+        useNativeControls={videoConfig?.useNativeControls}
       />
+      {__DEV__ ? (
+        <Text
+          style={{
+            fontSize: 30,
+            fontWeight: "bold",
+            color: "white",
+            position: "absolute",
+          }}
+        >
+          Video {id}
+        </Text>
+      ) : null}
     </>
   );
 }

--- a/packages/design-system/list-video/index.tsx
+++ b/packages/design-system/list-video/index.tsx
@@ -1,15 +1,16 @@
-import { ComponentProps, useRef } from "react";
+import { ComponentProps } from "react";
 import { Platform } from "react-native";
 
 import { Video as ExpoVideo, ResizeMode } from "expo-av";
 
 import { Image } from "@showtime-xyz/universal.image";
 import type { TW } from "@showtime-xyz/universal.tailwind";
-import { Text } from "@showtime-xyz/universal.text";
 
-import { useVideoConfig } from "app/context/video-config-context";
-import { useViewabilityMount } from "app/hooks/use-viewability-mount";
-import { useMuted } from "app/providers/mute-provider";
+// import { Text } from "@showtime-xyz/universal.text";
+
+// import { useVideoConfig } from "app/context/video-config-context";
+// import { useViewabilityMount } from "app/hooks/use-viewability-mount";
+// import { useMuted } from "app/providers/mute-provider";
 
 type VideoProps = {
   tw?: TW;
@@ -18,55 +19,66 @@ type VideoProps = {
 } & ComponentProps<typeof ExpoVideo>;
 
 export function ListVideo({ posterSource, ...props }: VideoProps) {
-  const videoConfig = useVideoConfig();
-  const videoRef = useRef<ExpoVideo | null>(null);
-  const [muted] = useMuted();
-  const isMuted = props.isMuted ?? muted;
-  const { id } = useViewabilityMount({
-    videoRef,
-    source: props.source,
-    isMuted: isMuted,
-  });
+  // const videoConfig = useVideoConfig();
+  // const videoRef = useRef<ExpoVideo | null>(null);
+  // const [muted] = useMuted();
+  // const isMuted = props.isMuted ?? muted;
+  // const { id } = useViewabilityMount({
+  //   videoRef,
+  //   source: props.source,
+  //   isMuted: isMuted,
+  // });
 
   // this is a temporary fix for the video on android due to expo-av performance issues
-  if (Platform.OS === "android" || videoConfig?.previewOnly) {
-    return (
-      <Image
-        source={posterSource}
-        // @ts-ignore
-        recyclingKey={posterSource?.uri}
-        data-test-id={Platform.select({ web: "nft-card-media" })}
-        resizeMode={ResizeMode.COVER}
-        alt={"Video Poster"}
-        style={{ height: "100%", width: "100%" }}
-      />
-    );
-  }
   return (
-    <>
-      <ExpoVideo
-        {...props}
-        ref={videoRef}
-        style={{ width: "100%", height: "100%" }}
-        resizeMode={ResizeMode.COVER}
-        posterSource={posterSource}
-        shouldPlay={true}
-        isMuted={true}
-        isLooping
-        useNativeControls={videoConfig?.useNativeControls}
-      />
-      {__DEV__ ? (
-        <Text
-          style={{
-            fontSize: 30,
-            fontWeight: "bold",
-            color: "white",
-            position: "absolute",
-          }}
-        >
-          Video {id}
-        </Text>
-      ) : null}
-    </>
+    <Image
+      source={posterSource}
+      // @ts-ignore
+      recyclingKey={posterSource?.uri}
+      data-test-id={Platform.select({ web: "nft-card-media" })}
+      resizeMode={ResizeMode.COVER}
+      alt={"Video Poster"}
+      style={{ height: "100%", width: "100%" }}
+    />
   );
+  // if (Platform.OS === "android" || videoConfig?.previewOnly) {
+  //   return (
+  //     <Image
+  //       source={posterSource}
+  //       // @ts-ignore
+  //       recyclingKey={posterSource?.uri}
+  //       data-test-id={Platform.select({ web: "nft-card-media" })}
+  //       resizeMode={ResizeMode.COVER}
+  //       alt={"Video Poster"}
+  //       style={{ height: "100%", width: "100%" }}
+  //     />
+  //   );
+  // }
+  // return (
+  //   <>
+  //     <ExpoVideo
+  //       {...props}
+  //       ref={videoRef}
+  //       style={{ width: "100%", height: "100%" }}
+  //       resizeMode={ResizeMode.COVER}
+  //       posterSource={posterSource}
+  //       shouldPlay={true}
+  //       isMuted={true}
+  //       isLooping
+  //       useNativeControls={videoConfig?.useNativeControls}
+  //     />
+  //     {__DEV__ ? (
+  //       <Text
+  //         style={{
+  //           fontSize: 30,
+  //           fontWeight: "bold",
+  //           color: "white",
+  //           position: "absolute",
+  //         }}
+  //       >
+  //         Video {id}
+  //       </Text>
+  //     ) : null}
+  //   </>
+  // );
 }

--- a/packages/design-system/list-video/index.web.tsx
+++ b/packages/design-system/list-video/index.web.tsx
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import { StyleSheet } from "react-native";
 
 import {
@@ -8,7 +9,9 @@ import {
 
 import { ResizeMode } from "@showtime-xyz/universal.image";
 import type { TW } from "@showtime-xyz/universal.tailwind";
-import { View } from "@showtime-xyz/universal.view";
+
+import { useItemVisible } from "app/hooks/use-viewability-mount";
+import { useMuted } from "app/providers/mute-provider";
 
 type VideoProps = Omit<AVVideoProps, "resizeMode"> & {
   tw?: TW;
@@ -30,20 +33,26 @@ const contentFitToresizeMode = (resizeMode: ResizeMode) => {
 };
 
 export function ListVideo({ resizeMode, posterSource, ...props }: VideoProps) {
+  const videoRef = useRef<ExpoVideo | null>(null);
+  const { id } = useItemVisible({ videoRef });
+  const [muted] = useMuted();
+  const isMuted = props.isMuted ?? muted;
+
   return (
-    <View style={{ height: "inherit", width: "inherit" }}>
+    <div style={{ height: "inherit", width: "inherit" }}>
       <ExpoVideo
         style={[StyleSheet.absoluteFill, { justifyContent: "center" }]}
         useNativeControls={false}
         resizeMode={contentFitToresizeMode(resizeMode)}
         posterSource={posterSource}
         source={props.source}
-        shouldPlay={true}
+        shouldPlay={typeof id === "undefined"}
         isLooping
-        isMuted={true}
         videoStyle={{ position: "relative" }}
         {...props}
+        ref={videoRef}
+        isMuted={isMuted}
       />
-    </View>
+    </div>
   );
 }

--- a/packages/design-system/video/index.tsx
+++ b/packages/design-system/video/index.tsx
@@ -14,8 +14,8 @@ import { useMuted } from "app/providers/mute-provider";
 type VideoProps = {
   tw?: TW;
   blurhash?: string;
-  width: number;
-  height: number;
+  width?: number;
+  height?: number;
   loading?: "eager" | "lazy";
   withVideoBackdrop?: boolean;
 } & ComponentProps<typeof ExpoVideo>;


### PR DESCRIPTION
# Why

Currently, we haven't supported video on home v2 yet. This PR enables auto play of videos on home v2. However, this change is only for the Web and iOS platforms because there is a performance issue on Android. We will add it back once Hirbod solves the Android player issue. 

# How  

Use React context and the `ViewabilityInfiniteScrollList` component to automatically play videos when scrolling through the current video content.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
I have checked the web and iOS, and it works well! and this change doesn't affect Android.

https://github.com/showtime-xyz/showtime-frontend/assets/37520667/f843ba09-4d36-4dfc-a311-2c42942e908f


