### PR TITLE
fix: sign in popup not closing on native

### DIFF
--- a/packages/app/components/login/index.tsx
+++ b/packages/app/components/login/index.tsx
@@ -5,6 +5,7 @@ import { PortalProvider } from "@gorhom/portal";
 
 import { Button } from "@showtime-xyz/universal.button";
 import { Fieldset } from "@showtime-xyz/universal.fieldset";
+import { useRouter } from "@showtime-xyz/universal.router";
 import { Text } from "@showtime-xyz/universal.text";
 import { View } from "@showtime-xyz/universal.view";
 
@@ -32,6 +33,7 @@ export function Login() {
   const { sendCode } = useLoginWithSMS();
   const otpInputRef = useRef<any>(null);
   const { authenticationStatus } = useAuth();
+  const router = useRouter();
 
   useEffect(() => {
     if (showOtp) {
@@ -111,7 +113,10 @@ export function Login() {
               setPhoneNumber(phoneNumber);
               setShowOtp(true);
             }}
-            handleSubmitWallet={handleSubmitWallet}
+            handleSubmitWallet={async () => {
+              await handleSubmitWallet();
+              router.pop();
+            }}
             loading={loading && !isConnectingToWallet}
           />
         )}

--- a/packages/app/hooks/auth/use-wallet-login.ts
+++ b/packages/app/hooks/auth/use-wallet-login.ts
@@ -52,7 +52,7 @@ export function useWalletLogin() {
             dispatch("LOG_IN_SUCCESS");
 
             dispatch("EXPIRE_NONCE_REQUEST");
-            await rotateNonce(res.address);
+            rotateNonce(res.address);
             dispatch("EXPIRE_NONCE_SUCCESS");
           }
         }


### PR DESCRIPTION
# Why
- Sign in popup stays open on native after successful login with wallet. Regression introduced in privy migration

