### PR TITLE
Use the ChatGPT generated gas price padding function when purchasing a creator token

### DIFF
--- a/packages/app/hooks/creator-token/use-creator-token-buy.ts
+++ b/packages/app/hooks/creator-token/use-creator-token-buy.ts
@@ -24,6 +24,24 @@ import {
 import { useSwitchChain } from "./use-switch-chain";
 import { baseChain } from "./utils";
 
+type BigIntish = string | number | bigint; // Define BigIntish type
+const paddedGasPrice = (
+  estimatedGasPrice: BigIntish,
+  paddingPercentage: number
+): bigint => {
+  const estimatedPriceBigInt = BigInt(estimatedGasPrice);
+  const paddedPriceBigInt =
+    (estimatedPriceBigInt * BigInt(paddingPercentage)) / BigInt(100);
+
+  Logger.log(
+    "padding estimated gas price, estimated -> padded ",
+    estimatedGasPrice,
+    paddedPriceBigInt.toString()
+  );
+
+  return paddedPriceBigInt;
+};
+
 export const useCreatorTokenBuy = (params: {
   username?: string;
   tokenAmount: number;
@@ -76,6 +94,11 @@ export const useCreatorTokenBuy = (params: {
                 args: [priceToBuyNext.data?.totalPrice],
                 chain: baseChain,
               });
+
+              if (request.gasPrice) {
+                request.gasPrice = paddedGasPrice(request.gasPrice, 110);
+              }
+
               requestPayload = request;
             } else {
               const { request } = await publicClient.simulateContract({
@@ -86,6 +109,11 @@ export const useCreatorTokenBuy = (params: {
                 args: [tokenAmount, priceToBuyNext.data?.totalPrice],
                 chain: baseChain,
               });
+
+              if (request.gasPrice) {
+                request.gasPrice = paddedGasPrice(request.gasPrice, 110);
+              }
+
               Logger.log("bulk buy ", request);
               requestPayload = request;
             }


### PR DESCRIPTION
# Why

The simulated contract function request payload seems to have discrepancies with the quoted gas price between the Alchemy rpc and the user wallet rpc.

# How

https://showtime-xyz.slack.com/archives/C02PXGK3V8D/p1698699732510189

I took whatever chat gpt did here and added it in the `useCreatorTokenBuy` hook.

This doesn't seem correct though. Because this is an eip 1559 transaction but gas price is [not an eip 1559](https://viem.sh/docs/contract/writeContract.html#gasprice-optional) thing.

We probably need to do this to the following:
- https://viem.sh/docs/contract/writeContract.html#maxfeepergas-optional
- https://viem.sh/docs/contract/writeContract.html#maxpriorityfeepergas-optional
- Potentially https://viem.sh/docs/contract/writeContract.html#gas-optional the raw gas param, but this turns off the auto estimate which is also not good...

# Test Plan

Staging