### PR TITLE
fix: add root shared value to as dep instead of .value

### DIFF
--- a/packages/app/components/creator-channels/components/message-item.tsx
+++ b/packages/app/components/creator-channels/components/message-item.tsx
@@ -114,7 +114,7 @@ export const MessageItem = memo(
         backgroundColor: "transparent",
         borderRadius: 0,
       };
-    }, [isDark, editMessageIdSharedValue.value, channel_message.id]);
+    }, [isDark, editMessageIdSharedValue, channel_message.id]);
 
     // check if message was edited
     const messageWasEdited = useMemo(() => {


### PR DESCRIPTION
# Why
The `.value` should be removed from the `deps` array when using `useSharedValue`. This is necessary for it to work on the web.

Fixes #2458 

Thanks, @nandorojo!

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

Removed .value and use the root shared value.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
