### PR TITLE
fix: channel image and audio preview when locked

### DIFF
--- a/packages/app/components/audio-player/audio-player.tsx
+++ b/packages/app/components/audio-player/audio-player.tsx
@@ -26,10 +26,12 @@ export const AudioPlayer = memo(
     id,
     url,
     duration,
+    isViewable = true,
   }: {
     id: number;
     url: string;
     duration?: number | null;
+    isViewable?: boolean;
   }) => {
     const isDark = useIsDarkMode();
     const timeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -236,6 +238,13 @@ export const AudioPlayer = memo(
             </LeanText>
           </LeanView>
         </LeanView>
+        {!isViewable ? (
+          <LeanView tw="absolute bottom-0 left-0 right-0 top-0 items-center justify-center bg-gray-800 bg-opacity-90">
+            <LeanText tw="select-none text-center text-lg text-white dark:text-gray-300">
+              Unlock to listen
+            </LeanText>
+          </LeanView>
+        ) : null}
       </LeanView>
     );
   }

--- a/packages/app/components/creator-channels/components/image-preview.tsx
+++ b/packages/app/components/creator-channels/components/image-preview.tsx
@@ -5,7 +5,7 @@ import { Image } from "@showtime-xyz/universal.image";
 import { LightBox } from "@showtime-xyz/universal.light-box";
 
 import { ChannelMessageAttachment } from "../types";
-import { LeanView } from "./lean-text";
+import { LeanText, LeanView } from "./lean-text";
 
 const width = Dimensions.get("window").width;
 const height = Dimensions.get("window").height;
@@ -37,7 +37,13 @@ const getImageAttachmentHeight = (attachment: ChannelMessageAttachment) => {
 };
 
 export const ImagePreview = memo(
-  ({ attachment }: { attachment: ChannelMessageAttachment }) => {
+  ({
+    attachment,
+    isViewable,
+  }: {
+    attachment: ChannelMessageAttachment;
+    isViewable?: boolean;
+  }) => {
     const imageAttachmentWidth = useMemo(
       () => getImageAttachmentWidth(attachment),
       [attachment]
@@ -68,11 +74,12 @@ export const ImagePreview = memo(
 
     return (
       <LeanView
-        tw="web:cursor-pointer overflow-hidden rounded-xl bg-gray-600"
+        tw="overflow-hidden rounded-xl bg-gray-600"
         style={{
           width: imageAttachmentWidth,
           height: imageAttachmentHeight,
         }}
+        pointerEvents={isViewable ? "auto" : "none"}
       >
         <LightBox
           width={imageAttachmentWidth}
@@ -99,6 +106,7 @@ export const ImagePreview = memo(
           }
         >
           <Image
+            tw="web:cursor-pointer"
             transition={100}
             recyclingKey={attachment?.media_upload}
             source={
@@ -113,6 +121,13 @@ export const ImagePreview = memo(
             }}
           />
         </LightBox>
+        {!isViewable ? (
+          <LeanView tw="absolute bottom-0 left-0 right-0 top-0 items-center justify-center bg-gray-800 bg-opacity-90">
+            <LeanText tw="text-center text-lg text-white dark:text-gray-300">
+              Unlock to view
+            </LeanText>
+          </LeanView>
+        ) : null}
       </LeanView>
     );
   }

--- a/packages/app/components/creator-channels/components/message-input.tsx
+++ b/packages/app/components/creator-channels/components/message-input.tsx
@@ -238,7 +238,9 @@ export const MessageInput = memo(
 
               <MessageBox
                 ref={inputRef}
-                placeholder="Send an update..."
+                placeholder={
+                  isUserAdmin ? "Send an update..." : "Write a message..."
+                }
                 textInputProps={{
                   maxLength: 2000,
                 }}

--- a/packages/app/components/creator-channels/components/message-item.tsx
+++ b/packages/app/components/creator-channels/components/message-item.tsx
@@ -373,7 +373,7 @@ export const MessageItem = memo(
                   </LeanView>
                 ) : (
                   <>
-                    <LeanText tw="text-sm text-gray-900  dark:text-gray-100">
+                    <LeanText tw="py-1.5 text-sm  text-gray-900 dark:text-gray-100">
                       {loremText}
                     </LeanText>
                     <BlurView

--- a/packages/app/components/creator-channels/components/message-item.tsx
+++ b/packages/app/components/creator-channels/components/message-item.tsx
@@ -392,7 +392,6 @@ export const MessageItem = memo(
               <>
                 {item.channel_message.body_text_length > 0 ? (
                   <LeanText
-                    selectable
                     tw={"text-sm text-gray-900 dark:text-gray-100"}
                     style={
                       Platform.OS === "web"
@@ -405,10 +404,7 @@ export const MessageItem = memo(
                   >
                     {linkifiedMessage}
                     {messageWasEdited && (
-                      <LeanText
-                        tw="text-xs text-gray-500 dark:text-gray-200"
-                        selectable
-                      >
+                      <LeanText tw="text-xs text-gray-500 dark:text-gray-200">
                         {` • edited`}
                       </LeanText>
                     )}
@@ -432,7 +428,10 @@ export const MessageItem = memo(
 
             {item.channel_message?.attachments?.length > 0 &&
             item.channel_message?.attachments[0].mime.includes("image") ? (
-              <ImagePreview attachment={item.channel_message?.attachments[0]} />
+              <ImagePreview
+                attachment={item.channel_message?.attachments[0]}
+                isViewable={permissions?.can_view_creator_messages}
+              />
             ) : null}
 
             {item.channel_message?.attachments?.length > 0 &&
@@ -441,6 +440,7 @@ export const MessageItem = memo(
                 id={item.channel_message.id}
                 url={item.channel_message.attachments[0]?.url}
                 duration={item.channel_message.attachments[0]?.duration}
+                isViewable={permissions?.can_view_creator_messages}
               />
             ) : null}
             {item.reaction_group.length > 0 ? (


### PR DESCRIPTION
# Why
Also fixed issues with [wrong network lost toast](https://showtime-xyz.slack.com/archives/C02PXGK3V8D/p1695744518713609)


<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
