### PR TITLE
fix: pad gas price to fix underpriced transaction

### DIFF
--- a/packages/app/hooks/creator-token/use-creator-token-buy.ts
+++ b/packages/app/hooks/creator-token/use-creator-token-buy.ts
@@ -78,7 +78,7 @@ export const useCreatorTokenBuy = (params: {
                 chain: baseChain,
               });
               requestPayload = request;
-              console.log("token amount 1 request ", request);
+              console.log("token amount 1 simulation ", request);
             } else {
               const { request } = await publicClient.simulateContract({
                 address: profileData?.data?.profile.creator_token.address,
@@ -94,17 +94,20 @@ export const useCreatorTokenBuy = (params: {
 
             console.log("simulate ", requestPayload);
 
-            console.log(requestPayload?.chain?.rpcUrls.default.http[0]);
+            console.log(
+              "Using following RPC for determing gas price",
+              requestPayload?.chain?.rpcUrls.default.http[0]
+            );
             // Fetch current gas price from the Ethereum network
             const provider = new providers.JsonRpcProvider(
               requestPayload?.chain?.rpcUrls.default.http[0]
-            ); // Replace `INFURA_URL` with your Ethereum RPC URL
+            );
             let currentGasPrice = await provider.getGasPrice();
-            console.log("current Gas price", currentGasPrice);
+            console.log("current Gas price fetched from RPC", currentGasPrice);
 
-            // Adjust the gas price (e.g., increase it by 20% to be more competitive)
+            // Adjust the gas price (increase it by 20% to be more competitive)
             const paddedGasPrice = currentGasPrice.mul(120).div(100);
-            console.log("padded gas price", paddedGasPrice);
+            console.log("padded gas price after calculation:", paddedGasPrice);
 
             const transactionHash = await walletClient?.writeContract?.({
               ...requestPayload,


### PR DESCRIPTION
# Why

We're receiving plenty of "transaction underpriced" error messages - this queries the current gas price from ethers.js, adds a 20% padding and pass gasPrice to the writeContract.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
