### PR TITLE
feat: add view channel button for home v2

### DIFF
--- a/packages/app/components/follow-button-small.tsx
+++ b/packages/app/components/follow-button-small.tsx
@@ -11,15 +11,29 @@ type ToggleFollowParams = ButtonProps & {
   name?: string;
   profileId: number;
   onToggleFollow?: () => void;
+  channelId?: number;
 };
 
 export const FollowButtonSmall = memo<ToggleFollowParams>(
-  function FollowButtonSmall({ profileId, name, tw = "", ...rest }) {
+  function FollowButtonSmall({ profileId, name, tw = "", channelId, ...rest }) {
     return (
       <FollowButton
         profileId={profileId}
         name={name}
-        renderButton={({ text, ...rest }) => {
+        renderButton={({ text, isFollowing, ...rest }) => {
+          if (channelId && isFollowing) {
+            return (
+              <Pressable
+                tw={[
+                  "h-[22px] items-center justify-center rounded-full bg-indigo-600 px-3.5",
+                  tw,
+                ]}
+                {...rest}
+              >
+                <Text tw="text-xs font-bold text-white">View Channel</Text>
+              </Pressable>
+            );
+          }
           return (
             <Pressable
               tw={[

--- a/packages/app/components/home/home-item.tsx
+++ b/packages/app/components/home/home-item.tsx
@@ -91,6 +91,7 @@ export const HomeItem = memo<{ nft: NFT; index: number; mediaSize: number }>(
                   <FollowButtonSmall
                     profileId={nft.creator_id}
                     name={nft.creator_username}
+                    channelId={detailData?.data.item?.creator_channel_id}
                     tw="mr-4"
                   />
                   <NFTDropdown


### PR DESCRIPTION
# Why
Since our endpoint already has the creator_channel_id field, we can show a View Channel button on the home if the user is already following a user. 
![image](https://github.com/showtime-xyz/showtime-frontend/assets/37520667/e0ec06b8-302e-4313-9fe8-3826d59ce9a0)

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
