### PR TITLE
fix: disable sign in tab

### DIFF
--- a/packages/app/components/settings/settings-wallet-item.tsx
+++ b/packages/app/components/settings/settings-wallet-item.tsx
@@ -124,10 +124,16 @@ const LoginWithTitle = ({
 const MakePrimaryBtn = ({
   isPrimary,
   onPress,
+  isMagicWallet,
 }: {
   isPrimary: boolean;
   onPress?: () => void;
+  isMagicWallet: boolean;
 }) => {
+  if (isMagicWallet) {
+    return null;
+  }
+
   return (
     <View tw="mb-2 md:mb-0">
       {!isPrimary ? (
@@ -162,6 +168,12 @@ export const SettingsWalletItem = (props: Props) => {
 
   const isPrimary = user.user?.data.profile.primary_wallet?.address === address;
   const { setPrimaryWallet } = useSetPrimaryWallet();
+  const isMagicWallet =
+    (!!props.wallet.is_email ||
+      !!props.wallet.is_phone ||
+      !!props.wallet.is_apple ||
+      !!props.wallet.is_google) &&
+    !props.wallet.is_privy;
 
   return (
     <>
@@ -195,6 +207,7 @@ export const SettingsWalletItem = (props: Props) => {
               <MakePrimaryBtn
                 isPrimary={isPrimary}
                 onPress={() => setPrimaryWallet(wallet.address)}
+                isMagicWallet={isMagicWallet}
               />
             </Hidden>
             <Text tw="text-sm text-gray-900 dark:text-white">{address}</Text>
@@ -205,17 +218,14 @@ export const SettingsWalletItem = (props: Props) => {
               <MakePrimaryBtn
                 isPrimary={isPrimary}
                 onPress={() => setPrimaryWallet(wallet.address)}
+                isMagicWallet={isMagicWallet}
               />
             </Hidden>
             <WalletDropdownMenu
               address={address}
               isCurrent={isConnectedAddress}
-              isMagicWallet={
-                !!props.wallet.is_email ||
-                !!props.wallet.is_phone ||
-                !!props.wallet.is_apple ||
-                !!props.wallet.is_google
-              }
+              isMagicWallet={isMagicWallet}
+              isPrivyWallet={!!props.wallet.is_privy}
               onEditNickname={props.onEditNickname}
             />
           </View>

--- a/packages/app/components/settings/tabs/account.web.tsx
+++ b/packages/app/components/settings/tabs/account.web.tsx
@@ -314,12 +314,24 @@ type SocialConnectButtonProps = {
 };
 
 const SocialConnectButton = ({ connected, type }: SocialConnectButtonProps) => {
-  const { linkApple, linkGoogle, unlinkApple, unlinkGoogle } = usePrivy();
+  const {
+    linkApple,
+    linkGoogle,
+    unlinkApple,
+    unlinkGoogle,
+    login,
+    authenticated,
+    ready,
+  } = usePrivy();
   const accountSubject = connected[type]?.subject;
   return (
     <Button
       variant={accountSubject ? "danger" : "tertiary"}
       onPress={async () => {
+        if (ready && !authenticated) {
+          login();
+          return;
+        }
         if (accountSubject) {
           if (type === "apple") {
             unlinkApple(accountSubject);

--- a/packages/app/components/settings/tabs/index.tsx
+++ b/packages/app/components/settings/tabs/index.tsx
@@ -24,7 +24,7 @@ export const SETTINGS_ROUTES = [
   {
     title: "Sign In",
     key: "Sign In",
-    hidden: Platform.OS !== "web",
+    hidden: true,
   },
   {
     title: "Connected Apps",

--- a/packages/app/components/settings/wallet-dropdown-menu.tsx
+++ b/packages/app/components/settings/wallet-dropdown-menu.tsx
@@ -5,6 +5,7 @@ import { Edit, MoreHorizontal, Wallet } from "@showtime-xyz/universal.icon";
 
 import { MenuItemIcon } from "app/components/dropdown/menu-item-icon";
 import { useManageAccount } from "app/hooks/use-manage-account";
+import { useExportPrivyWallet } from "app/lib/privy/privy-hooks";
 import { WalletAddressesV2 } from "app/types";
 
 import {
@@ -21,11 +22,14 @@ type AddressMenuProps = {
   isCurrent: boolean;
   onEditNickname: (item?: WalletAddressesV2) => void;
   isMagicWallet: boolean;
+  isPrivyWallet: boolean;
 };
 
 export const WalletDropdownMenu = (props: AddressMenuProps) => {
   const { removeAccount } = useManageAccount();
   const address = props.address;
+
+  const exportPrivyWallet = useExportPrivyWallet();
 
   return (
     <DropdownMenuRoot>
@@ -41,11 +45,15 @@ export const WalletDropdownMenu = (props: AddressMenuProps) => {
             Edit nickname
           </DropdownMenuItemTitle>
         </DropdownMenuItem>
-        {props.isMagicWallet ? (
+        {props.isMagicWallet || props.isPrivyWallet ? (
           <DropdownMenuItem
-            onSelect={() =>
-              Linking.openURL("https://reveal.magic.link/showtime")
-            }
+            onSelect={() => {
+              if (props.isMagicWallet) {
+                Linking.openURL("https://reveal.magic.link/showtime");
+              } else if (props.isPrivyWallet) {
+                exportPrivyWallet();
+              }
+            }}
             key="export_key"
           >
             <MenuItemIcon Icon={Wallet} ios={{ name: "person.badge.key" }} />

--- a/packages/app/lib/privy/privy-hooks.ts
+++ b/packages/app/lib/privy/privy-hooks.ts
@@ -1,1 +1,6 @@
 export { useLoginWithSMS } from "@privy-io/expo";
+
+export const useExportPrivyWallet = () => {
+  const exportPrivyWallet = async () => {};
+  return exportPrivyWallet;
+};

--- a/packages/app/lib/privy/privy-hooks.web.ts
+++ b/packages/app/lib/privy/privy-hooks.web.ts
@@ -1,6 +1,13 @@
+import { usePrivy } from "@privy-io/react-auth";
+
 export const useLoginWithSMS = () => {
   return {
     loginWithCode: () => {},
     sendCode: () => {},
   };
+};
+
+export const useExportPrivyWallet = () => {
+  const { exportWallet } = usePrivy();
+  return exportWallet;
 };

--- a/packages/app/providers/auth-provider.tsx
+++ b/packages/app/providers/auth-provider.tsx
@@ -151,6 +151,18 @@ export function AuthProvider({
       router,
     ]
   );
+
+  // Temp code to logout users who are logged in with Magic
+  useEffect(() => {
+    async function logoutMagicUsers() {
+      const isMagicLoggedIn = await magic?.user?.isLoggedIn();
+      if (isMagicLoggedIn) {
+        logout();
+      }
+    }
+    logoutMagicUsers();
+  }, [logout, magic]);
+
   const doRefreshToken = useCallback(async () => {
     setAuthenticationStatus("REFRESHING");
     try {

--- a/packages/app/types.ts
+++ b/packages/app/types.ts
@@ -100,6 +100,7 @@ export interface WalletAddressesV2 {
   is_twitter: number;
   is_google: number;
   is_apple: number;
+  is_privy: number;
   phone_number: string;
   is_phone: number;
   nickname?: string;


### PR DESCRIPTION
# Why
- Logout existing magic users so they can have a privy wallet.
- Hide sign in tab from settings (we don't support email with privy yet)
- Add export privy wallet button.
- Hide make primary button from magic wallet.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->
