### PR TITLE
fix: redirect to profile screen after onboarded

### DIFF
--- a/packages/app/components/profile/complete-profile-button.tsx
+++ b/packages/app/components/profile/complete-profile-button.tsx
@@ -3,9 +3,8 @@ import { Platform } from "react-native";
 import { Button, GradientButton } from "@showtime-xyz/universal.button";
 import { useRouter } from "@showtime-xyz/universal.router";
 
+import { useOnboardingPromise } from "app/components/onboarding";
 import { useUser } from "app/hooks/use-user";
-
-import { useOnboardingPromise } from "../onboarding";
 
 export const CompleteProfileButton = ({ isSelf }: { isSelf: boolean }) => {
   const router = useRouter();

--- a/packages/app/components/profile/complete-profile-button.tsx
+++ b/packages/app/components/profile/complete-profile-button.tsx
@@ -3,19 +3,23 @@ import { Platform } from "react-native";
 import { Button, GradientButton } from "@showtime-xyz/universal.button";
 import { useRouter } from "@showtime-xyz/universal.router";
 
-import { useRedirectToCreateDrop } from "app/hooks/use-redirect-to-create-drop";
 import { useUser } from "app/hooks/use-user";
+
+import { useOnboardingPromise } from "../onboarding";
 
 export const CompleteProfileButton = ({ isSelf }: { isSelf: boolean }) => {
   const router = useRouter();
   const { isIncompletedProfile } = useUser();
-  const redirectToCreateDrop = useRedirectToCreateDrop();
+  const { onboardingPromise } = useOnboardingPromise();
+
   if (!isSelf) return null;
   if (isIncompletedProfile) {
     return (
       <GradientButton
         size="small"
-        onPress={redirectToCreateDrop}
+        onPress={async () => {
+          await onboardingPromise();
+        }}
         labelTW={"color-white"}
         style={{ height: 28, paddingVertical: 0 }}
         gradientProps={{


### PR DESCRIPTION
# Why 

Now we will redirect to the create drop screen after being onboarded. Actually, it should redirect to the profile screen. 

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
