### PR TITLE
fix: open edit wallet nickname modal

### DIFF
--- a/packages/app/components/settings/setting-edit-nickname-moda.tsx
+++ b/packages/app/components/settings/setting-edit-nickname-moda.tsx
@@ -13,10 +13,12 @@ import { WalletAddressesV2 } from "app/types";
 export type EditNicknameModalProps = {
   editingWallet?: WalletAddressesV2;
   onClose: any;
+  visible: boolean;
 };
 export const EditNicknameModal = ({
   editingWallet,
   onClose,
+  visible = false,
 }: EditNicknameModalProps) => {
   const [nickname, setNickname] = useState("");
   const { editWalletNickName } = useAddWalletNickname();
@@ -34,9 +36,13 @@ export const EditNicknameModal = ({
       AvoidSoftInput.setEnabled(true);
     };
   }, [editingWallet?.nickname]);
-
   return (
-    <Modal tw="bottom-16 md:bottom-0" onClose={onClose} title="Edit Nickname">
+    <Modal
+      tw="bottom-16 md:bottom-0"
+      onClose={onClose}
+      visible={visible}
+      title="Edit Nickname"
+    >
       <View tw="p-4">
         <Fieldset
           placeholder="rainbow wallet"

--- a/packages/app/components/settings/setting.md.tsx
+++ b/packages/app/components/settings/setting.md.tsx
@@ -57,12 +57,11 @@ export const SettingsMd = () => {
       </View>
 
       <View style={{ height: bottomHeight }} />
-      {editingWallet ? (
-        <EditNicknameModal
-          editingWallet={editingWallet}
-          onClose={() => setEditingWallet(undefined)}
-        />
-      ) : null}
+      <EditNicknameModal
+        editingWallet={editingWallet}
+        visible={!!editingWallet}
+        onClose={() => setEditingWallet(undefined)}
+      />
     </View>
   );
 };

--- a/packages/design-system/modal/modal.container.web.tsx
+++ b/packages/design-system/modal/modal.container.web.tsx
@@ -47,7 +47,7 @@ const ModalContainerComponent = forwardRef<ModalMethods, ModalContainerProps>(
       disableBackdropPress,
       tw: propTw = "",
       headerShown = true,
-      visible,
+      visible = false,
       closeButtonProps,
     }: ModalContainerProps,
     ref


### PR DESCRIPTION
# Why
For the Modal component, if it is opened, you need to pass a `visible` field. 
Currently, if it doesn't pass this field, it will cause an error because the `Transition` component only accepts `true` or `false`. 

# How

I just made "visible" false by default. This change will no longer cause any broken.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
