### PR TITLE
fix: update user state after opt in is called

### DIFF
--- a/packages/app/components/creator-token/self-serve-explainer.tsx
+++ b/packages/app/components/creator-token/self-serve-explainer.tsx
@@ -48,6 +48,7 @@ export const SelfServeExplainer = () => {
   const [selectedImg, setSelectedImg] = useState<
     string | File | undefined | null
   >(null);
+  const { mutate: mutateUserProfile } = useUser();
 
   const pickFile = useFilePicker();
   const { trigger: deployContract, isMutating } = useCreatorTokenOptIn();
@@ -55,6 +56,7 @@ export const SelfServeExplainer = () => {
   const creatorTokenDeployStatus = useCreatorTokenDeployStatus({
     onSuccess: () => {
       if (user?.data.profile.username) {
+        mutateUserProfile();
         redirectToCreatorTokensShare({
           username: user?.data.profile.username,
           type: "launched",

--- a/packages/app/hooks/creator-token/use-creator-token-opt-in.ts
+++ b/packages/app/hooks/creator-token/use-creator-token-opt-in.ts
@@ -24,11 +24,12 @@ export const useCreatorTokenOptIn = () => {
     async (_url: string, { arg }: { arg?: { inviteCode: string } }) => {
       // if primary wallet is magic, we don't support creating tokens
       if (
-        user.user?.data.profile.primary_wallet?.is_apple ||
-        user.user?.data.profile.primary_wallet?.is_google ||
-        user.user?.data.profile.primary_wallet?.is_phone ||
-        user.user?.data.profile.primary_wallet?.is_twitter ||
-        user.user?.data.profile.primary_wallet?.is_email
+        (user.user?.data.profile.primary_wallet?.is_apple ||
+          user.user?.data.profile.primary_wallet?.is_google ||
+          user.user?.data.profile.primary_wallet?.is_phone ||
+          user.user?.data.profile.primary_wallet?.is_twitter ||
+          user.user?.data.profile.primary_wallet?.is_email) &&
+        !user.user?.data.profile.primary_wallet.is_privy
       ) {
         await setPrimaryIfMagic();
       }

--- a/packages/app/hooks/creator-token/use-creator-token-opt-in.ts
+++ b/packages/app/hooks/creator-token/use-creator-token-opt-in.ts
@@ -74,30 +74,8 @@ export const useCreatorTokenOptIn = () => {
             },
           ]
         );
-      } else {
-        Alert.alert(
-          "Unsupported wallet set to Primary",
-          `Would you like to set current wallet (${formatAddressShort(
-            wallet.address
-          )}) to Primary? Primary wallet is used to create the creator token.`,
-          [
-            {
-              text: "Okay",
-              onPress: async () => {
-                if (wallet.address) {
-                  setPrimaryWallet(wallet.address).then(resolve).catch(reject);
-                }
-              },
-            },
-            {
-              text: "Cancel",
-              style: "cancel",
-              onPress: () => {
-                reject("User cancelled");
-              },
-            },
-          ]
-        );
+      } else if (wallet.address) {
+        setPrimaryWallet(wallet.address).then(resolve).catch(reject);
       }
     });
   };


### PR DESCRIPTION
# Why
- Update myinfo cache when user creates a creator token
- set primary wallet if user is connected to a regular wallet and if magic wallet is set to primary
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, Slack messages, or feature requests.
-->
