### PR TITLE
fix: mobile web create button was still visible

### DIFF
--- a/packages/app/components/footer/index.tsx
+++ b/packages/app/components/footer/index.tsx
@@ -1,3 +1,4 @@
+import { useContext } from "react";
 import { useWindowDimensions } from "react-native";
 
 import { useIsDarkMode } from "@showtime-xyz/universal.hooks";
@@ -5,6 +6,7 @@ import { useRouter } from "@showtime-xyz/universal.router";
 import { View } from "@showtime-xyz/universal.view";
 
 import { MOBILE_WEB_TABS_HEIGHT } from "app/constants/layout";
+import { UserContext } from "app/context/user-context";
 import {
   HIDE_MOBILE_WEB_FOOTER_SCREENS,
   SWIPE_LIST_SCREENS,
@@ -19,6 +21,7 @@ import {
 import { useNavigationElements } from "app/navigation/use-navigation-elements";
 
 const Footer = () => {
+  const user = useContext(UserContext);
   const router = useRouter();
   const isDark = useIsDarkMode();
   const isDarkThemePage = SWIPE_LIST_SCREENS.includes(router.pathname);
@@ -32,6 +35,11 @@ const Footer = () => {
 
   const { width } = useWindowDimensions();
   const { isTabBarHidden } = useNavigationElements();
+
+  const canCreateMusicDrop =
+    !!user?.user?.data.profile.bypass_track_ownership_validation ||
+    !!user?.user?.data.profile.spotify_artist_id ||
+    !!user?.user?.data.profile.apple_music_artist_id;
 
   if (width >= 768) {
     return null;
@@ -65,11 +73,13 @@ const Footer = () => {
         color={color}
         focused={router.pathname === "/channels"}
       />
-      <CreateTabBarIcon
-        color={buttonColor}
-        focused={router.pathname === "/drop"}
-        style={{ backgroundColor: buttonBackgroundColor }}
-      />
+      {canCreateMusicDrop && (
+        <CreateTabBarIcon
+          color={buttonColor}
+          focused={router.pathname === "/drop"}
+          style={{ backgroundColor: buttonBackgroundColor }}
+        />
+      )}
       <NotificationsTabBarIcon
         color={color}
         focused={router.pathname === "/notifications"}


### PR DESCRIPTION
# Why

The bottom tabs + icon was still showed on mobile web, since its a dedicated component.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How
Added the canCreateMusicDrop condition for mobile web footer

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
