### PR TITLE
Show channel messages button on profile screen even if empty

### DIFF
--- a/packages/app/components/creator-channels/types.ts
+++ b/packages/app/components/creator-channels/types.ts
@@ -154,15 +154,17 @@ export type Channel = {
   owner: ChannelProfile;
 };
 
+export type ChannelPermissions = {
+  can_send_messages: boolean;
+  can_upload_media: boolean;
+  can_view_creator_messages: boolean;
+  can_view_public_messages: boolean;
+};
+
 export type ChannelById = {
   viewer_has_unlocked_messages: boolean;
   latest_paid_nft_slug?: string;
-  permissions: {
-    can_send_messages: boolean;
-    can_upload_media: boolean;
-    can_view_creator_messages: boolean;
-    can_view_public_messages: boolean;
-  };
+  permissions: ChannelPermissions | null;
 } & Channel;
 
 export type ChannelSetting = {

--- a/packages/app/components/profile/profile.tsx
+++ b/packages/app/components/profile/profile.tsx
@@ -126,6 +126,10 @@ const Profile = ({ username }: ProfileScreenProps) => {
     return profileData?.data?.profile?.channels?.[0]?.message_count || 0;
   }, [profileData?.data?.profile.channels]);
 
+  const channelPermissions = useMemo(() => {
+    return profileData?.data?.profile?.channels?.[0]?.permissions;
+  }, [profileData?.data?.profile.channels]);
+
   const renderScene = useCallback(
     ({
       route: { index: routeIndex, key },
@@ -144,6 +148,7 @@ const Profile = ({ username }: ProfileScreenProps) => {
             channelId={channelId}
             isSelf={isSelf}
             messageCount={messageCount}
+            channelPermissions={channelPermissions}
           />
         );
       }
@@ -177,6 +182,7 @@ const Profile = ({ username }: ProfileScreenProps) => {
       channelId,
       isSelf,
       messageCount,
+      channelPermissions,
       tabRefs,
     ]
   );

--- a/packages/app/components/profile/profile.web.tsx
+++ b/packages/app/components/profile/profile.web.tsx
@@ -108,6 +108,10 @@ const Profile = ({ username }: ProfileScreenProps) => {
     return profileData?.data?.profile?.channels?.[0]?.message_count || 0;
   }, [profileData?.data?.profile.channels]);
 
+  const channelPermissions = useMemo(() => {
+    return profileData?.data?.profile?.channels?.[0]?.permissions;
+  }, [profileData?.data?.profile.channels]);
+
   const routes = useMemo(() => formatProfileRoutes(data?.tabs), [data?.tabs]);
 
   const [queryTab] = useParam("type", {
@@ -301,6 +305,7 @@ const Profile = ({ username }: ProfileScreenProps) => {
                     channelId={channelId}
                     isSelf={isSelf}
                     messageCount={messageCount}
+                    channelPermissions={channelPermissions}
                   />
                 ) : null}
                 {type === "song_drops_created" && isSelf ? (

--- a/packages/app/components/profile/tokens-tab.tsx
+++ b/packages/app/components/profile/tokens-tab.tsx
@@ -114,7 +114,7 @@ export const TokensTabHeader = ({
       */}
 
       {isSelf && <MyCollection />}
-      {channelId && messageCount && messageCount >= 0 ? (
+      {channelId && (messageCount || messageCount == 0) && messageCount >= 0 ? (
         <Pressable
           onPress={() => {
             router.push(`/channels/${channelId}`);

--- a/packages/app/components/profile/tokens-tab.tsx
+++ b/packages/app/components/profile/tokens-tab.tsx
@@ -122,9 +122,15 @@ export const TokensTabHeader = ({
           tw="mt-6 rounded-xl border border-gray-200 bg-white px-4 dark:border-gray-700 dark:bg-gray-900"
         >
           <View tw="flex-row items-center justify-between py-4">
-            <Text tw="text-13 font-bold text-gray-900 dark:text-gray-50">
-              {formatNumber(messageCount || 0)} Channel messages
-            </Text>
+            {messageCount === 0 ? (
+              <Text tw="text-13 font-bold text-gray-900 dark:text-gray-50">
+                View Channel messages
+              </Text>
+            ) : (
+              <Text tw="text-13 font-bold text-gray-900 dark:text-gray-50">
+                {formatNumber(messageCount || 0)} Channel messages
+              </Text>
+            )}
             <ChevronRight width={20} height={20} color={colors.gray[500]} />
           </View>
           {/* TODO: Creator tokens P1

--- a/packages/app/components/profile/tokens-tab.tsx
+++ b/packages/app/components/profile/tokens-tab.tsx
@@ -140,7 +140,9 @@ export const TokensTabHeader = ({
           <View tw="flex-row items-center justify-between py-4">
             <View tw="flex-row items-center justify-between">
               <View tw="-mt-0.5 mr-2">
-                {channelPermissions?.can_view_creator_messages ? (
+                {(channelPermissions &&
+                  !channelPermissions?.can_view_creator_messages) ||
+                !channelPermissions ? (
                   <Lock
                     width={20}
                     height={20}
@@ -161,7 +163,8 @@ export const TokensTabHeader = ({
                 </Text>
               ) : (
                 <Text tw="text-13 font-bold text-gray-900 dark:text-gray-50">
-                  {!channelPermissions?.can_view_creator_messages
+                  {channelPermissions &&
+                  !channelPermissions?.can_view_creator_messages
                     ? `You've unlocked ${channelMessageCountFormatted} messages`
                     : `Channel locked (${channelMessageCountFormatted} messages)`}
                 </Text>

--- a/packages/app/components/profile/tokens-tab.tsx
+++ b/packages/app/components/profile/tokens-tab.tsx
@@ -114,7 +114,7 @@ export const TokensTabHeader = ({
       */}
 
       {isSelf && <MyCollection />}
-      {channelId && messageCount && messageCount > 0 ? (
+      {channelId && messageCount && messageCount >= 0 ? (
         <Pressable
           onPress={() => {
             router.push(`/channels/${channelId}`);

--- a/packages/app/components/profile/tokens-tab.tsx
+++ b/packages/app/components/profile/tokens-tab.tsx
@@ -4,13 +4,20 @@ import React, {
   forwardRef,
   useImperativeHandle,
   useRef,
+  useMemo,
 } from "react";
 
 import type { ListRenderItemInfo } from "@shopify/flash-list";
 
 import { Button } from "@showtime-xyz/universal.button";
 import { useIsDarkMode } from "@showtime-xyz/universal.hooks";
-import { ChevronRight } from "@showtime-xyz/universal.icon";
+import {
+  ChevronRight,
+  Lock,
+  LockBadge,
+  LockRounded,
+  UnLocked,
+} from "@showtime-xyz/universal.icon";
 import { Pressable } from "@showtime-xyz/universal.pressable";
 import { useRouter } from "@showtime-xyz/universal.router";
 import {
@@ -25,17 +32,19 @@ import { View, ViewProps } from "@showtime-xyz/universal.view";
 import { ProfileTabsNFTProvider } from "app/context/profile-tabs-nft-context";
 import { List, useProfileNFTs } from "app/hooks/api-hooks";
 import { useContentWidth } from "app/hooks/use-content-width";
-import { getNFTSlug } from "app/hooks/use-share-nft";
 import { useUser } from "app/hooks/use-user";
 import { useScrollToTop } from "app/lib/react-navigation/native";
 import { MutateProvider } from "app/providers/mutate-provider";
 import { NFT } from "app/types";
 import { formatNumber } from "app/utilities";
 
+import SvgUnlocked from "design-system/icon/Unlocked";
+
+import { ChannelPermissions } from "../creator-channels/types";
 import { EmptyPlaceholder } from "../empty-placeholder";
 import { FilterContext } from "./fillter-context";
 import { MyCollection } from "./my-collection";
-import { ProfileFooter, ProfileSpinnerFooter } from "./profile-footer";
+import { ProfileSpinnerFooter } from "./profile-footer";
 
 type TabListProps = {
   username?: string;
@@ -52,13 +61,20 @@ export const TokensTabHeader = ({
   channelId,
   isSelf,
   messageCount,
+  channelPermissions,
 }: {
   channelId: number | null | undefined;
   messageCount?: number | null;
   isSelf: boolean;
+  channelPermissions?: ChannelPermissions | null;
 }) => {
   const isDark = useIsDarkMode();
   const router = useRouter();
+
+  const channelMessageCountFormatted = useMemo(
+    () => formatNumber(messageCount || 0),
+    [messageCount]
+  );
 
   return (
     <View tw="w-full px-4">
@@ -122,15 +138,35 @@ export const TokensTabHeader = ({
           tw="mt-6 rounded-xl border border-gray-200 bg-white px-4 dark:border-gray-700 dark:bg-gray-900"
         >
           <View tw="flex-row items-center justify-between py-4">
-            {messageCount === 0 ? (
-              <Text tw="text-13 font-bold text-gray-900 dark:text-gray-50">
-                View Channel messages
-              </Text>
-            ) : (
-              <Text tw="text-13 font-bold text-gray-900 dark:text-gray-50">
-                {formatNumber(messageCount || 0)} Channel messages
-              </Text>
-            )}
+            <View tw="flex-row items-center justify-between">
+              <View tw="-mt-0.5 mr-2">
+                {channelPermissions?.can_view_creator_messages ? (
+                  <Lock
+                    width={20}
+                    height={20}
+                    stroke={isDark ? "white" : colors.gray[500]}
+                  />
+                ) : (
+                  <UnLocked
+                    stroke={isDark ? "white" : colors.gray[500]}
+                    width={20}
+                    height={20}
+                  />
+                )}
+              </View>
+
+              {messageCount === 0 ? (
+                <Text tw="text-13 font-bold text-gray-900 dark:text-gray-50">
+                  View Channel
+                </Text>
+              ) : (
+                <Text tw="text-13 font-bold text-gray-900 dark:text-gray-50">
+                  {!channelPermissions?.can_view_creator_messages
+                    ? `You've unlocked ${channelMessageCountFormatted} messages`
+                    : `Channel locked (${channelMessageCountFormatted} messages)`}
+                </Text>
+              )}
+            </View>
             <ChevronRight width={20} height={20} color={colors.gray[500]} />
           </View>
           {/* TODO: Creator tokens P1
@@ -230,6 +266,7 @@ export const TokensTab = forwardRef<
   TabListProps & {
     channelId: number | null | undefined;
     messageCount?: number | null;
+    channelPermissions?: ChannelPermissions | null;
     isSelf: boolean;
   }
 >(function ProfileTabList(
@@ -241,6 +278,7 @@ export const TokensTab = forwardRef<
     index,
     channelId,
     messageCount,
+    channelPermissions,
     isSelf,
   },
   ref
@@ -288,9 +326,10 @@ export const TokensTab = forwardRef<
         channelId={channelId}
         isSelf={isSelf}
         messageCount={messageCount}
+        channelPermissions={channelPermissions}
       />
     ),
-    [channelId, isSelf, messageCount]
+    [channelId, channelPermissions, isSelf, messageCount]
   );
   const keyExtractor = useCallback((item: NFT) => `${item?.nft_id}`, []);
 

--- a/packages/app/types.ts
+++ b/packages/app/types.ts
@@ -1,3 +1,4 @@
+import { ChannelPermissions } from "./components/creator-channels/types";
 import { DropPlan } from "./hooks/use-paid-drop-plans";
 
 export type BunnyVideoUrls = {
@@ -154,6 +155,7 @@ export interface Profile {
     name: string;
     self_is_member: boolean;
     message_count: number;
+    permissions: ChannelPermissions | null;
   }>;
   website_url: string;
   username: string;


### PR DESCRIPTION
# Why

<img width="1030" alt="Screenshot 2023-11-01 at 11 24 45 AM" src="https://github.com/showtime-xyz/showtime-frontend/assets/7495489/f1cc2e4b-86c1-4820-8cc4-2824e9ba6901">

I deleted a channel message locally but it was the only message in the channel. Then it looked like the channel did not exist. I did see it in the channels list though.

This is a problem only because i fixed https://linear.app/showtime/issue/SHOW2-2303/deleted-messages-are-included-in-profile-channel-message-count

Now we can see it:
<img width="1028" alt="Screenshot 2023-11-01 at 11 32 17 AM" src="https://github.com/showtime-xyz/showtime-frontend/assets/7495489/ce7418ce-ccd0-4496-8a24-0f2b0dcaf1f7">


# How

Validate message count is `>= 0` to display

# Test Plan

Locally and in staging
