### PR TITLE
reassign wallet on error code 409

### DIFF
--- a/packages/app/lib/add-wallet/add-wallet.ts
+++ b/packages/app/lib/add-wallet/add-wallet.ts
@@ -4,15 +4,17 @@ export const addWalletToBackend = async ({
   address,
   signature,
   nickname,
+  reassignWallet,
 }: {
   address: string;
   signature: string;
   nickname?: string;
+  reassignWallet?: boolean;
 }) => {
   return axios({
     url: `/v2/wallet/${address}/add`,
     method: "POST",
-    data: { address, signature, nickname },
+    data: { address, signature, nickname, reassign_wallet: reassignWallet },
   });
 };
 


### PR DESCRIPTION
# Why
If a wallet is already added, we receive an error code of 409. On receiving that we need to show a confirmation to reassign the wallet to the new profile.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->
