### PR TITLE
feat: check primary wallet is not magic wallet

### DIFF
--- a/packages/app/components/settings/settings-wallet-item.tsx
+++ b/packages/app/components/settings/settings-wallet-item.tsx
@@ -194,7 +194,7 @@ export const SettingsWalletItem = (props: Props) => {
             <Hidden from="md">
               <MakePrimaryBtn
                 isPrimary={isPrimary}
-                onPress={() => setPrimaryWallet(wallet)}
+                onPress={() => setPrimaryWallet(wallet.address)}
               />
             </Hidden>
             <Text tw="text-sm text-gray-900 dark:text-white">{address}</Text>
@@ -204,7 +204,7 @@ export const SettingsWalletItem = (props: Props) => {
             <Hidden until="md">
               <MakePrimaryBtn
                 isPrimary={isPrimary}
-                onPress={() => setPrimaryWallet(wallet)}
+                onPress={() => setPrimaryWallet(wallet.address)}
               />
             </Hidden>
             <WalletDropdownMenu

--- a/packages/app/hooks/api/use-set-primary-wallet.ts
+++ b/packages/app/hooks/api/use-set-primary-wallet.ts
@@ -2,7 +2,6 @@ import { useSWRConfig } from "swr";
 
 import { axios } from "app/lib/axios";
 import { MY_INFO_ENDPOINT } from "app/providers/user-provider";
-import { WalletAddressesExcludingEmailV2 } from "app/types";
 
 let onPrimaryWalletSetCallback: any = null;
 
@@ -12,10 +11,10 @@ export const setPrimaryWalletSuccessCallback = (cb?: Function) => {
 export const useSetPrimaryWallet = () => {
   const { mutate } = useSWRConfig();
 
-  const setPrimaryWallet = async (wallet: WalletAddressesExcludingEmailV2) => {
+  const setPrimaryWallet = async (walletAddress: string) => {
     mutate(MY_INFO_ENDPOINT, async () => {
       await axios({
-        url: `/v2/wallet/${wallet.address}/primary`,
+        url: `/v2/wallet/${walletAddress}/primary`,
         method: "PATCH",
         data: {},
       });

--- a/packages/app/hooks/creator-token/use-creator-token-opt-in.ts
+++ b/packages/app/hooks/creator-token/use-creator-token-opt-in.ts
@@ -5,13 +5,34 @@ import { useAlert } from "@showtime-xyz/universal.alert";
 
 import { axios } from "app/lib/axios";
 import { Logger } from "app/lib/logger";
-import { formatAPIErrorMessage } from "app/utilities";
+import { formatAPIErrorMessage, formatAddressShort } from "app/utilities";
+
+import { useSetPrimaryWallet } from "../api/use-set-primary-wallet";
+import { useAuth } from "../auth/use-auth";
+import { useUser } from "../use-user";
+import { useWallet } from "../use-wallet";
 
 export const useCreatorTokenOptIn = () => {
   const Alert = useAlert();
+  const wallet = useWallet();
+  const user = useUser();
+  const { setPrimaryWallet } = useSetPrimaryWallet();
+  const auth = useAuth();
+
   const state = useSWRMutation(
     "creatorTokenOptIn",
     async (_url: string, { arg }: { arg?: { inviteCode: string } }) => {
+      // if primary wallet is magic, we don't support creating tokens
+      if (
+        user.user?.data.profile.primary_wallet?.is_apple ||
+        user.user?.data.profile.primary_wallet?.is_google ||
+        user.user?.data.profile.primary_wallet?.is_phone ||
+        user.user?.data.profile.primary_wallet?.is_twitter ||
+        user.user?.data.profile.primary_wallet?.is_email
+      ) {
+        await setPrimaryIfMagic();
+      }
+
       return axios({
         url: "/v1/profile/creator-tokens/optin",
         method: "POST",
@@ -29,6 +50,44 @@ export const useCreatorTokenOptIn = () => {
       },
     }
   );
+
+  const setPrimaryIfMagic = () => {
+    return new Promise<void>((resolve, reject) => {
+      // Current logged in wallet is magic, we ask user to login using a regular web3 wallet
+      if (wallet.isMagicWallet) {
+        Alert.alert(
+          "Unsupported wallet",
+          "Please login using a web3 wallet to create the creator token",
+          [
+            {
+              text: "Log out",
+              onPress: () => {
+                auth.logout();
+                reject();
+              },
+            },
+          ]
+        );
+      } else {
+        Alert.alert(
+          "Unsupported wallet set to Primary",
+          ` Would you like to set current wallet (${formatAddressShort(
+            wallet.address
+          )}) to Primary? Primary wallet is used to create the creator token.`,
+          [
+            {
+              text: "Okay",
+              onPress: async () => {
+                if (wallet.address) {
+                  setPrimaryWallet(wallet.address).then(resolve).catch(reject);
+                }
+              },
+            },
+          ]
+        );
+      }
+    });
+  };
 
   return state;
 };

--- a/packages/app/hooks/use-add-wallet.ts
+++ b/packages/app/hooks/use-add-wallet.ts
@@ -85,7 +85,7 @@ const useAddWallet = () => {
 
                     // automatically set the primary wallet on add wallet if user doesn't have one
                     if (hasNoPrimaryWallet) {
-                      setPrimaryWallet(addedWallet);
+                      setPrimaryWallet(addedWallet.address);
                     }
                   }
                 },
@@ -105,7 +105,7 @@ const useAddWallet = () => {
 
             // automatically set the primary wallet on add wallet if user doesn't have one
             if (hasNoPrimaryWallet) {
-              setPrimaryWallet(addedWallet);
+              setPrimaryWallet(addedWallet.address);
             }
           }
         }
@@ -135,7 +135,7 @@ const useAddWallet = () => {
 
                   // automatically set the primary wallet on add wallet if user doesn't have one
                   if (hasNoPrimaryWallet) {
-                    setPrimaryWallet(addedWallet);
+                    setPrimaryWallet(addedWallet.address);
                   }
                 }
               },


### PR DESCRIPTION
# Why
Backend deploys the creator token contract using primary wallet. We need to make sure it is not set to magic. If it is set to magic, we provide some alerts to use the web3 wallet.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->


<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
