### PR TITLE
Rename Connect Wallet to Connect

### DIFF
--- a/.maestro/subflows/sign-up-with-wallet-android.yml
+++ b/.maestro/subflows/sign-up-with-wallet-android.yml
@@ -4,7 +4,7 @@ appId: io.showtime.development
 # - tapOn: "Showtime on Nishans-MacBook-Pro.local"
 - assertVisible: "Sign In"
 - tapOn: "Sign In"
-- tapOn: "Connect Wallet"
+- tapOn: "Connect"
 - assertNotVisible: "Sign In"
 - tapOn:
     point: "50%,94%"

--- a/.maestro/subflows/sign-up-with-wallet-ios.yml
+++ b/.maestro/subflows/sign-up-with-wallet-ios.yml
@@ -4,7 +4,7 @@ appId: io.showtime.development
 # - tapOn: "Showtime on Nishans-MacBook-Pro.local"
 - assertVisible: "Sign In"
 - tapOn: "Sign In"
-- tapOn: "Connect Wallet"
+- tapOn: "Connect"
 - assertNotVisible: "Sign In"
 - tapOn:
     point: "50%,94%"

--- a/packages/app/components/login/login-button.tsx
+++ b/packages/app/components/login/login-button.tsx
@@ -32,7 +32,7 @@ const BUTTON_TEXT = {
   facebook: "Continue with Facebook",
   twitter: "Continue with Twitter",
   email: "Continue with Email",
-  wallet: "Connect Wallet",
+  wallet: "Connect",
   social: "Back to social login",
 };
 const BUTTON_ICON = {


### PR DESCRIPTION
# Why
https://showtime-xyz.slack.com/archives/C02PXGK3V8D/p1693983930993909
As Alex said, we need to rename the "Connect Wallet" option to just "Connect" because it's cleaner. 

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
