### PR TITLE
refactor: remove star drop badge and follow chip

### DIFF
--- a/packages/app/components/card/avatar-hover-card.web.tsx
+++ b/packages/app/components/card/avatar-hover-card.web.tsx
@@ -120,9 +120,6 @@ export function AvatarHoverCardContent({ username }: AvatarHoverCardProps) {
                       <VerificationBadge size={16} />
                     </View>
                   ) : null}
-                  {profileData?.follows_you && !isSelf ? (
-                    <Chip label="Follows You" tw="ml-2" />
-                  ) : null}
                 </View>
                 {bio ? (
                   <View tw="mt-4 items-baseline">

--- a/packages/app/components/creator-channels/followers.tsx
+++ b/packages/app/components/creator-channels/followers.tsx
@@ -1,6 +1,5 @@
 import { memo, useCallback } from "react";
 
-import { Chip } from "@showtime-xyz/universal.chip";
 import { Image } from "@showtime-xyz/universal.image";
 import {
   InfiniteScrollList,
@@ -13,7 +12,6 @@ import { View } from "@showtime-xyz/universal.view";
 
 import { useMyInfo } from "app/hooks/api-hooks";
 import { UserItemType } from "app/hooks/api/use-follow-list";
-import { useFollow } from "app/hooks/use-follow";
 import { useModalListProps } from "app/hooks/use-modal-list-props";
 import { usePlatformBottomHeight } from "app/hooks/use-platform-bottom-height";
 import { Link } from "app/navigation/link";
@@ -101,11 +99,6 @@ export const CreatorChannelFollowers = ({
 
 const FollowingListUser = memo(
   ({ item }: { item: UserItemType } & FollowingListProp) => {
-    const { data } = useMyInfo();
-
-    const { onToggleFollow } = useFollow({
-      username: data?.data.profile.username,
-    });
     return (
       <View
         tw={`flex-row items-center justify-between overflow-hidden px-4`}
@@ -157,9 +150,6 @@ const FollowingListUser = memo(
                     <VerificationBadge size={14} />
                   </View>
                 )}
-                {item?.follows_you ? (
-                  <Chip label="Follows You" tw="ml-1 py-1" />
-                ) : null}
               </View>
             </View>
           </View>

--- a/packages/app/components/creator-channels/user-list.tsx
+++ b/packages/app/components/creator-channels/user-list.tsx
@@ -180,9 +180,6 @@ const CCUserListItem = memo(
                     <VerificationBadge size={14} />
                   </View>
                 )}
-                {/* {item?.follows_you ? (
-                  <Chip label="Follows You" tw="ml-1 py-1" />
-                ) : null} */}
               </View>
             </View>
           </View>

--- a/packages/app/components/profile/profile-top.tsx
+++ b/packages/app/components/profile/profile-top.tsx
@@ -214,15 +214,6 @@ export const ProfileTop = memo<ProfileTopProps>(function ProfileTop({
                         <VerificationBadge size={16} />
                       </View>
                     ) : null}
-                    <View tw="ml-1">
-                      <StarDropBadge
-                        size={16}
-                        data={profileData?.profile.latest_star_drop_collected}
-                      />
-                    </View>
-                    {profileData?.follows_you && !isSelf ? (
-                      <Chip label="Follows You" tw="ml-2" />
-                    ) : null}
                   </View>
                 </View>
                 <CompleteProfileButton isSelf={isSelf} />
@@ -346,14 +337,6 @@ export const ProfileTop = memo<ProfileTopProps>(function ProfileTop({
                     <VerificationBadge size={16} />
                   ) : null}
                 </View>
-                <StarDropBadge
-                  size={16}
-                  data={profileData?.profile.latest_star_drop_collected}
-                  tw="ml-1"
-                />
-                {profileData?.follows_you && !isSelf ? (
-                  <Chip label="Follows You" tw="ml-2" />
-                ) : null}
               </Pressable>
             </View>
             <View tw="-mt-1 ml-auto">

--- a/packages/app/components/user-list.tsx
+++ b/packages/app/components/user-list.tsx
@@ -153,9 +153,6 @@ const FollowingListUser = memo(
                     <VerificationBadge size={14} />
                   </View>
                 )}
-                {item?.follows_you ? (
-                  <Chip label="Follows You" tw="ml-1 py-1" />
-                ) : null}
               </View>
             </View>
           </View>


### PR DESCRIPTION
# Why
As requested by Alex, this PR removes the star drop badge from profiles and the `follows you` chip.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
