### PR TITLE
feat: add time limit for drop

### DIFF
--- a/packages/app/components/card/card.tsx
+++ b/packages/app/components/card/card.tsx
@@ -187,7 +187,7 @@ const CardLargeScreen = ({
     >
       <View tw="pb-4">
         <View tw="flex-row items-center justify-between px-4">
-          <Creator nft={nft} shouldShowDateCreated={false} />
+          <Creator nft={nft} timeLimit={edition?.time_limit} />
           <ErrorBoundary renderFallback={() => null}>
             <Suspense fallback={<Skeleton width={24} height={24} />}>
               <NFTDropdown

--- a/packages/app/components/card/list-card.tsx
+++ b/packages/app/components/card/list-card.tsx
@@ -154,6 +154,7 @@ const ListCardSmallScreen = ({
             shouldShowDateCreated={false}
             shouldShowCreatorIndicator={false}
             size={24}
+            timeLimit={edition?.time_limit}
             tw={"web:py-2 py-2"}
           />
           <View tw="items-center">
@@ -327,7 +328,11 @@ const ListCardLargeScreen = ({
         <View tw="flex-1 justify-between">
           <View tw="pr-6">
             <View tw="px-4">
-              <Creator nft={nft} shouldShowDateCreated={false} />
+              <Creator
+                nft={nft}
+                shouldShowDateCreated={false}
+                timeLimit={edition?.time_limit}
+              />
               <RouteComponent as={as} href={href!} onPress={handleOnPress}>
                 <View tw="inline flex-grow-0">
                   <Text

--- a/packages/app/components/card/rows/elements/creator.tsx
+++ b/packages/app/components/card/rows/elements/creator.tsx
@@ -1,4 +1,8 @@
-import { formatDistanceToNowStrict } from "date-fns";
+import {
+  formatDistanceToNowStrict,
+  formatDuration,
+  intervalToDuration,
+} from "date-fns";
 
 import { TW } from "@showtime-xyz/universal.tailwind";
 import { Text } from "@showtime-xyz/universal.text";
@@ -30,6 +34,7 @@ type Props = {
   label?: string;
   size?: number;
   tw?: TW;
+  timeLimit: string | null | undefined;
 };
 
 export function Creator({
@@ -39,6 +44,7 @@ export function Creator({
   label = "Creator",
   size = 32,
   tw = "",
+  timeLimit,
 }: Props) {
   if (!nft) return null;
 
@@ -71,16 +77,29 @@ export function Creator({
               <VerificationBadge style={{ marginLeft: 4 }} size={12} />
             ) : null}
           </View>
-          {Boolean(shouldShowDateCreated && nft.token_created) && (
+
+          {Boolean(
+            shouldShowDateCreated && (nft.token_created || timeLimit)
+          ) && (
             <>
               <View tw="h-2" />
               <Text tw="text-xs font-semibold text-gray-900 dark:text-white">
-                {formatDistanceToNowStrict(
-                  convertUTCDateToLocalDate(nft.token_created),
-                  {
-                    addSuffix: true,
-                  }
-                )}
+                {timeLimit
+                  ? `${formatDuration(
+                      intervalToDuration({
+                        start: new Date(),
+                        end: new Date(timeLimit),
+                      }),
+                      {
+                        format: ["days", "hours"],
+                      }
+                    )} left`
+                  : formatDistanceToNowStrict(
+                      convertUTCDateToLocalDate(nft.token_created),
+                      {
+                        addSuffix: true,
+                      }
+                    )}
               </Text>
             </>
           )}

--- a/packages/app/components/feed-item/css-feed-item.md.tsx
+++ b/packages/app/components/feed-item/css-feed-item.md.tsx
@@ -209,7 +209,7 @@ export const CssFeedItemMD = memo<FeedItemProps>(function FeedItemMD({
             </Text>
 
             <View tw="mt-6 flex-row items-center justify-between">
-              <Creator nft={nft} />
+              <Creator nft={nft} timeLimit={edition?.time_limit} />
             </View>
 
             <View tw="mt mb-4 h-5">

--- a/packages/app/components/feed-item/feed-item.md.tsx
+++ b/packages/app/components/feed-item/feed-item.md.tsx
@@ -200,7 +200,7 @@ export const FeedItemMD = memo<FeedItemProps>(function FeedItemMD({
               <RaffleTooltip edition={edition} tw="mr-1" />
             </View>
             <View tw="flex-row items-center justify-between">
-              <Creator nft={nft} />
+              <Creator nft={nft} timeLimit={edition?.time_limit} />
             </View>
             <View tw="mb-4 mr-4 flex-row items-center">
               <Text tw="text-lg font-bold text-black dark:text-white">


### PR DESCRIPTION
# Why

Regarding the thread in Slack, we want to add a countdown for the drop to let users know when it expires.  
![CleanShot 2023-09-01 at 12 52 08](https://github.com/showtime-xyz/showtime-frontend/assets/37520667/b96c8651-c4b8-4810-af8f-7e85d959840c)

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
