### PR TITLE
fix: wait for 2 confirmations

### DIFF
--- a/packages/app/components/creator-token/buy-creator-token.tsx
+++ b/packages/app/components/creator-token/buy-creator-token.tsx
@@ -55,12 +55,12 @@ const PAYMENT_METHODS = __DEV__
     ]
   : [
       {
-        title: "USDC",
-        value: "USDC",
-      },
-      {
         title: "ETH",
         value: "ETH",
+      },
+      {
+        title: "USDC",
+        value: "USDC",
       },
     ];
 const SELECT_LIST = [
@@ -266,7 +266,7 @@ export const BuyCreatorToken = () => {
                     options={
                       selectedAction === "buy"
                         ? PAYMENT_METHODS
-                        : PAYMENT_METHODS.slice(0, 1)
+                        : PAYMENT_METHODS.filter((m) => m.value === "USDC")
                     }
                     value={paymentMethod}
                     onChange={(value: any) => setPaymentMethod(value)}

--- a/packages/app/hooks/creator-token/use-creator-token-approve.ts
+++ b/packages/app/hooks/creator-token/use-creator-token-approve.ts
@@ -76,7 +76,7 @@ export const useApproveToken = () => {
             const transaction = await publicClient.waitForTransactionReceipt({
               hash,
               pollingInterval: 2000,
-              confirmations: 3,
+              confirmations: 2,
             });
             if (transaction.status === "success") {
               return true;

--- a/packages/app/hooks/creator-token/use-creator-token-buy.ts
+++ b/packages/app/hooks/creator-token/use-creator-token-buy.ts
@@ -165,6 +165,7 @@ export const useCreatorTokenBuy = (params: {
               const transaction = await publicClient.waitForTransactionReceipt({
                 hash: transactionHash,
                 pollingInterval: 2000,
+                confirmations: 2,
               });
 
               if (transaction.status === "success") {

--- a/packages/app/hooks/creator-token/use-creator-token-sell.ts
+++ b/packages/app/hooks/creator-token/use-creator-token-sell.ts
@@ -128,6 +128,7 @@ export const useCreatorTokenSell = () => {
           const transaction = await publicClient.waitForTransactionReceipt({
             hash: txHash as any,
             pollingInterval: 2000,
+            confirmations: 2,
           });
 
           if (transaction.status === "success") {


### PR DESCRIPTION
# Why
- backend api can throw transaction not found error as we trigger it soon after one block confirmation - https://showtime-xyz.slack.com/archives/C02PXGK3V8D/p1698811424282289
- To fix it from the root we need subgraph in backend which are in progress.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

