### PR TITLE
fix: redirect auth bug

### DIFF
--- a/packages/app/components/settings/setting.web.tsx
+++ b/packages/app/components/settings/setting.web.tsx
@@ -23,10 +23,7 @@ const SettingsTabs = () => {
     WalletAddressesV2 | undefined
   >(undefined);
   const { width } = useWindowDimensions();
-  const { isAuthenticated } = useUser({
-    redirectTo: "/login",
-    redirectIfProfileIncomplete: false,
-  });
+  const { isAuthenticated } = useUser();
   const isLgWidth = width >= breakpoints["lg"];
   const { index, setIndex, routes } = useTabState(SETTINGS_ROUTES);
 

--- a/packages/app/hooks/use-auth-screen.tsx
+++ b/packages/app/hooks/use-auth-screen.tsx
@@ -1,0 +1,16 @@
+import { useEffectOnce } from "@showtime-xyz/universal.hooks";
+
+import { useNavigateToLogin } from "app/navigation/use-navigate-to";
+
+import { useAuth } from "./auth/use-auth";
+
+// Add this hook to screen that requires authentication
+export const useAuthScreen = () => {
+  const navigateToLogin = useNavigateToLogin();
+  const { authenticationStatus } = useAuth();
+  useEffectOnce(() => {
+    if (authenticationStatus === "UNAUTHENTICATED") {
+      navigateToLogin();
+    }
+  });
+};

--- a/packages/app/hooks/use-user.ts
+++ b/packages/app/hooks/use-user.ts
@@ -1,47 +1,9 @@
-import { useContext, useEffect } from "react";
-
-import { useRouter } from "@showtime-xyz/universal.router";
+import { useContext } from "react";
 
 import { UserContext } from "app/context/user-context";
-import {
-  useNavigateToLogin,
-  useNavigateToOnboarding,
-} from "app/navigation/use-navigate-to";
 
-type UserParams = {
-  redirectTo?: string;
-  redirectIfProfileIncomplete?: boolean;
-};
-export function useUser(params?: UserParams) {
+export function useUser() {
   const context = useContext(UserContext);
-  const router = useRouter();
-  const navigateToOnboarding = useNavigateToOnboarding();
-  const navigateToLogin = useNavigateToLogin();
-  useEffect(() => {
-    if (!context?.isAuthenticated && params?.redirectTo && router) {
-      if (params.redirectTo === "/login") {
-        navigateToLogin();
-      } else {
-        router.replace(params?.redirectTo);
-      }
-    }
-    if (
-      context?.isAuthenticated &&
-      params?.redirectIfProfileIncomplete &&
-      context?.isIncompletedProfile &&
-      router
-    ) {
-      navigateToOnboarding({ replace: true });
-    }
-  }, [
-    context?.isAuthenticated,
-    context?.isIncompletedProfile,
-    navigateToLogin,
-    navigateToOnboarding,
-    params?.redirectIfProfileIncomplete,
-    params?.redirectTo,
-    router,
-  ]);
 
   if (!context) {
     throw "You need to add `UserProvider` to your root component";

--- a/packages/app/screens/creator-channels.tsx
+++ b/packages/app/screens/creator-channels.tsx
@@ -1,14 +1,12 @@
 import { CreatorChannels } from "app/components/creator-channels";
 import { withColorScheme } from "app/components/memo-with-theme";
 import { useIntroducingCreatorChannels } from "app/components/onboarding/introducing-creator-channels";
-import { useUser } from "app/hooks/use-user";
+import { useAuthScreen } from "app/hooks/use-auth-screen";
 import { useTrackPageViewed } from "app/lib/analytics";
 
 const CreatorChannelsScreen = withColorScheme(() => {
   useTrackPageViewed({ name: "Creator Channels" });
-  useUser({
-    redirectTo: "/login",
-  });
+  useAuthScreen();
 
   useIntroducingCreatorChannels();
 

--- a/packages/app/screens/creator-tokens-self-serve-explainer.tsx
+++ b/packages/app/screens/creator-tokens-self-serve-explainer.tsx
@@ -4,14 +4,12 @@ import { withModalScreen } from "@showtime-xyz/universal.modal-screen";
 
 import { SelfServeExplainer } from "app/components/creator-token/self-serve-explainer";
 import { withColorScheme } from "app/components/memo-with-theme";
-import { useUser } from "app/hooks/use-user";
+import { useAuthScreen } from "app/hooks/use-auth-screen";
 import { useTrackPageViewed } from "app/lib/analytics";
 
 const SelfServeExplainerScreen = withColorScheme(() => {
   useTrackPageViewed({ name: "Creator Tokens self serve explainer" });
-  useUser({
-    redirectTo: "/login",
-  });
+  useAuthScreen();
 
   return <SelfServeExplainer />;
 });

--- a/packages/app/screens/edit-profile.tsx
+++ b/packages/app/screens/edit-profile.tsx
@@ -1,14 +1,12 @@
 import { withModalScreen } from "@showtime-xyz/universal.modal-screen";
 
 import { EditProfile } from "app/components/edit-profile";
-import { useUser } from "app/hooks/use-user";
+import { useAuthScreen } from "app/hooks/use-auth-screen";
 import { useTrackPageViewed } from "app/lib/analytics";
 
 export const EditProfilePage = () => {
   useTrackPageViewed({ name: "Edit Profile" });
-  useUser({
-    redirectIfProfileIncomplete: false,
-  });
+  useAuthScreen();
 
   return <EditProfile />;
 };

--- a/packages/app/screens/settings.tsx
+++ b/packages/app/screens/settings.tsx
@@ -1,9 +1,11 @@
 import { withColorScheme } from "app/components/memo-with-theme";
 import Settings from "app/components/settings";
+import { useAuthScreen } from "app/hooks/use-auth-screen";
 import { useTrackPageViewed } from "app/lib/analytics";
 
 const SettingsScreen = withColorScheme(() => {
   useTrackPageViewed({ name: "Settings" });
+  useAuthScreen();
 
   return <Settings />;
 });


### PR DESCRIPTION
# Why
- Better fix for - https://github.com/showtime-xyz/showtime-frontend/pull/2541
- Adds a `useAuthScreen` hook, that can be used in screens that require authentication.
- Cleans up `useUser` hook
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->

